### PR TITLE
FAN-1640: Implemented NSError's isEqual and hash.

### DIFF
--- a/Source/NSError.m
+++ b/Source/NSError.m
@@ -167,5 +167,27 @@
 {
   return _userInfo;
 }
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:[NSError class]]) {
+        return NO;
+    }
+
+    NSError *otherError = (NSError *) object;
+    return [_domain isEqualToString:[otherError domain]]
+           && _code == [otherError code]
+           && [_userInfo isEqual:[otherError userInfo]];
+}
+
+- (NSUInteger)hash
+{
+    return [_domain hash] ^ _code ^ [_userInfo hash];
+}
+
 @end
 


### PR DESCRIPTION
Required for using `NSError` as a dictionary key.