### PR TITLE
FAN-2232: stringsdict support

### DIFF
--- a/Headers/Foundation/NSString.h
+++ b/Headers/Foundation/NSString.h
@@ -1222,4 +1222,22 @@ extern struct objc_class _NSConstantStringClassReference;
 #import <GNUstepBase/NSMutableString+GNUstepBase.h>
 #endif
 
+@interface GSLocalizedString : NSString
+{
+  NSDictionary *_dict;
+  NSString     *_parent;
+}
+
+/** Initialize with a dictionary from a .stringsdict file.
+ */
+- (instancetype)initWithDictionary:(NSDictionary *)dict
+		      defaultValue:(NSString *)value;
+
+/** Returns a format that's appropriate for the pluralization of the arguments
+ * in the current language
+ */
+- (NSString *)getPluralizedFormat:(va_list)argList;
+
+@end
+
 #endif /* __NSString_h_GNUSTEP_BASE_INCLUDE */

--- a/Source/GSString.m
+++ b/Source/GSString.m
@@ -1616,6 +1616,12 @@ fixBOM(unsigned char **bytes, NSUInteger*length, BOOL *owned,
   if (NULL == format)
     [NSException raise: NSInvalidArgumentException
       format: @"[GSPlaceholderString-initWithFormat:locale:arguments:]: NULL format"];
+
+  if ([format isKindOfClass:[GSLocalizedString class]])
+    {
+      // Get the appropriate format according to the pluralization rules.
+      format = [(GSLocalizedString *) format getPluralizedFormat:argList];
+    }
   /*
    * First we provide an array of unichar characters containing the
    * format string.  For performance reasons we try to use an on-stack

--- a/Source/NSBundle.m
+++ b/Source/NSBundle.m
@@ -375,6 +375,13 @@ GSPrivateExecutablePath()
 #endif
 	  if (executablePath == nil || [executablePath length] == 0)
 	    {
+	      // Allow the executable path to be overridden, for when invoked
+	      // from a test runner.
+	      executablePath =
+		[[NSProcessInfo processInfo] environment][@"GNUSTEP_EXE"];
+	    }
+	  if (executablePath == nil || [executablePath length] == 0)
+	    {
 	      executablePath
 		= [[[NSProcessInfo processInfo] arguments] objectAtIndex: 0];
 	    }
@@ -2829,6 +2836,35 @@ IF_NO_ARC(
           NSDebugMLLog(@"NSBundle", @"Failed to locate strings file %@",
                        tableName);
         }
+
+      if (table)
+	{
+	  // Add the corresponding stringsdict file
+	  NSString *dictPath = [self pathForResource:tableName
+					      ofType:@"stringsdict"];
+	  if (dictPath != nil)
+	    {
+	      NSDictionary *stringsDict =
+		[[NSDictionary alloc] initWithContentsOfFile:dictPath];
+	      if (stringsDict)
+		{
+		  NSMutableDictionary *newTable = [table mutableCopy];
+
+		  [stringsDict
+		    enumerateKeysAndObjectsUsingBlock:
+		      (GSKeysAndObjectsEnumeratorBlock)
+		      ^ (NSString * k, NSDictionary * v, BOOL * stop) {
+			  GSLocalizedString *ls =
+			    [[GSLocalizedString alloc] initWithDictionary:v
+							     defaultValue:k];
+			  [newTable setObject:ls forKey:k];
+			}];
+
+		  table = [newTable copy];
+		}
+	    }
+	}
+
       /*
        * If we couldn't found and parsed the strings table, we put it in
        * the cache of strings tables in this bundle, otherwise we will just

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -6861,8 +6861,8 @@ static NSFileManager *fm = nil;
       else if ([type isEqualToString:@"1g"])
 	{
 	  double d = va_arg(args, double);
-      // Casting to an int would mean 0.3 is "zero" and 1.2 would be "one", so
-      // check against just 0 or 1 and let any other value be "other". 
+	  // Casting to an int would mean 0.3 is "zero" and 1.2 would be "one", so
+	  // check against just 0 or 1 and let any other value be "other". 
 	  number = d == 0 ? 0 : (d == 1 || d == -1) ? 1 : 10;
 	}
       else

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -6839,7 +6839,7 @@ static NSFileManager *fm = nil;
 
       // Get the numeric value of the variable (luckily, only "%ld", "%lu", and
       // "%1g" is used).
-      unsigned long number;
+      unsigned long number = 0;
       NSString	   *type = varDict[@"NSStringFormatValueTypeKey"];
 
       if ([type isEqualToString:@"ld"])
@@ -6850,10 +6850,20 @@ static NSFileManager *fm = nil;
 	{
 	  number = va_arg(args, unsigned long);
 	}
+      else if ([type isEqualToString:@"d"])
+	{
+	  number = va_arg(args, int);
+	}
+      else if ([type isEqualToString:@"u"])
+	{
+	  number = va_arg(args, unsigned int);
+	}
       else if ([type isEqualToString:@"1g"])
 	{
 	  double d = va_arg(args, double);
-	  number = d == 0 ? 0 : d == 1 ? 1 : 10;
+      // Casting to an int would mean 0.3 is "zero" and 1.2 would be "one", so
+      // check against just 0 or 1 and let any other value be "other". 
+	  number = d == 0 ? 0 : (d == 1 || d == -1) ? 1 : 10;
 	}
       else
 	{
@@ -6905,13 +6915,6 @@ static NSFileManager *fm = nil;
 
 - (unichar)characterAtIndex:(NSUInteger)index
 {
-  if (index == 999)
-    {
-      NSString *s =
-	[NSString localizedStringWithFormat:self, (unsigned long) 123,
-					    (unsigned long) 555];
-      return 0;
-    }
   return [_parent characterAtIndex:index];
 }
 

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -45,8 +45,6 @@
 #define GS_UNSAFE_REGEX 1
 #import "common.h"
 #include <stdio.h>
-#import <dispatch/dispatch.h>
-#import <dispatch/once.h>
 
 #import "Foundation/NSAutoreleasePool.h"
 #import "Foundation/NSCalendarDate.h"
@@ -6815,8 +6813,7 @@ static NSFileManager *fm = nil;
       return self;
     }
 
-  static dispatch_once_t      onceToken;
-  static NSRegularExpression *regex = nil;
+  NSRegularExpression *regex = nil;
 
   regex = [NSRegularExpression
     regularExpressionWithPattern:@"%#@([^@]+)@"

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -45,6 +45,8 @@
 #define GS_UNSAFE_REGEX 1
 #import "common.h"
 #include <stdio.h>
+#import <dispatch/dispatch.h>
+#import <dispatch/once.h>
 
 #import "Foundation/NSAutoreleasePool.h"
 #import "Foundation/NSCalendarDate.h"
@@ -59,6 +61,7 @@
 #import "Foundation/NSPathUtilities.h"
 #import "Foundation/NSRange.h"
 #import "Foundation/NSRegularExpression.h"
+#import "Foundation/NSTextCheckingResult.h"
 #import "Foundation/NSException.h"
 #import "Foundation/NSData.h"
 #import "Foundation/NSURL.h"
@@ -1436,6 +1439,13 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
   if (NULL == format)
     [NSException raise: NSInvalidArgumentException
       format: @"[NSString-initWithFormat:locale:arguments:]: NULL format"];
+
+  if ([format isKindOfClass:[GSLocalizedString class]])
+    {
+      // Get the appropriate format according to the pluralization rules.
+      format = [(GSLocalizedString *) format getPluralizedFormat:argList];
+    }
+
   /*
    * First we provide an array of unichar characters containing the
    * format string.  For performance reasons we try to use an on-stack
@@ -6765,3 +6775,309 @@ static NSFileManager *fm = nil;
 
 @end
 
+/**
+ * An item in a .stringsdict file.
+ * https://developer.apple.com/documentation/xcode/localizing-strings-that-contain-plurals
+ */
+@implementation GSLocalizedString
+
+- (id)initWithDictionary:(NSDictionary *)dict defaultValue:(NSString *)value
+{
+  _dict = dict;
+  return [self initWithString:value];
+}
+
+/* Returns a format that's appropriate for the pluralization of the arguments in
+ * the current language */
+- (NSString *)getPluralizedFormat:(va_list)argList
+{
+  /* Sample dictionary:
+      NSStringLocalizedFormatKey=%#@x_hours@, %#@x_minutes@
+      x_hours=NSDictionary {
+	NSStringFormatSpecTypeKey=NSStringPluralRuleType
+	NSStringFormatValueTypeKey=ld
+	zero=0 hours
+	one=1 hour
+	other=%1$ld hours
+      }
+      x_minutes=NSDictionary {
+	NSStringFormatSpecTypeKey=NSStringPluralRuleType
+	NSStringFormatValueTypeKey=ld
+	zero=0 minutes
+	one=1 minute
+	other=%2$ld minutes
+      }
+   */
+
+  NSString *formatKey = _dict[@"NSStringLocalizedFormatKey"];
+  if (!formatKey)
+    {
+      return self;
+    }
+
+  static dispatch_once_t      onceToken;
+  static NSRegularExpression *regex = nil;
+
+  regex = [NSRegularExpression
+    regularExpressionWithPattern:@"%#@([^@]+)@"
+			 options:NSRegularExpressionCaseInsensitive
+			   error:nil];
+
+  NSArray<NSTextCheckingResult *> *matches =
+    [regex matchesInString:formatKey
+		   options:0
+		     range:NSMakeRange(0, [formatKey length])];
+
+  va_list args;
+  va_copy(args, argList);
+
+  NSMutableString *newFormat = [formatKey mutableCopy];
+  NSInteger	   offset = 0;
+
+  for (NSTextCheckingResult *match in matches)
+    {
+      NSString *varKey = [formatKey substringWithRange:[match rangeAtIndex:1]];
+
+      NSDictionary<NSString *, NSString *> *varDict = _dict[varKey];
+
+      // Get the numeric value of the variable (luckily, only "%ld", "%lu", and
+      // "%1g" is used).
+      unsigned long number;
+      NSString	   *type = varDict[@"NSStringFormatValueTypeKey"];
+
+      if ([type isEqualToString:@"ld"])
+	{
+	  number = va_arg(args, long);
+	}
+      else if ([type isEqualToString:@"lu"])
+	{
+	  number = va_arg(args, unsigned long);
+	}
+      else if ([type isEqualToString:@"1g"])
+	{
+	  double d = va_arg(args, double);
+	  number = d == 0 ? 0 : d == 1 ? 1 : 10;
+	}
+      else
+	{
+	  number = va_arg(args, int);
+	}
+
+      // Only supports languages which have similar rules to english (zero,
+      // none, or other), as well as japanese (zero or other).
+      NSString *variantKey;
+      if (number == 0)
+	{
+	  variantKey = @"zero";
+	}
+      else if (number == 1)
+	{
+	  variantKey = @"one";
+	}
+      else
+	{
+	  variantKey = @"other";
+	}
+
+      NSString *replacement = varDict[variantKey];
+      if (!replacement)
+	{
+	  // Fallback to the "other" variant.
+	  replacement = varDict[@"other"];
+	}
+
+      if (replacement)
+	{
+	  [newFormat
+	    replaceCharactersInRange:NSMakeRange(match.range.location + offset,
+						 match.range.length)
+			  withString:replacement];
+	  offset += (NSInteger) ([replacement length] - match.range.length);
+	}
+    }
+
+  va_end(args);
+
+  return newFormat;
+}
+
+- (BOOL)canBeConvertedToEncoding:(NSStringEncoding)enc
+{
+  return [_parent canBeConvertedToEncoding:enc];
+}
+
+- (unichar)characterAtIndex:(NSUInteger)index
+{
+  if (index == 999)
+    {
+      NSString *s =
+	[NSString localizedStringWithFormat:self, (unsigned long) 123,
+					    (unsigned long) 555];
+      return 0;
+    }
+  return [_parent characterAtIndex:index];
+}
+
+- (NSComparisonResult)compare:(NSString *)aString
+		      options:(NSUInteger)mask
+			range:(NSRange)aRange
+{
+  return [_parent compare:aString options:mask range:aRange];
+}
+
+- (const char *)cString
+{
+  return [_parent cString];
+}
+
+- (const char *)cStringUsingEncoding:(NSStringEncoding)encoding
+{
+  return [_parent cStringUsingEncoding:encoding];
+}
+
+- (NSUInteger)cStringLength
+{
+  return [_parent cStringLength];
+}
+
+- (NSData *)dataUsingEncoding:(NSStringEncoding)encoding
+	 allowLossyConversion:(BOOL)flag
+{
+  return [_parent dataUsingEncoding:encoding allowLossyConversion:flag];
+}
+
+- (void)dealloc
+{
+  RELEASE(_parent);
+  [super dealloc];
+}
+
+- (id)copyWithZone:(NSZone *)z
+{
+  return [_parent copyWithZone:z];
+}
+
+- (id)mutableCopyWithZone:(NSZone *)z
+{
+  return [_parent mutableCopyWithZone:z];
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+  [_parent encodeWithCoder:aCoder];
+}
+
+- (NSStringEncoding)fastestEncoding
+{
+  return [_parent fastestEncoding];
+}
+
+- (void)getCharacters:(unichar *)buffer
+{
+  [_parent getCharacters:buffer];
+}
+
+- (void)getCharacters:(unichar *)buffer range:(NSRange)aRange
+{
+  [_parent getCharacters:buffer range:aRange];
+}
+
+- (void)getCString:(char *)buffer
+{
+  [_parent getCString:buffer];
+}
+
+- (void)getCString:(char *)buffer maxLength:(NSUInteger)maxLength
+{
+  [_parent getCString:buffer maxLength:maxLength];
+}
+
+- (BOOL)getCString:(char *)buffer
+	 maxLength:(NSUInteger)maxLength
+	  encoding:(NSStringEncoding)encoding
+{
+  return [_parent getCString:buffer maxLength:maxLength encoding:encoding];
+}
+
+- (void)getCString:(char *)buffer
+	 maxLength:(NSUInteger)maxLength
+	     range:(NSRange)aRange
+    remainingRange:(NSRange *)leftoverRange
+{
+  [_parent getCString:buffer
+	    maxLength:maxLength
+		range:aRange
+       remainingRange:leftoverRange];
+}
+
+- (NSUInteger)hash
+{
+  return [_parent hash];
+}
+
+- (id)initWithString:(NSString *)parent
+{
+  _parent = RETAIN(parent);
+  return self;
+}
+
+- (BOOL)isEqual:(id)anObject
+{
+  return [_parent isEqual:anObject];
+}
+
+- (BOOL)isEqualToString:(NSString *)anObject
+{
+  return [_parent isEqualToString:anObject];
+}
+
+- (BOOL)isProxy
+{
+  return YES;
+}
+
+- (NSUInteger)length
+{
+  return [_parent length];
+}
+
+- (NSUInteger)lengthOfBytesUsingEncoding:(NSStringEncoding)encoding
+{
+  return [_parent lengthOfBytesUsingEncoding:encoding];
+}
+
+- (const char *)lossyCString
+{
+  return [_parent lossyCString];
+}
+
+- (NSUInteger)maximumLengthOfBytesUsingEncoding:(NSStringEncoding)encoding
+{
+  return [_parent maximumLengthOfBytesUsingEncoding:encoding];
+}
+
+- (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
+{
+  return [_parent rangeOfComposedCharacterSequenceAtIndex:anIndex];
+}
+
+- (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+			   options:(NSUInteger)mask
+			     range:(NSRange)aRange
+{
+  return [_parent rangeOfCharacterFromSet:aSet options:mask range:aRange];
+}
+
+- (NSRange)rangeOfString:(NSString *)aString
+		 options:(NSUInteger)mask
+		   range:(NSRange)aRange
+{
+  return [_parent rangeOfString:aString options:mask range:aRange];
+}
+
+- (NSStringEncoding)smallestEncoding
+{
+  return [_parent smallestEncoding];
+}
+
+@end


### PR DESCRIPTION
Provides support for pluralisation rules specified in .stringsdict files.

For something in a .stringsdict file, `NSLocalizedString` will return `GSLocalizedString`, which is a `NSString` that contains the dict. When the formatter gets this, it builds a string format according to the pluralisation rules in the dict.