### PR TITLE
NSPointerFunctions overhaul

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,77 +1,87 @@
-# Copyright (C) 2015 Free Software Foundation, Inc.
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# Modified from gcc's clang-format config.
-
-# clang-format 7.0.1 is required
-#
-# To utilize the tool to lines just touched by a patch, use
-# clang-format-diff script that is usually also packaged with clang-format.
-#
-# Example of usage:
-# git diff -U0 --no-color | clang-format-diff -p1
-# (here the tool will generate a patch)
-# git diff -U0 --no-color | clang-format-diff -p1 -i
-# (modifications are applied)
-
 ---
-AccessModifierOffset: -2
-AlwaysBreakAfterReturnType: TopLevel
-AlignConsecutiveDeclarations: true
+# Custom options in the special build of clang-format (these are not standard options)
+#IndentNestedBlocks: false
+#AllowNewlineBeforeBlockParameter: false
+
+Language:        ObjC
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+ConstructorInitializerIndentWidth: 4
+SortIncludes: false
+
+AlignAfterOpenBracket: true
+AlignEscapedNewlinesLeft: true
+AlignOperands: false
+AlignTrailingComments: false
+
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakTemplateDeclarations: false
+AlwaysBreakBeforeMultilineStrings: false
+
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+
 BinPackArguments: true
 BinPackParameters: true
-BreakBeforeBinaryOperators: All
-BreakBeforeBraces: Custom
-# Newer clang-format has BS_GNU
-BraceWrapping:
-  AfterClass: true
-  AfterControlStatement: true
-  AfterEnum: true
-  AfterFunction: true
-  AfterNamespace: false
-  AfterObjCDeclaration: true
-  AfterStruct: true
-  AfterUnion: true
-  BeforeCatch: true
-  BeforeElse: true
-  IndentBraces: true
-  SplitEmptyFunction: false
-BreakBeforeTernaryOperators: true
-ColumnLimit: 80
-ConstructorInitializerIndentWidth: 2
-ContinuationIndentWidth: 2
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: true
-ObjCSpaceBeforeProtocolList: true
-ForEachMacros: []
-IndentCaseLabels: false
-NamespaceIndentation: None
-PenaltyBreakBeforeFirstCallParameter: 100
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 DerivePointerAlignment: false
-PointerAlignment: Right
-SortIncludes: false
-SpaceAfterCStyleCast: true
-SpaceBeforeParens: ControlStatements
-SpacesBeforeTrailingComments: 1
-UseTab: Always
-AlignEscapedNewlines: Right
-AlignTrailingComments: true
-AllowShortFunctionsOnASingleLine: All
-AlwaysBreakTemplateDeclarations: MultiLine
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+IndentWrappedFunctionNames: false
+IndentFunctionDeclarationAfterType: false
+MaxEmptyLinesToKeep: 2
 KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: Inner
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+ObjCBlockIndentWidth: 4
+PenaltyBreakBeforeFirstCallParameter: 10000
+PenaltyBreakComment: 300
+PenaltyBreakString: 1000
+PenaltyBreakFirstLessLess: 120
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+SpacesBeforeTrailingComments: 1
+Cpp11BracedListStyle: true
+Standard:        Auto
+IndentWidth:     4
+TabWidth:        8
+UseTab:          Never
+BreakBeforeBraces: Custom
+BraceWrapping: 
+    AfterClass: true
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterFunction: true
+    AfterNamespace: true
+    AfterObjCDeclaration: false
+    AfterStruct: false
+    AfterUnion: false
+    BeforeCatch: false
+    BeforeElse: false
+    IndentBraces: false
 
-# TODO
-# MacroBlockBegin: 
-# MacroBlockEnd:
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpacesInContainerLiterals: false
+SpaceBeforeAssignmentOperators: true
+
+ContinuationIndentWidth: 4
+CommentPragmas:  '^ IWYU pragma:'
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+SpaceBeforeParens: ControlStatements
+DisableFormat:   false

--- a/Headers/Foundation/NSPointerFunctions.h
+++ b/Headers/Foundation/NSPointerFunctions.h
@@ -44,16 +44,19 @@ enum {
    * is not active. */
   NSPointerFunctionsStrongMemory = (0<<0),
 
-  /** Garbage collected weak references */
+  /** UNSUPPORTED
+   * Garbage collected weak references */
   NSPointerFunctionsZeroingWeakMemory = (1<<0),
 
   /** Non-GC memory */
   NSPointerFunctionsOpaqueMemory = (2<<0),
 
-  /** Heap (calloc/free) memory */
+  /** UNSUPPORTED
+   * Heap (calloc/free) memory */
   NSPointerFunctionsMallocMemory = (3<<0),
 
-  /** MACH virtual memory (not implemented) */
+  /** UNSUPPORTED
+   * MACH virtual memory (not implemented) */
   NSPointerFunctionsMachVirtualMemory = (4<<0),
 
   /** Uses read and write barriers appropriate for either automatic reference
@@ -76,21 +79,23 @@ enum {
    */
   NSPointerFunctionsObjectPointerPersonality = (2<<8),
 
-  /** Use strcmp for comparison and a hash of the string contents.  Describe
+  /** UNSUPPORTED
+   * Use strcmp for comparison and a hash of the string contents.  Describe
    * assuming that the string contains UTF-8 data.
    */
   NSPointerFunctionsCStringPersonality = (3<<8),
 
-  /** Use memcmp for comparison and a hash of the sructure contents.
+  /** UNSUPPORTED
+   * Use memcmp for comparison and a hash of the sructure contents.
    * A size function must be set so that the size of the memcmp and hash
    * are known,
    */
   NSPointerFunctionsStructPersonality = (4<<8),
 
-  /** Use unmodified integer value for both hash and equality test.
+  /** UNSUPPORTED
+   * Use unmodified integer value for both hash and equality test.
    */
   NSPointerFunctionsIntegerPersonality = (5<<8),
-
 
   /** Request the memory acquire function to allocate/copy items.
    */

--- a/Source/NSConcreteHashTable.m
+++ b/Source/NSConcreteHashTable.m
@@ -77,7 +77,7 @@ typedef GSIMapNode_t *GSIMapNode;
 #define	GSI_MAP_TABLE_S	instanceSize
   
 #define IS_WEAK(M) \
-      M->cb.pf.options & (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsWeakMemory)
+      (hasMemoryType(M->cb.pf.options, NSPointerFunctionsZeroingWeakMemory) || hasMemoryType(M->cb.pf.options, NSPointerFunctionsWeakMemory))
 #define GSI_MAP_HASH(M, X)\
  (M->legacy ? M->cb.old.hash(M, X.ptr) \
  : pointerFunctionsHash(&M->cb.pf, X.ptr))

--- a/Source/NSConcreteMapTable.m
+++ b/Source/NSConcreteMapTable.m
@@ -104,6 +104,11 @@ typedef GSIMapNode_t *GSIMapNode;
  (M->legacy ? M->cb.old.v.retain(M, X.ptr) \
   : IS_WEAK_VALUE(M) ? nil : pointerFunctionsAcquire(&M->cb.pf.v, &X.ptr, X.ptr))
 
+// NOTE: The below comment makes me very nervous, especially considering the
+//       acquire/relinquish/etc functionalities have now been fixed. Are any of these
+//       following definitions even correct? Are we reintroducing this double-retain bug?
+//        - brooke.tilley (2023-08-11)
+
 /* 2013-05-25 Here are the macros originally added for GC/ARC ...
  * but they caused map table entries to be doubly retained :-(
  * The question is, are the new versions I hacked in below to

--- a/Source/NSConcreteMapTable.m
+++ b/Source/NSConcreteMapTable.m
@@ -82,9 +82,9 @@ typedef GSIMapNode_t *GSIMapNode;
 #define	GSI_MAP_KTYPES	GSUNION_PTR | GSUNION_OBJ
 #define	GSI_MAP_VTYPES	GSUNION_PTR | GSUNION_OBJ
 #define IS_WEAK_KEY(M) \
-  M->cb.pf.k.options & (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsWeakMemory)
+  (hasMemoryType(M->cb.pf.k.options, NSPointerFunctionsZeroingWeakMemory) || hasMemoryType(M->cb.pf.k.options, NSPointerFunctionsWeakMemory))
 #define IS_WEAK_VALUE(M) \
-  M->cb.pf.v.options & (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsWeakMemory)
+  (hasMemoryType(M->cb.pf.v.options, NSPointerFunctionsZeroingWeakMemory) || hasMemoryType(M->cb.pf.v.options, NSPointerFunctionsWeakMemory))
 #define GSI_MAP_HASH(M, X)\
  (M->legacy ? M->cb.old.k.hash(M, X.ptr) \
  : pointerFunctionsHash(&M->cb.pf.k, X.ptr))

--- a/Source/NSConcretePointerFunctions.h
+++ b/Source/NSConcretePointerFunctions.h
@@ -71,10 +71,7 @@ typedef struct
     void (*relinquishFunction)(const void *item,
                                NSUInteger (*size)(const void *item));
 
-    NSUInteger (*sizeFunction)(const void *item);
-
     NSPointerFunctionsOptions options;
-
 } PFInfo;
 
 const int NSPointerFunctionsMemoryMask = 0xff;
@@ -154,7 +151,7 @@ static inline void *
 pointerFunctionsAcquire(PFInfo *PF, void **dst, void *src)
 {
     if (PF->acquireFunction != 0)
-        src = (*PF->acquireFunction)(src, PF->sizeFunction,
+        src = (*PF->acquireFunction)(src, nil,
                                      isCopyIn(PF->options) ? YES : NO);
     // FIXME: This shouldn't be here.  Acquire and assign are separate
     // operations.  Acquire is for copy-in operations (i.e. retain / copy),
@@ -191,7 +188,7 @@ static inline NSUInteger
 pointerFunctionsHash(PFInfo *PF, void *item)
 {
     if (PF->hashFunction != 0)
-        return (*PF->hashFunction)(item, PF->sizeFunction);
+        return (*PF->hashFunction)(item, nil);
     return (NSUInteger)(uintptr_t)item;
 }
 
@@ -202,7 +199,7 @@ static inline BOOL
 pointerFunctionsEqual(PFInfo *PF, void *item1, void *item2)
 {
     if (PF->isEqualFunction != 0)
-        return (*PF->isEqualFunction)(item1, item2, PF->sizeFunction);
+        return (*PF->isEqualFunction)(item1, item2, nil);
     if (item1 == item2)
         return YES;
     return NO;
@@ -215,7 +212,7 @@ static inline void
 pointerFunctionsRelinquish(PFInfo *PF, void **itemptr)
 {
     if (PF->relinquishFunction != 0)
-        (*PF->relinquishFunction)(*itemptr, PF->sizeFunction);
+        (*PF->relinquishFunction)(*itemptr, nil);
     if (hasMemoryType(PF->options, NSPointerFunctionsWeakMemory))
         ARC_WEAK_WRITE(itemptr, 0);
     else if (hasMemoryType(PF->options, NSPointerFunctionsZeroingWeakMemory))
@@ -230,10 +227,10 @@ pointerFunctionsReplace(PFInfo *PF, void **dst, void *src)
 {
     if (src != *dst) {
         if (PF->acquireFunction != 0)
-            src = (*PF->acquireFunction)(src, PF->sizeFunction,
+            src = (*PF->acquireFunction)(src, nil,
                                          isCopyIn(PF->options) ? YES : NO);
         if (PF->relinquishFunction != 0)
-            (*PF->relinquishFunction)(*dst, PF->sizeFunction);
+            (*PF->relinquishFunction)(*dst, nil);
         if (hasMemoryType(PF->options, NSPointerFunctionsWeakMemory))
             ARC_WEAK_WRITE(dst, 0);
         else if (hasMemoryType(PF->options, NSPointerFunctionsZeroingWeakMemory))

--- a/Source/NSConcretePointerFunctions.h
+++ b/Source/NSConcretePointerFunctions.h
@@ -73,7 +73,7 @@ typedef struct
 
     BOOL (*isEqualFunction)
     (const void *item1, const void *item2,
-     NSUInteger (*size)(const void *item));
+     NSUInteger (*_size)(const void *item));
 
     void (*relinquishFunction)(const void *item,
                                NSUInteger (*size)(const void *item));
@@ -158,7 +158,7 @@ static inline void *
 pointerFunctionsAcquire(PFInfo *PF, void **dst, void *src)
 {
     if (PF->acquireFunction != 0)
-        src = (*PF->acquireFunction)(src, nil,
+        src = (*PF->acquireFunction)(src, NULL,
                                      isCopyIn(PF->options) ? YES : NO);
     // FIXME: This shouldn't be here.  Acquire and assign are separate
     // operations.  Acquire is for copy-in operations (i.e. retain / copy),
@@ -195,7 +195,7 @@ static inline NSUInteger
 pointerFunctionsHash(PFInfo *PF, void *item)
 {
     if (PF->hashFunction != 0)
-        return (*PF->hashFunction)(item, nil);
+        return (*PF->hashFunction)(item, NULL);
     return (NSUInteger)(uintptr_t)item;
 }
 
@@ -206,7 +206,7 @@ static inline BOOL
 pointerFunctionsEqual(PFInfo *PF, void *item1, void *item2)
 {
     if (PF->isEqualFunction != 0)
-        return (*PF->isEqualFunction)(item1, item2, nil);
+        return (*PF->isEqualFunction)(item1, item2, NULL);
     if (item1 == item2)
         return YES;
     return NO;
@@ -219,7 +219,7 @@ static inline void
 pointerFunctionsRelinquish(PFInfo *PF, void **itemptr)
 {
     if (PF->relinquishFunction != 0)
-        (*PF->relinquishFunction)(*itemptr, nil);
+        (*PF->relinquishFunction)(*itemptr, NULL);
     if (hasMemoryType(PF->options, NSPointerFunctionsWeakMemory))
         ARC_WEAK_WRITE(itemptr, 0);
     else if (hasMemoryType(PF->options, NSPointerFunctionsZeroingWeakMemory))
@@ -234,10 +234,10 @@ pointerFunctionsReplace(PFInfo *PF, void **dst, void *src)
 {
     if (src != *dst) {
         if (PF->acquireFunction != 0)
-            src = (*PF->acquireFunction)(src, nil,
+            src = (*PF->acquireFunction)(src, NULL,
                                          isCopyIn(PF->options) ? YES : NO);
         if (PF->relinquishFunction != 0)
-            (*PF->relinquishFunction)(*dst, nil);
+            (*PF->relinquishFunction)(*dst, NULL);
         if (hasMemoryType(PF->options, NSPointerFunctionsWeakMemory))
             ARC_WEAK_WRITE(dst, 0);
         else if (hasMemoryType(PF->options, NSPointerFunctionsZeroingWeakMemory))

--- a/Source/NSConcretePointerFunctions.h
+++ b/Source/NSConcretePointerFunctions.h
@@ -106,7 +106,7 @@ inline static BOOL hasPersonalityType(int options, int flag)
 
 inline static BOOL isCopyIn(int options)
 {
-    return personalityType(options) & NSPointerFunctionsCopyIn;
+    return options & NSPointerFunctionsCopyIn;
 }
 
 /* Declare the concrete pointer functions class as a wrapper around

--- a/Source/NSConcretePointerFunctions.h
+++ b/Source/NSConcretePointerFunctions.h
@@ -81,8 +81,8 @@ typedef struct
     NSPointerFunctionsOptions options;
 } PFInfo;
 
-const int NSPointerFunctionsMemoryMask = 0xff;
-const int NSPointerFunctionsPersonalityMask = 0xff00;
+#define NSPointerFunctionsMemoryMask (0xff)
+#define NSPointerFunctionsPersonalityMask (0xff00)
 
 inline static int memoryType(int options)
 {

--- a/Source/NSConcretePointerFunctions.h
+++ b/Source/NSConcretePointerFunctions.h
@@ -30,24 +30,31 @@
 #endif
 
 #if defined(OBJC_CAP_ARC)
+
 #include <objc/objc-arc.h>
+
 #define ARC_WEAK_READ(x) objc_loadWeak((id *)x)
 #define ARC_WEAK_WRITE(addr, x) objc_storeWeak((id *)addr, (id)x)
+
+// Unused: NSPointerFunctionsZeroingWeakMemory deprecated
 #define WEAK_READ(x) (*x)
 #define WEAK_WRITE(addr, x) (*(addr) = x)
+
 #define STRONG_WRITE(addr, x) objc_storeStrong((id *)addr, (id)x)
 #define STRONG_ACQUIRE(x) objc_retain(x)
+
 #else
-#define WEAK_READ(x) (*x)
-#define WEAK_WRITE(addr, x) (*(addr) = x)
-#define STRONG_WRITE(addr, x) ASSIGN(*((id *)addr), ((id)x))
-#define STRONG_ACQUIRE(x) RETAIN(((id)x))
-#endif
-#ifndef ARC_WEAK_WRITE
-#define ARC_WEAK_WRITE(addr, x) WEAK_WRITE(addr, x)
-#endif
-#ifndef ARC_WEAK_READ
-#define ARC_WEAK_READ(x) WEAK_READ(x)
+#error Non-ARC compilation unsupported
+// #define WEAK_READ(x) (*x)
+// #define WEAK_WRITE(addr, x) (*(addr) = x)
+// #define STRONG_WRITE(addr, x) ASSIGN(*((id *)addr), ((id)x))
+// #define STRONG_ACQUIRE(x) RETAIN(((id)x))
+// #endif
+// #ifndef ARC_WEAK_WRITE
+// #define ARC_WEAK_WRITE(addr, x) WEAK_WRITE(addr, x)
+// #endif
+// #ifndef ARC_WEAK_READ
+// #define ARC_WEAK_READ(x) WEAK_READ(x)
 #endif
 
 

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -158,6 +158,11 @@ relinquishRetainedMemory(const void *item,
             pf.acquireFunction = NULL;
             pf.relinquishFunction = NULL;
         } break;
+        default: {
+            NSLog(@"ERROR: Invalid NSPointerFunctionsOptions passed to initWithOptions");
+            NSParameterAssert(NO);
+            return nil;
+        } break;
     }
 
     switch (personalityOption) {
@@ -191,6 +196,10 @@ relinquishRetainedMemory(const void *item,
             pf.descriptionFunction = describeInteger;
             pf.hashFunction = hashDirect;
             pf.isEqualFunction = equalDirect;
+        } break;
+        default: {
+            NSLog(@"ERROR: Invalid NSPointerFunctionsOptions passed to initWithOptions");
+            NSParameterAssert(NO);
             return nil;
         } break;
     }

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -102,7 +102,9 @@ relinquishRetainedMemory(const void *item,
 
 - (id)initWithOptions:(NSPointerFunctionsOptions)options
 {
-    _x.options = options;
+    PFInfo pf = { 0 };
+
+    pf.options = options;
 
     int memoryOption = memoryType(options);
     int personalityOption = personalityType(options);
@@ -117,8 +119,8 @@ relinquishRetainedMemory(const void *item,
     switch (memoryOption) {
         case NSPointerFunctionsStrongMemory: {
             // Default option (0)
-            _x.acquireFunction = acquireRetainedObject;
-            _x.relinquishFunction = relinquishRetainedMemory;
+            pf.acquireFunction = acquireRetainedObject;
+            pf.relinquishFunction = relinquishRetainedMemory;
         } break;
         case NSPointerFunctionsZeroingWeakMemory: {
             NSLog(@"ERROR: Unsupported NSPointerFunctionsOptions option NSPointerFunctionsZeroingWeakMemory");
@@ -126,8 +128,8 @@ relinquishRetainedMemory(const void *item,
             return nil;
         } break;
         case NSPointerFunctionsOpaqueMemory: {
-            _x.acquireFunction = nil;
-            _x.relinquishFunction = nil;
+            pf.acquireFunction = NULL;
+            pf.relinquishFunction = NULL;
         } break;
         case NSPointerFunctionsMallocMemory: {
             NSLog(@"ERROR: Unsupported NSPointerFunctionsOptions option NSPointerFunctionsMallocMemory");
@@ -140,27 +142,27 @@ relinquishRetainedMemory(const void *item,
             return nil;
         } break;
         case NSPointerFunctionsWeakMemory: {
-            _x.acquireFunction = nil;
-            _x.relinquishFunction = nil;
+            pf.acquireFunction = NULL;
+            pf.relinquishFunction = NULL;
         } break;
     }
 
     switch (personalityOption) {
         case NSPointerFunctionsObjectPersonality: {
             // Default option (0)
-            _x.descriptionFunction = describeObject;
-            _x.hashFunction = hashObject;
-            _x.isEqualFunction = equalObject;
+            pf.descriptionFunction = describeObject;
+            pf.hashFunction = hashObject;
+            pf.isEqualFunction = equalObject;
         } break;
         case NSPointerFunctionsOpaquePersonality: {
-            _x.descriptionFunction = describePointer;
-            _x.hashFunction = hashDirect;
-            _x.isEqualFunction = equalDirect;
+            pf.descriptionFunction = describePointer;
+            pf.hashFunction = hashDirect;
+            pf.isEqualFunction = equalDirect;
         } break;
         case NSPointerFunctionsObjectPointerPersonality: {
-            _x.descriptionFunction = describeObject;
-            _x.hashFunction = hashShifted;
-            _x.isEqualFunction = equalDirect;
+            pf.descriptionFunction = describeObject;
+            pf.hashFunction = hashShifted;
+            pf.isEqualFunction = equalDirect;
         } break;
         case NSPointerFunctionsCStringPersonality: {
             NSLog(@"ERROR: Unsupported NSPointerFunctionsOptions option NSPointerFunctionsCStringPersonality");
@@ -179,6 +181,7 @@ relinquishRetainedMemory(const void *item,
         } break;
     }
 
+    memcpy(&_x, &pf, sizeof(PFInfo));
     return self;
 }
 
@@ -244,7 +247,7 @@ relinquishRetainedMemory(const void *item,
 {
     NSLog(@"Error: Unsupported NSPointerFunctions property sizeFunction");
     NSParameterAssert(NO);
-    return nil;
+    return NULL;
 }
 
 - (void)setSizeFunction:(NSUInteger (*)(const void *item))func

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -315,31 +315,30 @@ relinquishRetainedMemory(const void *item,
         ~(NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsOpaqueMemory | NSPointerFunctionsMallocMemory | NSPointerFunctionsMachVirtualMemory);
 }
 
-- (void)setUsesWeakReadAndWriteBarriers:(BOOL)flag
-{
-    _x.options |= NSPointerFunctionsZeroingWeakMemory;
-    _x.options &=
-        ~(NSPointerFunctionsOpaqueMemory | NSPointerFunctionsMallocMemory | NSPointerFunctionsMachVirtualMemory);
-}
-
-- (NSUInteger (*)(const void *item))sizeFunction
-{
-    return _x.sizeFunction;
-}
-
 - (BOOL)usesStrongWriteBarrier
 {
-    if ((_x.options &
-         (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsOpaqueMemory | NSPointerFunctionsMallocMemory | NSPointerFunctionsMachVirtualMemory)) == NSPointerFunctionsStrongMemory)
-        return YES;
+    NSLog(@"ERROR: Unsupported NSPointerFunctions property usesStrongWriteBarrier");
+    NSParameterAssert(NO);
     return NO;
+}
+
+- (void)setUsesStrongWriteBarrier:(BOOL)flag
+{
+    NSLog(@"ERROR: Unsupported NSPointerFunctions property usesStrongWriteBarrier");
+    NSParameterAssert(NO);
 }
 
 - (BOOL)usesWeakReadAndWriteBarriers
 {
-    if (_x.options & NSPointerFunctionsZeroingWeakMemory)
-        return YES;
+    NSLog(@"ERROR: Unsupported NSPointerFunctions property usesWeakReadAndWriteBarriers");
+    NSParameterAssert(NO);
     return NO;
+}
+
+- (void)setUsesWeakReadAndWriteBarriers:(BOOL)flag
+{
+    NSLog(@"ERROR: Unsupported NSPointerFunctions property usesWeakReadAndWriteBarriers");
+    NSParameterAssert(NO);
 }
 
 @end

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -3,381 +3,343 @@
 
    Written by:  Richard Frith-Macdonald <rfm@gnu.org>
    Date:	2009
-   
+
    This file is part of the GNUstep Base Library.
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public
    License as published by the Free Software Foundation; either
    version 2 of the License, or (at your option) any later version.
-   
+
    This library is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
    Lesser General Public License for more details.
-   
+
    You should have received a copy of the GNU Lesser General Public
    License along with this library; if not, write to the Free
    Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
    Boston, MA 02110 USA.
 
-   */ 
+   */
 
 #import "common.h"
-#import	"NSConcretePointerFunctions.h"
+#import "NSConcretePointerFunctions.h"
 
-static void*
+static void *
 acquireMallocMemory(const void *item,
-  NSUInteger (*size)(const void *item), BOOL shouldCopy)
+                    NSUInteger (*size)(const void *item), BOOL shouldCopy)
 {
-  if (shouldCopy == YES)
-    {
-      NSUInteger	len = (*size)(item);
-      void		*newItem = malloc(len);
+    if (shouldCopy == YES) {
+        NSUInteger len = (*size)(item);
+        void *newItem = malloc(len);
 
-      memcpy(newItem, item, len);
-      item = newItem;
+        memcpy(newItem, item, len);
+        item = newItem;
     }
-  return (void*)item;
+    return (void *)item;
 }
 
-static void*
+static void *
 acquireRetainedObject(const void *item,
-  NSUInteger (*size)(const void *item), BOOL shouldCopy)
+                      NSUInteger (*size)(const void *item), BOOL shouldCopy)
 {
-  if (shouldCopy == YES)
-    {
-      return [(NSObject*)item copy];
+    if (shouldCopy == YES) {
+        return [(NSObject *)item copy];
     }
-  return [(NSObject*)item retain];
+    return [(NSObject *)item retain];
 }
 
-static void*
+static void *
 acquireExistingMemory(const void *item,
-  NSUInteger (*size)(const void *item), BOOL shouldCopy)
+                      NSUInteger (*size)(const void *item), BOOL shouldCopy)
 {
-  return (void*)item;
+    return (void *)item;
 }
 
-static NSString*
+static NSString *
 describeString(const void *item)
 {
-  return [NSString stringWithFormat: @"%s", (char*)item];
+    return [NSString stringWithFormat:@"%s", (char *)item];
 }
 
-static NSString*
+static NSString *
 describeInteger(const void *item)
 {
-  return [NSString stringWithFormat: @"%"PRIdPTR, (intptr_t)item];
+    return [NSString stringWithFormat:@"%" PRIdPTR, (intptr_t)item];
 }
 
-static NSString*
+static NSString *
 describeObject(const void *item)
 {
-  return [(NSObject*)item description];
+    return [(NSObject *)item description];
 }
 
-static NSString*
+static NSString *
 describePointer(const void *item)
 {
-  return [NSString stringWithFormat: @"%p", item];
+    return [NSString stringWithFormat:@"%p", item];
 }
 
 static BOOL
 equalDirect(const void *item1, const void *item2,
-  NSUInteger (*size)(const void *item))
+            NSUInteger (*size)(const void *item))
 {
-  return (item1 == item2) ? YES : NO;
+    return (item1 == item2) ? YES : NO;
 }
 
 static BOOL
 equalObject(const void *item1, const void *item2,
-  NSUInteger (*size)(const void *item))
+            NSUInteger (*size)(const void *item))
 {
-  return [(NSObject*)item1 isEqual: (NSObject*)item2];
+    return [(NSObject *)item1 isEqual:(NSObject *)item2];
 }
 
 static BOOL
 equalMemory(const void *item1, const void *item2,
-  NSUInteger (*size)(const void *item))
+            NSUInteger (*size)(const void *item))
 {
-  NSUInteger	s1 = (*size)(item1);
-  NSUInteger	s2 = (*size)(item2);
+    NSUInteger s1 = (*size)(item1);
+    NSUInteger s2 = (*size)(item2);
 
-  return (s1 == s2 && memcmp(item1, item2, s1) == 0) ? YES : NO;
+    return (s1 == s2 && memcmp(item1, item2, s1) == 0) ? YES : NO;
 }
 
 static BOOL
 equalString(const void *item1, const void *item2,
-  NSUInteger (*size)(const void *item))
+            NSUInteger (*size)(const void *item))
 {
-  return (strcmp((const char*)item1, (const char*)item2) == 0) ? YES : NO;
+    return (strcmp((const char *)item1, (const char *)item2) == 0) ? YES : NO;
 }
 
 static NSUInteger
 hashDirect(const void *item, NSUInteger (*size)(const void *item))
 {
-  return (NSUInteger)(uintptr_t)item;
+    return (NSUInteger)(uintptr_t)item;
 }
 
 static NSUInteger
 hashObject(const void *item, NSUInteger (*size)(const void *item))
 {
-  return [(NSObject*)item hash];
+    return [(NSObject *)item hash];
 }
 
 static NSUInteger
 hashMemory(const void *item, NSUInteger (*size)(const void *item))
 {
-  unsigned	len = (*size)(item);
-  NSUInteger	hash = 0;
+    unsigned len = (*size)(item);
+    NSUInteger hash = 0;
 
-  while (len-- > 0)
-    {
-      hash = (hash << 5) + hash + *(const uint8_t*)item++;
+    while (len-- > 0) {
+        hash = (hash << 5) + hash + *(const uint8_t *)item++;
     }
-  return hash;
+    return hash;
 }
 
 static NSUInteger
 hashShifted(const void *item, NSUInteger (*size)(const void *item))
 {
-  return ((NSUInteger)(uintptr_t)item) >> 2;
+    return ((NSUInteger)(uintptr_t)item) >> 2;
 }
 
 static NSUInteger
 hashString(const void *item, NSUInteger (*size)(const void *item))
 {
-  NSUInteger	hash = 0;
+    NSUInteger hash = 0;
 
-  while (*(const uint8_t*)item != 0)
-    {
-      hash = (hash << 5) + hash + *(const uint8_t*)item++;
+    while (*(const uint8_t *)item != 0) {
+        hash = (hash << 5) + hash + *(const uint8_t *)item++;
     }
-  return hash;
+    return hash;
 }
 
 static void
 relinquishMallocMemory(const void *item,
-  NSUInteger (*size)(const void *item))
+                       NSUInteger (*size)(const void *item))
 {
-  free((void*)item);
+    free((void *)item);
 }
 
 static void
 relinquishRetainedMemory(const void *item,
-  NSUInteger (*size)(const void *item))
+                         NSUInteger (*size)(const void *item))
 {
-  [(NSObject*)item release];
+    [(NSObject *)item release];
 }
 
 @implementation NSConcretePointerFunctions
 
-+ (id) allocWithZone: (NSZone*)zone
++ (id)allocWithZone:(NSZone *)zone
 {
-  return (id) NSAllocateObject(self, 0, zone);
+    return (id)NSAllocateObject(self, 0, zone);
 }
 
-- (id) copyWithZone: (NSZone*)zone
+- (id)copyWithZone:(NSZone *)zone
 {
-  return NSCopyObject(self, 0, zone);
+    return NSCopyObject(self, 0, zone);
 }
 
-- (id) initWithOptions: (NSPointerFunctionsOptions)options
+- (id)initWithOptions:(NSPointerFunctionsOptions)options
 {
-  _x.options = options;
+    _x.options = options;
 
-  /* First we look at the memory management options to see which function
-   * should be used to relinquish contents of a container with these
-   * options.
-   */
-  if (options & NSPointerFunctionsZeroingWeakMemory)
-    {
-      _x.relinquishFunction = 0;
-    }
-  else if (options & NSPointerFunctionsOpaqueMemory)
-    {
-      _x.relinquishFunction = 0;
-    }
-  else if (options & NSPointerFunctionsMallocMemory)
-    {
-      _x.relinquishFunction = relinquishMallocMemory;
-    }
-  else if (options & NSPointerFunctionsMachVirtualMemory)
-    {
-      _x.relinquishFunction = relinquishMallocMemory;
-    }
-  else
-    {
-      _x.relinquishFunction = relinquishRetainedMemory;
+    /* First we look at the memory management options to see which function
+     * should be used to relinquish contents of a container with these
+     * options.
+     */
+    if (options & NSPointerFunctionsZeroingWeakMemory) {
+        _x.relinquishFunction = 0;
+    } else if (options & NSPointerFunctionsOpaqueMemory) {
+        _x.relinquishFunction = 0;
+    } else if (options & NSPointerFunctionsMallocMemory) {
+        _x.relinquishFunction = relinquishMallocMemory;
+    } else if (options & NSPointerFunctionsMachVirtualMemory) {
+        _x.relinquishFunction = relinquishMallocMemory;
+    } else {
+        _x.relinquishFunction = relinquishRetainedMemory;
     }
 
-  /* Now we look at the personality options to determine other functions.
-   */
-  if (options & NSPointerFunctionsOpaquePersonality)
+    /* Now we look at the personality options to determine other functions.
+     */
+    if (options & NSPointerFunctionsOpaquePersonality) {
+        _x.acquireFunction = acquireExistingMemory;
+        _x.descriptionFunction = describePointer;
+        _x.hashFunction = hashShifted;
+        _x.isEqualFunction = equalDirect;
+    } else if (options & NSPointerFunctionsObjectPointerPersonality) {
+        if (options & NSPointerFunctionsZeroingWeakMemory) {
+            _x.acquireFunction = acquireExistingMemory;
+        } else {
+            _x.acquireFunction = acquireRetainedObject;
+        }
+        _x.descriptionFunction = describeObject;
+        _x.hashFunction = hashShifted;
+        _x.isEqualFunction = equalDirect;
+    } else if (options & NSPointerFunctionsCStringPersonality) {
+        _x.acquireFunction = acquireMallocMemory;
+        _x.descriptionFunction = describeString;
+        _x.hashFunction = hashString;
+        _x.isEqualFunction = equalString;
+    } else if (options & NSPointerFunctionsStructPersonality) {
+        _x.acquireFunction = acquireMallocMemory;
+        _x.descriptionFunction = describePointer;
+        _x.hashFunction = hashMemory;
+        _x.isEqualFunction = equalMemory;
+    } else if (options & NSPointerFunctionsIntegerPersonality) {
+        _x.acquireFunction = acquireExistingMemory;
+        _x.descriptionFunction = describeInteger;
+        _x.hashFunction = hashDirect;
+        _x.isEqualFunction = equalDirect;
+    } else /* objects */
     {
-      _x.acquireFunction = acquireExistingMemory;
-      _x.descriptionFunction = describePointer;
-      _x.hashFunction = hashShifted;
-      _x.isEqualFunction = equalDirect;
-    }
-  else if (options & NSPointerFunctionsObjectPointerPersonality)
-    {
-      if (options & NSPointerFunctionsZeroingWeakMemory)
-	{
-	  _x.acquireFunction = acquireExistingMemory;
-	}
-      else
-	{
-	  _x.acquireFunction = acquireRetainedObject;
-	}
-      _x.descriptionFunction = describeObject;
-      _x.hashFunction = hashShifted;
-      _x.isEqualFunction = equalDirect;
-    }
-  else if (options & NSPointerFunctionsCStringPersonality)
-    {
-      _x.acquireFunction = acquireMallocMemory;
-      _x.descriptionFunction = describeString;
-      _x.hashFunction = hashString;
-      _x.isEqualFunction = equalString;
-    }
-  else if (options & NSPointerFunctionsStructPersonality)
-    {
-      _x.acquireFunction = acquireMallocMemory;
-      _x.descriptionFunction = describePointer;
-      _x.hashFunction = hashMemory;
-      _x.isEqualFunction = equalMemory;
-    }
-  else if (options & NSPointerFunctionsIntegerPersonality)
-    {
-      _x.acquireFunction = acquireExistingMemory;
-      _x.descriptionFunction = describeInteger;
-      _x.hashFunction = hashDirect;
-      _x.isEqualFunction = equalDirect;
-    }
-  else		/* objects */
-    {
-      if (options & NSPointerFunctionsZeroingWeakMemory)
-	{
-	  _x.acquireFunction = acquireExistingMemory;
-	}
-      else
-	{
-          _x.acquireFunction = acquireRetainedObject;
-	}
-      _x.descriptionFunction = describeObject;
-      _x.hashFunction = hashObject;
-      _x.isEqualFunction = equalObject;
+        if (options & NSPointerFunctionsZeroingWeakMemory) {
+            _x.acquireFunction = acquireExistingMemory;
+        } else {
+            _x.acquireFunction = acquireRetainedObject;
+        }
+        _x.descriptionFunction = describeObject;
+        _x.hashFunction = hashObject;
+        _x.isEqualFunction = equalObject;
     }
 
 
-  return self;
+    return self;
 }
 
-- (void* (*)(const void *item,
-  NSUInteger (*size)(const void *item), BOOL shouldCopy)) acquireFunction
+- (void *(*)(const void *item,
+             NSUInteger (*size)(const void *item), BOOL shouldCopy))acquireFunction
 {
-  return _x.acquireFunction;
+    return _x.acquireFunction;
 }
 
-- (NSString *(*)(const void *item)) descriptionFunction
+- (NSString *(*)(const void *item))descriptionFunction
 {
-  return _x.descriptionFunction;
+    return _x.descriptionFunction;
 }
 
 - (NSUInteger (*)(const void *item,
-  NSUInteger (*size)(const void *item))) hashFunction
+                  NSUInteger (*size)(const void *item)))hashFunction
 {
-  return _x.hashFunction;
+    return _x.hashFunction;
 }
 
 - (BOOL (*)(const void *item1, const void *item2,
-  NSUInteger (*size)(const void *item))) isEqualFunction
+            NSUInteger (*size)(const void *item)))isEqualFunction
 {
-  return _x.isEqualFunction;
+    return _x.isEqualFunction;
 }
 
 - (void (*)(const void *item,
-  NSUInteger (*size)(const void *item))) relinquishFunction
+            NSUInteger (*size)(const void *item)))relinquishFunction
 {
-  return _x.relinquishFunction;
+    return _x.relinquishFunction;
 }
 
-- (void) setAcquireFunction: (void* (*)(const void *item,
-  NSUInteger (*size)(const void *item), BOOL shouldCopy))func
+- (void)setAcquireFunction:(void *(*)(const void *item,
+                                      NSUInteger (*size)(const void *item), BOOL shouldCopy))func
 {
-  _x.acquireFunction = func;
+    _x.acquireFunction = func;
 }
 
-- (void) setDescriptionFunction: (NSString *(*)(const void *item))func
+- (void)setDescriptionFunction:(NSString *(*)(const void *item))func
 {
-  _x.descriptionFunction = func;
+    _x.descriptionFunction = func;
 }
 
-- (void) setHashFunction: (NSUInteger (*)(const void *item,
-  NSUInteger (*size)(const void *item)))func
+- (void)setHashFunction:(NSUInteger (*)(const void *item,
+                                        NSUInteger (*size)(const void *item)))func
 {
-  _x.hashFunction = func;
+    _x.hashFunction = func;
 }
 
-- (void) setIsEqualFunction: (BOOL (*)(const void *item1, const void *item2,
-  NSUInteger (*size)(const void *item)))func
+- (void)setIsEqualFunction:(BOOL (*)(const void *item1, const void *item2,
+                                     NSUInteger (*size)(const void *item)))func
 {
-  _x.isEqualFunction = func;
+    _x.isEqualFunction = func;
 }
 
-- (void) setRelinquishFunction: (void (*)(const void *item,
-  NSUInteger (*size)(const void *item))) func
+- (void)setRelinquishFunction:(void (*)(const void *item,
+                                        NSUInteger (*size)(const void *item)))func
 {
-  _x.relinquishFunction = func;
+    _x.relinquishFunction = func;
 }
 
-- (void) setSizeFunction: (NSUInteger (*)(const void *item))func
+- (void)setSizeFunction:(NSUInteger (*)(const void *item))func
 {
-  _x.sizeFunction = func;
+    _x.sizeFunction = func;
 }
 
-- (void) setUsesStrongWriteBarrier: (BOOL)flag
+- (void)setUsesStrongWriteBarrier:(BOOL)flag
 {
-  _x.options &=
-    ~(NSPointerFunctionsZeroingWeakMemory
-    |NSPointerFunctionsOpaqueMemory
-    |NSPointerFunctionsMallocMemory
-    |NSPointerFunctionsMachVirtualMemory);
+    _x.options &=
+        ~(NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsOpaqueMemory | NSPointerFunctionsMallocMemory | NSPointerFunctionsMachVirtualMemory);
 }
 
-- (void) setUsesWeakReadAndWriteBarriers: (BOOL)flag
+- (void)setUsesWeakReadAndWriteBarriers:(BOOL)flag
 {
-  _x.options |= NSPointerFunctionsZeroingWeakMemory;
-  _x.options &=
-    ~(NSPointerFunctionsOpaqueMemory
-    |NSPointerFunctionsMallocMemory
-    |NSPointerFunctionsMachVirtualMemory);
+    _x.options |= NSPointerFunctionsZeroingWeakMemory;
+    _x.options &=
+        ~(NSPointerFunctionsOpaqueMemory | NSPointerFunctionsMallocMemory | NSPointerFunctionsMachVirtualMemory);
 }
 
-- (NSUInteger (*)(const void *item)) sizeFunction
+- (NSUInteger (*)(const void *item))sizeFunction
 {
-  return _x.sizeFunction;
+    return _x.sizeFunction;
 }
 
-- (BOOL) usesStrongWriteBarrier
+- (BOOL)usesStrongWriteBarrier
 {
-  if ((_x.options &
-    (NSPointerFunctionsZeroingWeakMemory
-    |NSPointerFunctionsOpaqueMemory
-    |NSPointerFunctionsMallocMemory
-    |NSPointerFunctionsMachVirtualMemory)) == NSPointerFunctionsStrongMemory)
-    return YES;
-  return NO;
+    if ((_x.options &
+         (NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsOpaqueMemory | NSPointerFunctionsMallocMemory | NSPointerFunctionsMachVirtualMemory)) == NSPointerFunctionsStrongMemory)
+        return YES;
+    return NO;
 }
 
-- (BOOL) usesWeakReadAndWriteBarriers
+- (BOOL)usesWeakReadAndWriteBarriers
 {
-  if (_x.options & NSPointerFunctionsZeroingWeakMemory)
-    return YES;
-  return NO;
+    if (_x.options & NSPointerFunctionsZeroingWeakMemory)
+        return YES;
+    return NO;
 }
 
 @end
-

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -169,7 +169,7 @@ relinquishRetainedMemory(const void *item,
         } break;
         case NSPointerFunctionsOpaquePersonality: {
             pf.descriptionFunction = describePointer;
-            pf.hashFunction = hashDirect;
+            pf.hashFunction = hashShifted;
             pf.isEqualFunction = equalDirect;
         } break;
         case NSPointerFunctionsObjectPointerPersonality: {

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -25,6 +25,7 @@
 
 #import "common.h"
 #import "NSConcretePointerFunctions.h"
+#import <Foundation/NSException.h>
 
 static void *
 acquireRetainedObject(const void *item,
@@ -103,8 +104,8 @@ relinquishRetainedMemory(const void *item,
 {
     _x.options = options;
 
-    NSUInteger memoryOption = memoryType(options);
-    NSUInteger personalityOption = personalityType(options);
+    int memoryOption = memoryType(options);
+    int personalityOption = personalityType(options);
     BOOL copyIn = isCopyIn(options);
 
     if (memoryOption == NSPointerFunctionsOpaqueMemory && copyIn) {
@@ -113,7 +114,7 @@ relinquishRetainedMemory(const void *item,
         return nil;
     }
 
-    switch (memoryType) {
+    switch (memoryOption) {
         case NSPointerFunctionsStrongMemory: {
             // Default option (0)
             _x.acquireFunction = acquireRetainedObject;
@@ -144,7 +145,7 @@ relinquishRetainedMemory(const void *item,
         } break;
     }
 
-    switch (personalityType) {
+    switch (personalityOption) {
         case NSPointerFunctionsObjectPersonality: {
             // Default option (0)
             _x.descriptionFunction = describeObject;

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -27,46 +27,13 @@
 #import "NSConcretePointerFunctions.h"
 
 static void *
-acquireMallocMemory(const void *item,
-                    NSUInteger (*size)(const void *item), BOOL shouldCopy)
-{
-    if (shouldCopy == YES) {
-        NSUInteger len = (*size)(item);
-        void *newItem = malloc(len);
-
-        memcpy(newItem, item, len);
-        item = newItem;
-    }
-    return (void *)item;
-}
-
-static void *
 acquireRetainedObject(const void *item,
-                      NSUInteger (*size)(const void *item), BOOL shouldCopy)
+                      NSUInteger (*_size)(const void *item), BOOL shouldCopy)
 {
     if (shouldCopy == YES) {
         return [(NSObject *)item copy];
     }
     return [(NSObject *)item retain];
-}
-
-static void *
-acquireExistingMemory(const void *item,
-                      NSUInteger (*size)(const void *item), BOOL shouldCopy)
-{
-    return (void *)item;
-}
-
-static NSString *
-describeString(const void *item)
-{
-    return [NSString stringWithFormat:@"%s", (char *)item];
-}
-
-static NSString *
-describeInteger(const void *item)
-{
-    return [NSString stringWithFormat:@"%" PRIdPTR, (intptr_t)item];
 }
 
 static NSString *
@@ -83,86 +50,39 @@ describePointer(const void *item)
 
 static BOOL
 equalDirect(const void *item1, const void *item2,
-            NSUInteger (*size)(const void *item))
+            NSUInteger (*_size)(const void *item))
 {
     return (item1 == item2) ? YES : NO;
 }
 
 static BOOL
 equalObject(const void *item1, const void *item2,
-            NSUInteger (*size)(const void *item))
+            NSUInteger (*_size)(const void *item))
 {
     return [(NSObject *)item1 isEqual:(NSObject *)item2];
 }
 
-static BOOL
-equalMemory(const void *item1, const void *item2,
-            NSUInteger (*size)(const void *item))
-{
-    NSUInteger s1 = (*size)(item1);
-    NSUInteger s2 = (*size)(item2);
-
-    return (s1 == s2 && memcmp(item1, item2, s1) == 0) ? YES : NO;
-}
-
-static BOOL
-equalString(const void *item1, const void *item2,
-            NSUInteger (*size)(const void *item))
-{
-    return (strcmp((const char *)item1, (const char *)item2) == 0) ? YES : NO;
-}
-
 static NSUInteger
-hashDirect(const void *item, NSUInteger (*size)(const void *item))
+hashDirect(const void *item, NSUInteger (*_size)(const void *item))
 {
     return (NSUInteger)(uintptr_t)item;
 }
 
 static NSUInteger
-hashObject(const void *item, NSUInteger (*size)(const void *item))
+hashObject(const void *item, NSUInteger (*_size)(const void *item))
 {
     return [(NSObject *)item hash];
 }
 
 static NSUInteger
-hashMemory(const void *item, NSUInteger (*size)(const void *item))
-{
-    unsigned len = (*size)(item);
-    NSUInteger hash = 0;
-
-    while (len-- > 0) {
-        hash = (hash << 5) + hash + *(const uint8_t *)item++;
-    }
-    return hash;
-}
-
-static NSUInteger
-hashShifted(const void *item, NSUInteger (*size)(const void *item))
+hashShifted(const void *item, NSUInteger (*_size)(const void *item))
 {
     return ((NSUInteger)(uintptr_t)item) >> 2;
 }
 
-static NSUInteger
-hashString(const void *item, NSUInteger (*size)(const void *item))
-{
-    NSUInteger hash = 0;
-
-    while (*(const uint8_t *)item != 0) {
-        hash = (hash << 5) + hash + *(const uint8_t *)item++;
-    }
-    return hash;
-}
-
-static void
-relinquishMallocMemory(const void *item,
-                       NSUInteger (*size)(const void *item))
-{
-    free((void *)item);
-}
-
 static void
 relinquishRetainedMemory(const void *item,
-                         NSUInteger (*size)(const void *item))
+                         NSUInteger (*_size)(const void *item))
 {
     [(NSObject *)item release];
 }

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -122,6 +122,13 @@ relinquishRetainedMemory(const void *item,
         return nil;
     }
 
+    if (personalityOption == NSPointerFunctionsIntegerPersonality &&
+        memoryOption != NSPointerFunctionsOpaqueMemory) {
+        NSLog(@"ERROR: Unsupported use of NSPointerFunctionsIntegerPersonality with a memory type other than NSPointerFunctionsOpaqueMemory");
+        NSParameterAssert(NO);
+        return nil;
+    }
+
     switch (memoryOption) {
         case NSPointerFunctionsStrongMemory: {
             // Default option (0)
@@ -181,8 +188,9 @@ relinquishRetainedMemory(const void *item,
             return nil;
         } break;
         case NSPointerFunctionsIntegerPersonality: {
-            NSLog(@"ERROR: Unsupported NSPointerFunctionsOptions option NSPointerFunctionsIntegerPersonality");
-            NSParameterAssert(NO);
+            pf.descriptionFunction = describeInteger;
+            pf.hashFunction = hashDirect;
+            pf.isEqualFunction = equalDirect;
             return nil;
         } break;
     }

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -49,6 +49,12 @@ describePointer(const void *item)
     return [NSString stringWithFormat:@"%p", item];
 }
 
+static NSString *
+describeInteger(const void *item)
+{
+    return [NSString stringWithFormat:@"%" PRIdPTR, (intptr_t)item];
+}
+
 static BOOL
 equalDirect(const void *item1, const void *item2,
             NSUInteger (*_size)(const void *item))

--- a/Source/NSConcretePointerFunctions.m
+++ b/Source/NSConcretePointerFunctions.m
@@ -304,15 +304,17 @@ relinquishRetainedMemory(const void *item,
     _x.relinquishFunction = func;
 }
 
-- (void)setSizeFunction:(NSUInteger (*)(const void *item))func
+- (NSUInteger (*)(const void *item))sizeFunction
 {
-    _x.sizeFunction = func;
+    NSLog(@"Error: Unsupported NSPointerFunctions property sizeFunction");
+    NSParameterAssert(NO);
+    return nil;
 }
 
-- (void)setUsesStrongWriteBarrier:(BOOL)flag
+- (void)setSizeFunction:(NSUInteger (*)(const void *item))func
 {
-    _x.options &=
-        ~(NSPointerFunctionsZeroingWeakMemory | NSPointerFunctionsOpaqueMemory | NSPointerFunctionsMallocMemory | NSPointerFunctionsMachVirtualMemory);
+    NSLog(@"Error: Unsupported NSPointerFunctions property sizeFunction");
+    NSParameterAssert(NO);
 }
 
 - (BOOL)usesStrongWriteBarrier

--- a/Source/NSPointerArray.m
+++ b/Source/NSPointerArray.m
@@ -534,7 +534,7 @@ static Class	concreteClass = Nil;
 	  new_gf = new_cap / 2;
 	  if (_contents == 0)
 	    {
-	      if (_pf.options & NSPointerFunctionsZeroingWeakMemory)
+	      if (hasMemoryType(_pf.options, NSPointerFunctionsZeroingWeakMemory))
 		{
 		  ptr = (void**)NSAllocateCollectable(size, 0);
 		}
@@ -545,7 +545,7 @@ static Class	concreteClass = Nil;
 	    }
 	  else
 	    {
-	      if (_pf.options & NSPointerFunctionsZeroingWeakMemory)
+	      if (hasMemoryType(_pf.options, NSPointerFunctionsZeroingWeakMemory))
 		{
 		  ptr = (void**)NSReallocateCollectable(
 		    _contents, size, 0);


### PR DESCRIPTION
resolves FLEX-393

Note that the first commit is a clang-format

 - Deprecate memory types `ZeroingWeak`, `Malloc`, and `MachVirtual`
 - Deprecate personality types `CString`, `Struct`, and `Integer`
 - Deprecate properties `usesStrongWriteBarrier`, `usesWeakReadAndWriteBarriers`, and `sizeFunction`
 - Rewrite `initWithOptions `to be sane
   - The specific thing that fixes FLEX-393 is setting `acquireFunction` properly based on the memory type
 - Revise code to handle `NSPointerFunctionsOptions` correctly
   - Previously, they were being treated as bitflags when they are actually sequential enum values, which led to lots of essentially undefined behaviour
 - Deprecated non-ARC behaviour
 - Removed dead code

This is not yet complete, so I'm drafting it for now. The changes have incurred an extra crash which I am currently debugging. Also worth taking 2049f1e into consideration: NSConcreteMapTable it turns out could very well have memory-soundness issues in its implementation.