### PR TITLE
Not re-adding the headers if they have already been set 

### DIFF
--- a/Source/GSHTTPURLProtocol.h
+++ b/Source/GSHTTPURLProtocol.h
@@ -4,6 +4,9 @@
 #import "GSNativeProtocol.h"
 
 @interface GSHTTPURLProtocol : GSNativeProtocol
+{
+    BOOL _headersSet;
+}
 @end
 
 #endif

--- a/Source/GSHTTPURLProtocol.m
+++ b/Source/GSHTTPURLProtocol.m
@@ -563,7 +563,10 @@ parseArgumentPart(NSString *part, NSString *name)
     {
       [curlHeaders addObject: @"Content-Type:application/x-www-form-urlencoded"];
     }
-  [_easyHandle setCustomHeaders: curlHeaders];
+  if (!_headersSet) {
+      [_easyHandle setCustomHeaders:curlHeaders];
+      _headersSet = YES;
+  }
 
   NSInteger        timeoutInterval = [request timeoutInterval] * 1000;
   GSTimeoutSource  *timeoutTimer;


### PR DESCRIPTION
Redirects were causing headers to be re-applied to the curl request - unsurprisingly, this stops that from happening.

This was causing the "email is not validated" loop, because requests where silently failing.