### PR TITLE
Initialize calendar property, and NULL after ucal_close

### DIFF
--- a/Source/NSCalendar.m
+++ b/Source/NSCalendar.m
@@ -239,7 +239,11 @@ static NSRecursiveLock *classLock = nil;
     || [tz isEqual: [my->tz name]] == NO)
     {
 #if GS_USE_ICU == 1
-      ucal_close(my->cal);
+      if (my->cal != NULL)
+        {
+          ucal_close (my->cal);
+          my->cal = NULL;
+        }
 #endif
 
       ASSIGN(my->localeID, locale);
@@ -312,6 +316,7 @@ static NSRecursiveLock *classLock = nil;
   my->minimumDaysInFirstWeek = NSNotFound;
   ASSIGN(my->identifier, identifier);
   ASSIGN(my->tz, [NSTimeZone defaultTimeZone]);
+  my->cal = NULL;
   [self setLocale: [NSLocale currentLocale]];
 
   return self;
@@ -322,7 +327,11 @@ static NSRecursiveLock *classLock = nil;
   if (0 != _NSCalendarInternal)
     {
 #if GS_USE_ICU == 1
-      ucal_close (my->cal);
+    if (my->cal != NULL)
+      {
+        ucal_close (my->cal);
+        my->cal = NULL;
+      }
 #endif
       RELEASE(my->identifier);
       RELEASE(my->localeID);


### PR DESCRIPTION
Without this, we have garbage in `cal`, leading to `ucal_close` sometimes crashing on 
```
  if (my->cal != NULL)
    {
      ucal_close(my->cal);
    }
```
