### PR TITLE
responding to 302 redirects with the same method as the original request

### DIFF
--- a/Source/GSHTTPURLProtocol.m
+++ b/Source/GSHTTPURLProtocol.m
@@ -656,8 +656,13 @@ parseArgumentPart(NSString *part, NSString *name)
     {
       case 301:
       case 302:
-        method = [[fromRequest HTTPMethod] isEqualToString:@"POST"] ? 
-          @"GET" : [fromRequest HTTPMethod];
+#if REDIRECT_302_GET
+          method = [[fromRequest HTTPMethod] isEqualToString:@"POST"] ? 
+            @"GET" : [fromRequest HTTPMethod];
+#else
+          // RFC leaves the choice of method to the client - the Mac appears to use the same method.
+          method = [fromRequest HTTPMethod];
+#endif
         break;
       case 303:
         method = @"GET";


### PR DESCRIPTION
RFC-7231:
> Note: For historical reasons, a user agent MAY change the request method from POST to GET for the subsequent request.

choosing not to
