### PR TITLE
FAN-2263: Fix some bugs in NSString/GSString

### DIFF
--- a/Headers/Foundation/NSString.h
+++ b/Headers/Foundation/NSString.h
@@ -700,6 +700,9 @@ GS_EXPORT_CLASS
 
 #endif
 - (NSUInteger) cStringLength;
+
+#define HIDE_DEPRECATED_METHODS 1
+#if !HIDE_DEPRECATED_METHODS
 - (void) getCString: (char*)buffer;
 - (void) getCString: (char*)buffer
 	  maxLength: (NSUInteger)maxLength;
@@ -707,6 +710,7 @@ GS_EXPORT_CLASS
 	  maxLength: (NSUInteger)maxLength
 	      range: (NSRange)aRange
      remainingRange: (NSRange*)leftoverRange;
+#endif
 
 // Getting Numeric Values
 - (float) floatValue;

--- a/Source/GSString.m
+++ b/Source/GSString.m
@@ -2300,14 +2300,13 @@ getCStringE_c(GSStr self, char *buffer, unsigned int maxLength,
             unichar *u = (unichar *)(void *)buffer;
 
             if (GSToUnicode(&u, &bytes, self->_contents.c, self->_count,
-                            internalEncoding, NSDefaultMallocZone(), GSUniTerminate) == NO) {
+                            internalEncoding, NULL, GSUniTerminate) == NO
+                || u != (unichar *)(void *)buffer) {
                 [NSException raise:NSCharacterConversionException
                             format:@"Can't convert to Unicode string."];
             }
-            if (u == (unichar *)(void *)buffer) {
-                return YES;
-            }
-            NSZoneFree(NSDefaultMallocZone(), u);
+
+            return YES;
         }
         return NO;
     } else {

--- a/Source/GSString.m
+++ b/Source/GSString.m
@@ -67,7 +67,7 @@ static NSStringEncoding internalEncoding = NSISOLatin1StringEncoding;
 
 static BOOL isByteEncoding(NSStringEncoding enc)
 {
-  return GSPrivateIsByteEncoding(enc);
+    return GSPrivateIsByteEncoding(enc);
 }
 
 #ifdef NeXT_RUNTIME
@@ -83,7 +83,7 @@ struct objc_class _NSConstantStringClassReference;
       * It will return 0 for anything illegal
  */
 #define UTF8_BYTE_COUNT(c) \
-  (((c) < 0xf8) ? 1 + ((c) >= 0xc0) + ((c) >= 0xe0) + ((c) >= 0xf0) : 0)
+    (((c) < 0xf8) ? 1 + ((c) >= 0xc0) + ((c) >= 0xe0) + ((c) >= 0xf0) : 0)
 
 
 #ifndef GNUSTEP_NEW_STRING_ABI
@@ -93,104 +93,87 @@ struct objc_class _NSConstantStringClassReference;
 static NSUInteger
 lengthUTF8(const uint8_t *p, unsigned l, BOOL *ascii, BOOL *latin1)
 {
-  const uint8_t	*e = p + l;
-  BOOL		a = YES;
-  BOOL		l1 = YES;
+    const uint8_t *e = p + l;
+    BOOL a = YES;
+    BOOL l1 = YES;
 
-  l = 0;
-  while (p < e)
-    {
-      uint8_t	c = *p;
-      uint32_t	u = c;
+    l = 0;
+    while (p < e) {
+        uint8_t c = *p;
+        uint32_t u = c;
 
-      if (c > 0x7f)
-	{
-	  int i, sle = 0;
+        if (c > 0x7f) {
+            int i, sle = 0;
 
-	  a = NO;
-	  /* calculated the expected sequence length */
-	  while (c & 0x80)
-	    {
-	      c = c << 1;
-	      sle++;
-	    }
+            a = NO;
+            /* calculated the expected sequence length */
+            while (c & 0x80) {
+                c = c << 1;
+                sle++;
+            }
 
-	  /* legal ? */
-	  if ((sle < 2) || (sle > 6))
-	    {
-	      [NSException raise: NSInternalInconsistencyException
-			  format: @"Bad sequence length in constant string"];
-	    }
+            /* legal ? */
+            if ((sle < 2) || (sle > 6)) {
+                [NSException raise:NSInternalInconsistencyException
+                            format:@"Bad sequence length in constant string"];
+            }
 
-	  if (p + sle > e)
-	    {
-	      [NSException raise: NSInternalInconsistencyException
-			  format: @"Short data in constant string"];
-	    }
+            if (p + sle > e) {
+                [NSException raise:NSInternalInconsistencyException
+                            format:@"Short data in constant string"];
+            }
 
-	  /* get the codepoint */
-	  for (i = 1; i < sle; i++)
-	    {
-	      if (p[i] < 0x80 || p[i] >= 0xc0)
-		break;
-	      u = (u << 6) | (p[i] & 0x3f);
-	    }
+            /* get the codepoint */
+            for (i = 1; i < sle; i++) {
+                if (p[i] < 0x80 || p[i] >= 0xc0)
+                    break;
+                u = (u << 6) | (p[i] & 0x3f);
+            }
 
-	  if (i < sle)
-	    {
-	      [NSException raise: NSInternalInconsistencyException
-			  format: @"Codepoint out of range in constant string"];
-	    }
-	  u = u & ~(0xffffffff << ((5 * sle) + 1));
-	  p += sle;
+            if (i < sle) {
+                [NSException raise:NSInternalInconsistencyException
+                            format:@"Codepoint out of range in constant string"];
+            }
+            u = u & ~(0xffffffff << ((5 * sle) + 1));
+            p += sle;
 
-	  /*
-	   * We check for invalid codepoints here.
-	   */
-	  if (u > 0x10ffff)
-	    {
-	      [NSException raise: NSInternalInconsistencyException
-			  format: @"Codepoint invalid in constant string"];
-	    }
+            /*
+             * We check for invalid codepoints here.
+             */
+            if (u > 0x10ffff) {
+                [NSException raise:NSInternalInconsistencyException
+                            format:@"Codepoint invalid in constant string"];
+            }
 
-	  if ((u >= 0xd800) && (u <= 0xdfff))
-	    {
-	      [NSException raise: NSInternalInconsistencyException
-			  format: @"Bad surrogate pair in constant string"];
-	    }
-	}
-      else
-	{
-	  p++;
-	}
+            if ((u >= 0xd800) && (u <= 0xdfff)) {
+                [NSException raise:NSInternalInconsistencyException
+                            format:@"Bad surrogate pair in constant string"];
+            }
+        } else {
+            p++;
+        }
 
-      /*
-       * Add codepoint as either a single unichar for BMP
-       * or as a pair of surrogates for codepoints over 16 bits.
-       */
-      if (u < 0x10000)
-	{
-	  l++;
-	  if (u > 255)
-	    {
-	      l1 = NO;
-	    }
-	}
-      else
-	{
-	  l += 2;
-          l1 = NO;
-	}
+        /*
+         * Add codepoint as either a single unichar for BMP
+         * or as a pair of surrogates for codepoints over 16 bits.
+         */
+        if (u < 0x10000) {
+            l++;
+            if (u > 255) {
+                l1 = NO;
+            }
+        } else {
+            l += 2;
+            l1 = NO;
+        }
     }
-  if (0 != ascii)
-    {
-      *ascii = a;
+    if (0 != ascii) {
+        *ascii = a;
     }
-  if (0 != latin1)
-    {
-      *latin1 = l1;
+    if (0 != latin1) {
+        *latin1 = l1;
     }
-  return l;
+    return l;
 }
 
 /* Sequentially extracts characters from UTF-8 string
@@ -205,96 +188,85 @@ lengthUTF8(const uint8_t *p, unsigned l, BOOL *ascii, BOOL *latin1)
 static inline unichar
 nextUTF8(const uint8_t *p, unsigned l, unsigned *o, unichar *n)
 {
-  unsigned	i;
+    unsigned i;
 
-  /* If we still have the second part of a surrogate pair, return it.
-   */
-  if (*n > 0)
-    {
-      unichar	u = *n;
+    /* If we still have the second part of a surrogate pair, return it.
+     */
+    if (*n > 0) {
+        unichar u = *n;
 
-      *n = 0;
-      return u;
+        *n = 0;
+        return u;
     }
 
-  if ((i = *o) < l)
-    {
-      uint8_t	c = p[i];
-      uint32_t	u = c;
+    if ((i = *o) < l) {
+        uint8_t c = p[i];
+        uint32_t u = c;
 
-      if (c > 0x7f)
-	{
-	  int j, sle = 0;
+        if (c > 0x7f) {
+            int j, sle = 0;
 
-	  /* calculated the expected sequence length */
-	  sle = UTF8_BYTE_COUNT(c);
+            /* calculated the expected sequence length */
+            sle = UTF8_BYTE_COUNT(c);
 
-	  /* legal ? */
-	  if (sle < 2)
-	    {
-	      [NSException raise: NSInvalidArgumentException
-			  format: @"bad multibyte character length"];
-	    }
+            /* legal ? */
+            if (sle < 2) {
+                [NSException raise:NSInvalidArgumentException
+                            format:@"bad multibyte character length"];
+            }
 
-	  if (sle + i > l)
-	    {
-	      [NSException raise: NSInvalidArgumentException
-			  format: @"multibyte character extends beyond data"];
-	    }
+            if (sle + i > l) {
+                [NSException raise:NSInvalidArgumentException
+                            format:@"multibyte character extends beyond data"];
+            }
 
-	  /* get the codepoint */
-	  for (j = 1; j < sle; j++)
-	    {
-	      uint8_t	b = p[i + j];
+            /* get the codepoint */
+            for (j = 1; j < sle; j++) {
+                uint8_t b = p[i + j];
 
-	      if (b < 0x80 || b >= 0xc0)
-		break;
-	      u = (u << 6) | (b & 0x3f);
-	    }
+                if (b < 0x80 || b >= 0xc0)
+                    break;
+                u = (u << 6) | (b & 0x3f);
+            }
 
-	  if (j < sle)
-	    {
-	      [NSException raise: NSInvalidArgumentException
-			  format: @"bad data in multibyte character"];
-	    }
-	  u = u & ~(0xffffffff << ((5 * sle) + 1));
-	  i += sle;
+            if (j < sle) {
+                [NSException raise:NSInvalidArgumentException
+                            format:@"bad data in multibyte character"];
+            }
+            u = u & ~(0xffffffff << ((5 * sle) + 1));
+            i += sle;
 
-	  /*
-	   * We discard invalid codepoints here.
-	   */
-	  if (u > 0x10ffff)
-	    {
-	      [NSException raise: NSInvalidArgumentException
-			  format: @"invalid unicode codepoint"];
-	    }
-	}
-      else
-	{
-	  i++;
-	}
+            /*
+             * We discard invalid codepoints here.
+             */
+            if (u > 0x10ffff) {
+                [NSException raise:NSInvalidArgumentException
+                            format:@"invalid unicode codepoint"];
+            }
+        } else {
+            i++;
+        }
 
-      /*
-       * Add codepoint as either a single unichar for BMP
-       * or as a pair of surrogates for codepoints over 16 bits.
-       */
-      if (u >= 0x10000)
-	{
-	  unichar ul, uh;
+        /*
+         * Add codepoint as either a single unichar for BMP
+         * or as a pair of surrogates for codepoints over 16 bits.
+         */
+        if (u >= 0x10000) {
+            unichar ul, uh;
 
-	  u -= 0x10000;
-	  ul = u & 0x3ff;
-	  uh = (u >> 10) & 0x3ff;
+            u -= 0x10000;
+            ul = u & 0x3ff;
+            uh = (u >> 10) & 0x3ff;
 
-	  *n = ul + 0xdc00;	// record second part of pair
-	  u = uh + 0xd800;	// return first part.
-	}
-      *o = i;			// Return new index
-      return (unichar)u;
+            *n = ul + 0xdc00; // record second part of pair
+            u = uh + 0xd800; // return first part.
+        }
+        *o = i; // Return new index
+        return (unichar)u;
     }
-  [NSException raise: NSInvalidArgumentException
-	      format: @"no more data in UTF-8 string"];
-  return 0;
+    [NSException raise:NSInvalidArgumentException
+                format:@"no more data in UTF-8 string"];
+    return 0;
 }
 #endif
 
@@ -302,185 +274,148 @@ static BOOL
 literalIsEqualInternal(NXConstantString *s, GSStr o)
 {
 #ifdef GNUSTEP_NEW_STRING_ABI
-  if (s->nxcslen != o->_count)
-    {
-      return NO;
-    }
-  else
-    {
-      size_t end = s->nxcslen;
-      static const int buffer_size = 64;
-      unichar buffer1[buffer_size];
-      unichar buffer2[buffer_size];
-      NSRange r = { 0, buffer_size };
-      do
-	{
-	  if (r.location + r.length > end)
-	    {
-	      r.length = s->nxcslen - r.location;
-	    }
-	  [s getCharacters: buffer1 range: r];
-	  [o getCharacters: buffer2 range: r];
-	  if (memcmp(buffer1, buffer2, r.length * sizeof(unichar)) != 0)
-	    {
-	      return NO;
-	    }
-	  r.location += buffer_size;
-	} while (r.location < end);
-      return YES;
+    if (s->nxcslen != o->_count) {
+        return NO;
+    } else {
+        size_t end = s->nxcslen;
+        static const int buffer_size = 64;
+        unichar buffer1[buffer_size];
+        unichar buffer2[buffer_size];
+        NSRange r = {0, buffer_size};
+        do {
+            if (r.location + r.length > end) {
+                r.length = s->nxcslen - r.location;
+            }
+            [s getCharacters:buffer1 range:r];
+            [o getCharacters:buffer2 range:r];
+            if (memcmp(buffer1, buffer2, r.length * sizeof(unichar)) != 0) {
+                return NO;
+            }
+            r.location += buffer_size;
+        } while (r.location < end);
+        return YES;
     }
 #else
-  unsigned	len = o->_count;
+    unsigned len = o->_count;
 
-  /* Since UTF-8 is a multibyte character set, it must have at least
-   * as many bytes as another string of the same length. So if the
-   * UTF-8 string is shorter, the two cannot be equal.
-   * A check for this can quickly give us a result in half the cases
-   * where the two strings have different lengths.
-   */
-  if (len > s->nxcslen)
-    {
-      return NO;
-    }
-  else
-    {
-      NSUInteger	pos = 0;
-      unichar		n = 0;
-      unsigned		i = 0;
-      unichar		u;
+    /* Since UTF-8 is a multibyte character set, it must have at least
+     * as many bytes as another string of the same length. So if the
+     * UTF-8 string is shorter, the two cannot be equal.
+     * A check for this can quickly give us a result in half the cases
+     * where the two strings have different lengths.
+     */
+    if (len > s->nxcslen) {
+        return NO;
+    } else {
+        NSUInteger pos = 0;
+        unichar n = 0;
+        unsigned i = 0;
+        unichar u;
 
-      if (0 == o->_flags.wide)
-	{
-	  /* If the other string is a buffer containing ascii characters,
-	   * we can perform a bytewise comparison.
-	   */
-	  if (internalEncoding == NSASCIIStringEncoding)
-	    {
-	      if (len == s->nxcslen
-		&& 0 == memcmp(o->_contents.c, s->nxcsptr, len))
-		{
-		  return YES;
-		}
-	      else
-		{
-		  return NO;
-		}
-	    }
+        if (0 == o->_flags.wide) {
+            /* If the other string is a buffer containing ascii characters,
+             * we can perform a bytewise comparison.
+             */
+            if (internalEncoding == NSASCIIStringEncoding) {
+                if (len == s->nxcslen && 0 == memcmp(o->_contents.c, s->nxcsptr, len)) {
+                    return YES;
+                } else {
+                    return NO;
+                }
+            }
 
-	  /* If the other string is a buffer containing latin1 characters,
-	   * we can compare buffer contents with unichar values directly.
-	   */
-	  if (internalEncoding == NSISOLatin1StringEncoding)
-	    {
-	      while (i < s->nxcslen || n > 0)
-		{
-		  u = nextUTF8((const uint8_t *)s->nxcsptr, s->nxcslen, &i, &n);
-		  if (pos >= len || (unichar)o->_contents.c[pos] != u)
-		    {
-		      return NO;
-		    }
-		  pos++;
-		}
-	      if (pos != len)
-		{
-		  return NO;
-		}
-	      return YES;
-	    }
+            /* If the other string is a buffer containing latin1 characters,
+             * we can compare buffer contents with unichar values directly.
+             */
+            if (internalEncoding == NSISOLatin1StringEncoding) {
+                while (i < s->nxcslen || n > 0) {
+                    u = nextUTF8((const uint8_t *)s->nxcsptr, s->nxcslen, &i, &n);
+                    if (pos >= len || (unichar)o->_contents.c[pos] != u) {
+                        return NO;
+                    }
+                    pos++;
+                }
+                if (pos != len) {
+                    return NO;
+                }
+                return YES;
+            }
 
-	  /* For any other narrow internal string, we know that ascii is
-	   * a subset of the encoding, so as long as characters are ascii
-	   * (don't have the top bit set) we can do bytewise comparison.
-	   */
-	  if (len == s->nxcslen)
-	    {
-	      unsigned	index;
+            /* For any other narrow internal string, we know that ascii is
+             * a subset of the encoding, so as long as characters are ascii
+             * (don't have the top bit set) we can do bytewise comparison.
+             */
+            if (len == s->nxcslen) {
+                unsigned index;
 
-	      for (index = 0; index < len; index++)
-		{
-		  uint8_t	c = s->nxcsptr[index];
+                for (index = 0; index < len; index++) {
+                    uint8_t c = s->nxcsptr[index];
 
-		  if (c != o->_contents.c[index] || c >= 128)
-		    {
-		      /* Characters differ at this point.
-		       */
-		      break;
-		    }
-		}
-	      if (index == len)
-		{
-		  return YES;
-		}
-	      /* The characters were the same up to 'index', so we won't
-	       * need to recheck those first few characters.
-	       */
-	      pos = i = index;
-	    }
-	}
+                    if (c != o->_contents.c[index] || c >= 128) {
+                        /* Characters differ at this point.
+                         */
+                        break;
+                    }
+                }
+                if (index == len) {
+                    return YES;
+                }
+                /* The characters were the same up to 'index', so we won't
+                 * need to recheck those first few characters.
+                 */
+                pos = i = index;
+            }
+        }
 
-      /* For small strings, or ones where we already have an array of
-       * UTF-16 characters, we can do a UTF-16 comparison directly.
-       * For larger strings, we may do as well with a character by
-       * character comparison.
-       */
-      if (1 == o->_flags.wide || (len < 200 && pos < len))
-	{
-	  unichar	*ptr;
+        /* For small strings, or ones where we already have an array of
+         * UTF-16 characters, we can do a UTF-16 comparison directly.
+         * For larger strings, we may do as well with a character by
+         * character comparison.
+         */
+        if (1 == o->_flags.wide || (len < 200 && pos < len)) {
+            unichar *ptr;
 
-	  if (1 == o->_flags.wide)
-	    {
-	      ptr = o->_contents.u;
-	    }
-	  else
-	    {
-	      ptr = alloca(sizeof(unichar) * len);
-	      if (NO == GSToUnicode(&ptr, &len, o->_contents.c,
-		len, internalEncoding, 0, 0))
-		{
-		  return NO;
-		}
-	    }
+            if (1 == o->_flags.wide) {
+                ptr = o->_contents.u;
+            } else {
+                ptr = alloca(sizeof(unichar) * len);
+                if (NO == GSToUnicode(&ptr, &len, o->_contents.c, len, internalEncoding, 0, 0)) {
+                    return NO;
+                }
+            }
 
-	  /* Now we have a UTF-16 buffer, so we can do a UTF-16 comparison.
-	   */
-	  while (i < s->nxcslen || n > 0)
-	    {
-	      u = nextUTF8((const uint8_t *)s->nxcsptr, s->nxcslen, &i, &n);
-	      if (pos >= len || ptr[pos] != u)
-		{
-		  return NO;
-		}
-	      pos++;
-	    }
-	}
-      else
-	{
-	  unichar	(*imp)(id, SEL, NSUInteger);
+            /* Now we have a UTF-16 buffer, so we can do a UTF-16 comparison.
+             */
+            while (i < s->nxcslen || n > 0) {
+                u = nextUTF8((const uint8_t *)s->nxcsptr, s->nxcslen, &i, &n);
+                if (pos >= len || ptr[pos] != u) {
+                    return NO;
+                }
+                pos++;
+            }
+        } else {
+            unichar (*imp)(id, SEL, NSUInteger);
 
-	  /* Do a character by character comparison using characterAtIndex:
-	   * This will be relatively slow, but how often will we actually
-	   * need to do this for a literal string?  Most string literals will
-	   * either be short or will differ from any other string we are
-	   * doing a comparison with within the first few tens of characters.
-	   */
-	  imp = (unichar(*)(id,SEL,NSUInteger))[(id)o methodForSelector:
-	    @selector(characterAtIndex:)];
-	  while (i < s->nxcslen || n > 0)
-	    {
-	      u = nextUTF8((const uint8_t *)s->nxcsptr, s->nxcslen, &i, &n);
-	      if (pos >= len
-		|| (*imp)((id)o, @selector(characterAtIndex:), pos) != u)
-		{
-		  return NO;
-		}
-	      pos++;
-	    }
-	}
-      if (pos != len)
-	{
-	  return NO;
-	}
-      return YES;
+            /* Do a character by character comparison using characterAtIndex:
+             * This will be relatively slow, but how often will we actually
+             * need to do this for a literal string?  Most string literals will
+             * either be short or will differ from any other string we are
+             * doing a comparison with within the first few tens of characters.
+             */
+            imp = (unichar(*)(id, SEL, NSUInteger))[(id)o methodForSelector:
+                                                              @selector(characterAtIndex:)];
+            while (i < s->nxcslen || n > 0) {
+                u = nextUTF8((const uint8_t *)s->nxcsptr, s->nxcslen, &i, &n);
+                if (pos >= len || (*imp)((id)o, @selector(characterAtIndex:), pos) != u) {
+                    return NO;
+                }
+                pos++;
+            }
+        }
+        if (pos != len) {
+            return NO;
+        }
+        return YES;
     }
 #endif
 }
@@ -489,9 +424,8 @@ literalIsEqualInternal(NXConstantString *s, GSStr o)
 /*
  * GSPlaceholderString - placeholder class for objects awaiting intialisation.
  */
-@interface GSPlaceholderString : NSString
-{
-  NSZone        *myZone;
+@interface GSPlaceholderString : NSString {
+    NSZone *myZone;
 }
 @end
 
@@ -519,8 +453,7 @@ to another strings _contents buffer, are valid only if this flag is set.
 GSCString, an abstract class that stores the string as 8-bit data in the
 internal encoding.
 */
-@interface GSCString : GSString
-{
+@interface GSCString : GSString {
 }
 @end
 
@@ -528,8 +461,7 @@ internal encoding.
 And GSUnicodeString, an abstract class that stores the string as 16-bit
 unicode characters.
 */
-@interface GSUnicodeString : GSString
-{
+@interface GSUnicodeString : GSString {
 }
 @end
 
@@ -544,13 +476,11 @@ GS*BufferString, concrete subclasses that store the data in an external
 by the instance; the 'owned' flag indicates which. If it is set,
 we may need to free the buffer when we are deallocated.
 */
-@interface GSCBufferString : GSCString
-{
+@interface GSCBufferString : GSCString {
 }
 @end
 
-@interface GSUnicodeBufferString : GSUnicodeString
-{
+@interface GSUnicodeBufferString : GSUnicodeString {
 }
 @end
 
@@ -559,13 +489,11 @@ we may need to free the buffer when we are deallocated.
 GS*InlineString, concrete subclasses that store the data immediately after
 the instance iself.
 */
-@interface GSCInlineString : GSCString
-{
+@interface GSCInlineString : GSCString {
 }
 @end
 
-@interface GSUInlineString : GSUnicodeString
-{
+@interface GSUInlineString : GSUnicodeString {
 }
 @end
 
@@ -574,17 +502,15 @@ the instance iself.
 GS*SubString, concrete subclasses that use the data in another string
 instance.
 */
-@interface GSCSubString : GSCString
-{
-@public
-  GSString	*_parent;
+@interface GSCSubString : GSCString {
+   @public
+    GSString *_parent;
 }
 @end
 
-@interface GSUnicodeSubString : GSUnicodeString
-{
-@public
-  GSString	*_parent;
+@interface GSUnicodeSubString : GSUnicodeString {
+   @public
+    GSString *_parent;
 }
 @end
 
@@ -592,45 +518,45 @@ instance.
  *	Include sequence handling code with instructions to generate search
  *	and compare functions for NSString objects.
  */
-#define	GSEQ_STRCOMP	strCompUsNs
-#define	GSEQ_STRRANGE	strRangeUsNs
-#define	GSEQ_O	GSEQ_NS
-#define	GSEQ_S	GSEQ_US
+#define GSEQ_STRCOMP strCompUsNs
+#define GSEQ_STRRANGE strRangeUsNs
+#define GSEQ_O GSEQ_NS
+#define GSEQ_S GSEQ_US
 #include "GSeq.h"
 
-#define	GSEQ_STRCOMP	strCompUsUs
-#define	GSEQ_STRRANGE	strRangeUsUs
-#define	GSEQ_O	GSEQ_US
-#define	GSEQ_S	GSEQ_US
+#define GSEQ_STRCOMP strCompUsUs
+#define GSEQ_STRRANGE strRangeUsUs
+#define GSEQ_O GSEQ_US
+#define GSEQ_S GSEQ_US
 #include "GSeq.h"
 
-#define	GSEQ_STRCOMP	strCompUsCs
-#define	GSEQ_STRRANGE	strRangeUsCs
-#define	GSEQ_O	GSEQ_CS
-#define	GSEQ_S	GSEQ_US
+#define GSEQ_STRCOMP strCompUsCs
+#define GSEQ_STRRANGE strRangeUsCs
+#define GSEQ_O GSEQ_CS
+#define GSEQ_S GSEQ_US
 #include "GSeq.h"
 
-#define	GSEQ_STRCOMP	strCompCsNs
-#define	GSEQ_STRRANGE	strRangeCsNs
-#define	GSEQ_O	GSEQ_NS
-#define	GSEQ_S	GSEQ_CS
+#define GSEQ_STRCOMP strCompCsNs
+#define GSEQ_STRRANGE strRangeCsNs
+#define GSEQ_O GSEQ_NS
+#define GSEQ_S GSEQ_CS
 #include "GSeq.h"
 
-#define	GSEQ_STRCOMP	strCompCsUs
-#define	GSEQ_STRRANGE	strRangeCsUs
-#define	GSEQ_O	GSEQ_US
-#define	GSEQ_S	GSEQ_CS
+#define GSEQ_STRCOMP strCompCsUs
+#define GSEQ_STRRANGE strRangeCsUs
+#define GSEQ_O GSEQ_US
+#define GSEQ_S GSEQ_CS
 #include "GSeq.h"
 
-#define	GSEQ_STRCOMP	strCompCsCs
-#define	GSEQ_STRRANGE	strRangeCsCs
-#define	GSEQ_O	GSEQ_CS
-#define	GSEQ_S	GSEQ_CS
+#define GSEQ_STRCOMP strCompCsCs
+#define GSEQ_STRRANGE strRangeCsCs
+#define GSEQ_O GSEQ_CS
+#define GSEQ_S GSEQ_CS
 #include "GSeq.h"
 
-#define	GSEQ_STRRANGE	strRangeNsNs
-#define	GSEQ_O	GSEQ_NS
-#define	GSEQ_S	GSEQ_NS
+#define GSEQ_STRRANGE strRangeNsNs
+#define GSEQ_O GSEQ_NS
+#define GSEQ_S GSEQ_NS
 #include "GSeq.h"
 
 static Class NSDataClass = 0;
@@ -648,14 +574,14 @@ static Class GSImmutableStringClass = 0;
 static Class GSMutableStringClass = 0;
 static Class NSConstantStringClass = 0;
 
-static SEL	cMemberSel;
-static SEL	convertSel;
-static BOOL	(*convertImp)(id, SEL, NSStringEncoding);
-static SEL	equalSel;
-static BOOL	(*equalImp)(id, SEL, id);
-static SEL	hashSel;
+static SEL cMemberSel;
+static SEL convertSel;
+static BOOL (*convertImp)(id, SEL, NSStringEncoding);
+static SEL equalSel;
+static BOOL (*equalImp)(id, SEL, id);
+static SEL hashSel;
 static NSUInteger (*hashImp)(id, SEL);
-static Ivar	immutableIvar;
+static Ivar immutableIvar;
 
 /*
  * The setup() function is called when any concrete string class is
@@ -664,102 +590,97 @@ static Ivar	immutableIvar;
 static void
 setup(BOOL rerun)
 {
-  static BOOL	beenHere = NO;
+    static BOOL beenHere = NO;
 
-  if (!beenHere || rerun)
-    {
-      beenHere = YES;
+    if (!beenHere || rerun) {
+        beenHere = YES;
 
-      caiSel = @selector(characterAtIndex:);
-      gcrSel = @selector(getCharacters:range:);
-      ranSel = @selector(rangeOfComposedCharacterSequenceAtIndex:);
+        caiSel = @selector(characterAtIndex:);
+        gcrSel = @selector(getCharacters:range:);
+        ranSel = @selector(rangeOfComposedCharacterSequenceAtIndex:);
 
-      /*
-       * Cache the default string encoding, and set the internal encoding
-       * used by 8-bit character strings to match if possible.
-       */
-      externalEncoding = GSPrivateDefaultCStringEncoding();
-      if (isByteEncoding(externalEncoding) == YES)
-	{
-	  internalEncoding = externalEncoding;
-	}
+        /*
+         * Cache the default string encoding, and set the internal encoding
+         * used by 8-bit character strings to match if possible.
+         */
+        externalEncoding = GSPrivateDefaultCStringEncoding();
+        if (isByteEncoding(externalEncoding) == YES) {
+            internalEncoding = externalEncoding;
+        }
 
-      /*
-       * Cache pointers to classes to work round misfeature in
-       * GNU compiler/runtime system where class lookup is very slow.
-       */
-      NSDataClass = [NSData class];
-      NSStringClass = [NSString class];
-      GSStringClass = [GSString class];
-      GSCStringClass = [GSCString class];
-      GSUnicodeStringClass = [GSUnicodeString class];
-      GSCBufferStringClass = [GSCBufferString class];
-      GSUnicodeBufferStringClass = [GSUnicodeBufferString class];
-      GSCInlineStringClass = [GSCInlineString class];
-      GSUInlineStringClass = [GSUInlineString class];
-      GSCSubStringClass = [GSCSubString class];
-      GSUnicodeSubStringClass = [GSUnicodeSubString class];
-      GSMutableStringClass = [GSMutableString class];
-      NSConstantStringClass = [NXConstantString class];
+        /*
+         * Cache pointers to classes to work round misfeature in
+         * GNU compiler/runtime system where class lookup is very slow.
+         */
+        NSDataClass = [NSData class];
+        NSStringClass = [NSString class];
+        GSStringClass = [GSString class];
+        GSCStringClass = [GSCString class];
+        GSUnicodeStringClass = [GSUnicodeString class];
+        GSCBufferStringClass = [GSCBufferString class];
+        GSUnicodeBufferStringClass = [GSUnicodeBufferString class];
+        GSCInlineStringClass = [GSCInlineString class];
+        GSUInlineStringClass = [GSUInlineString class];
+        GSCSubStringClass = [GSCSubString class];
+        GSUnicodeSubStringClass = [GSUnicodeSubString class];
+        GSMutableStringClass = [GSMutableString class];
+        NSConstantStringClass = [NXConstantString class];
 
-      /* This comes from the base additions library.  The instance variable
-       * pointing to the original mutable string is not public, but we want
-       * to use it efficiently.
-       */
-      GSImmutableStringClass = NSClassFromString(@"GSImmutableString");
-      immutableIvar
-	= class_getInstanceVariable(GSImmutableStringClass, "_parent");
+        /* This comes from the base additions library.  The instance variable
+         * pointing to the original mutable string is not public, but we want
+         * to use it efficiently.
+         */
+        GSImmutableStringClass = NSClassFromString(@"GSImmutableString");
+        immutableIvar = class_getInstanceVariable(GSImmutableStringClass, "_parent");
 
-      /*
-       * Cache some selectors and method implementations for
-       * cases where we want to use the implementation
-       * provided in the abstract rolot cllass of the cluster.
-       */
-      cMemberSel = @selector(characterIsMember:);
-      convertSel = @selector(canBeConvertedToEncoding:);
-      convertImp = (BOOL (*)(id, SEL, NSStringEncoding))
-	[NSStringClass instanceMethodForSelector: convertSel];
-      equalSel = @selector(isEqualToString:);
-      equalImp = (BOOL (*)(id, SEL, id))
-	[NSStringClass instanceMethodForSelector: equalSel];
-      hashSel = @selector(hash);
-      hashImp = (NSUInteger (*)(id, SEL))
-	[GSStringClass instanceMethodForSelector: hashSel];
+        /*
+         * Cache some selectors and method implementations for
+         * cases where we want to use the implementation
+         * provided in the abstract rolot cllass of the cluster.
+         */
+        cMemberSel = @selector(characterIsMember:);
+        convertSel = @selector(canBeConvertedToEncoding:);
+        convertImp = (BOOL(*)(id, SEL, NSStringEncoding))
+            [NSStringClass instanceMethodForSelector:convertSel];
+        equalSel = @selector(isEqualToString:);
+        equalImp = (BOOL(*)(id, SEL, id))
+            [NSStringClass instanceMethodForSelector:equalSel];
+        hashSel = @selector(hash);
+        hashImp = (NSUInteger(*)(id, SEL))
+            [GSStringClass instanceMethodForSelector:hashSel];
 
-      caiSel = @selector(characterAtIndex:);
-      gcrSel = @selector(getCharacters:range:);
-      ranSel = @selector(rangeOfComposedCharacterSequenceAtIndex:);
+        caiSel = @selector(characterAtIndex:);
+        gcrSel = @selector(getCharacters:range:);
+        ranSel = @selector(rangeOfComposedCharacterSequenceAtIndex:);
     }
 }
 
-static GSCInlineString*
+static GSCInlineString *
 newCInline(unsigned length, NSZone *zone)
 {
-  GSCInlineString *me;
+    GSCInlineString *me;
 
-  me = (GSCInlineString*)
-    NSAllocateObject(GSCInlineStringClass, length, zone);
-  me->_contents.c = (unsigned char*)
-    (((void*)me)+class_getInstanceSize(GSCInlineStringClass));
-  me->_count = length;
-  me->_flags.wide = 0;
-  me->_flags.owned = 1;	// Ignored on dealloc, but means we own buffer
-  return me;
+    me = (GSCInlineString *)
+        NSAllocateObject(GSCInlineStringClass, length, zone);
+    me->_contents.c = (unsigned char *)(((void *)me) + class_getInstanceSize(GSCInlineStringClass));
+    me->_count = length;
+    me->_flags.wide = 0;
+    me->_flags.owned = 1; // Ignored on dealloc, but means we own buffer
+    return me;
 }
 
-static GSUInlineString*
+static GSUInlineString *
 newUInline(unsigned length, NSZone *zone)
 {
-  GSUInlineString *me;
+    GSUInlineString *me;
 
-  me = (GSUInlineString*)
-    NSAllocateObject(GSUInlineStringClass, length*sizeof(unichar), zone);
-  me->_contents.u = (unichar*)
-    (((void*)me)+class_getInstanceSize(GSUInlineStringClass));
-  me->_count = length;
-  me->_flags.wide = 1;
-  me->_flags.owned = 1;	// Ignored on dealloc, but means we own buffer
-  return me;
+    me = (GSUInlineString *)
+        NSAllocateObject(GSUInlineStringClass, length * sizeof(unichar), zone);
+    me->_contents.u = (unichar *)(((void *)me) + class_getInstanceSize(GSUInlineStringClass));
+    me->_count = length;
+    me->_flags.wide = 1;
+    me->_flags.owned = 1; // Ignored on dealloc, but means we own buffer
+    return me;
 }
 
 @implementation NSString (RegressionTesting)
@@ -768,17 +689,16 @@ newUInline(unsigned length, NSZone *zone)
  * so that all the comparison operations between 8bit and 16bit strings
  * can be tested.
  */
-- (NSString*) _unicodeString
+- (NSString *)_unicodeString
 {
-  GSUInlineString       *o;
-  unsigned              i = [self length];
+    GSUInlineString *o;
+    unsigned i = [self length];
 
-  o = [newUInline(i, [self zone]) autorelease];
-  while (i-- > 0)
-    {
-      o->_contents.u[i] = [self characterAtIndex: i];
+    o = [newUInline(i, [self zone]) autorelease];
+    while (i-- > 0) {
+        o->_contents.u[i] = [self characterAtIndex:i];
     }
-  return o;
+    return o;
 }
 @end
 
@@ -786,7 +706,7 @@ newUInline(unsigned length, NSZone *zone)
  */
 static void GSStrWiden(GSStr s);
 static void getCString_u(GSStr self, char *buffer, unsigned int maxLength,
-  NSRange aRange, NSRange *leftoverRange);
+                         NSRange aRange, NSRange *leftoverRange);
 
 #if defined(OBJC_SMALL_OBJECT_SHIFT) && (OBJC_SMALL_OBJECT_SHIFT == 3)
 #define TINY_STRING_MASK 4
@@ -810,43 +730,36 @@ static BOOL useTinyStrings;
     uintptr_t tag    :3;
   };
  */
-#define TINY_STRING_CHAR(s, x) ((s & (0xFE00000000000000 >> (x*7))) >> (57-(x*7)))
+#define TINY_STRING_CHAR(s, x) ((s & (0xFE00000000000000 >> (x * 7))) >> (57 - (x * 7)))
 #define TINY_STRING_LENGTH_MASK 0x1f
 #define TINY_STRING_LENGTH_SHIFT OBJC_SMALL_OBJECT_SHIFT
 
 static BOOL
 tinyEqualToString(uintptr_t s, NSString *aString)
 {
-  NSUInteger    l;
+    NSUInteger l;
 
-  if ((NSString*)s == aString)
-    {
-      return YES;
+    if ((NSString *)s == aString) {
+        return YES;
     }
-  if (nil == aString)
-    {
-      return NO;
+    if (nil == aString) {
+        return NO;
     }
-  
-  l = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
-  if ([aString length] != l)
-    {
-      return NO;
-    }
-  else if (l > 0)
-    {
-      unichar   buf[8];
 
-      [aString getCharacters: buf range: NSMakeRange(0, l)];
-      while (l-- > 0)
-        {
-          if ((unichar)TINY_STRING_CHAR(s, l) != buf[l])
-            {
-              return NO;
+    l = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    if ([aString length] != l) {
+        return NO;
+    } else if (l > 0) {
+        unichar buf[8];
+
+        [aString getCharacters:buf range:NSMakeRange(0, l)];
+        while (l-- > 0) {
+            if ((unichar)TINY_STRING_CHAR(s, l) != buf[l]) {
+                return NO;
             }
         }
     }
-  return YES;
+    return YES;
 }
 
 @interface GSTinyString : NSString
@@ -856,325 +769,300 @@ tinyEqualToString(uintptr_t s, NSString *aString)
 static int tinyStrings = 0;
 static void logTinyStringCount(void)
 {
-  fprintf(stderr, "%d tiny strings created\n", tinyStrings);
+    fprintf(stderr, "%d tiny strings created\n", tinyStrings);
 }
 #endif
 
 static int
 tsbytes(uintptr_t s, char *buf)
 {
-  int   length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
-  int   index;
- 
-  for (index = 0; index < length; index++)
-    {
-      buf[index] = (char)TINY_STRING_CHAR(s, index);
+    int length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    int index;
+
+    for (index = 0; index < length; index++) {
+        buf[index] = (char)TINY_STRING_CHAR(s, index);
     }
-  buf[index] = 0;
-  return index;
+    buf[index] = 0;
+    return index;
 }
 
 @implementation GSTinyString
 
-- (BOOL) boolValue
+- (BOOL)boolValue
 {
-  char  buf[9];
-  int   count =  tsbytes((uintptr_t)self, buf);
-  int   i;
+    char buf[9];
+    int count = tsbytes((uintptr_t)self, buf);
+    int i;
 
-  for (i = 0; i < count; i++)
-    {
-      char	c = buf[i];
+    for (i = 0; i < count; i++) {
+        char c = buf[i];
 
-      if (strchr("123456789yYtT", c) != 0)
-        {
-          return YES;
+        if (strchr("123456789yYtT", c) != 0) {
+            return YES;
         }
-      if (!isspace(c) && c != '0' && c != '-' && c != '+')
-	{
-	  break;
-	}
-    }
-  return NO;
-}
-
-- (unichar) characterAtIndex: (NSUInteger)anIndex
-{
-  uintptr_t s = (uintptr_t)self;
-  NSUInteger length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
-
-  if (anIndex >= length)
-    {
-      [NSException raise: NSInvalidArgumentException
-                  format: @"-characterAtIndex: index out of range"];
-    }
-  // Implicit NULL terminator on slightly-too-long strings.
-  if (anIndex == 8)
-    {
-      return '\0';
-    }
-  return TINY_STRING_CHAR(s, anIndex);
-}
-
-- (void) getCharacters: (unichar*)buffer
-{
-  uintptr_t s = (uintptr_t)self;
-  int   length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
-  int   index;
- 
-  for (index = 0; index < length; index++)
-    {
-      buffer[index] = (unichar)TINY_STRING_CHAR(s, index);
-    }
-}
-
-- (void) getCharacters: (unichar*)buffer range: (NSRange)aRange
-{
-  uintptr_t s = (uintptr_t)self;
-  int   length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
-  int   index;
-  int   offset;
-
-  GS_RANGE_CHECK(aRange, length);
-  length = NSMaxRange(aRange);
-  offset = 0;
-  for (index = aRange.location; index < length; index++)
-    {
-      buffer[offset++] = (unichar)TINY_STRING_CHAR(s, index);
-    }
-}
-
-- (BOOL) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	   encoding: (NSStringEncoding)encoding
-{
-  uintptr_t s = (uintptr_t)self;
-  int   length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
-  int   index;
-
-  if (buffer == 0)
-    {
-      return NO;	// Can't fit in here
-    }
-  if (NSUnicodeStringEncoding == encoding)
-    {
-      maxLength /= 2;
-      if (maxLength > 1)
-	{
-          unichar       *buf = (unichar*)(void*)buffer;
-	  BOOL		result = (length < maxLength) ? YES : NO;
-
-          if (maxLength <= length)
-            {
-              length = maxLength - 1;
-            }
-          for (index = 0; index < length; index++)
-            {
-              buf[index] = (unichar)TINY_STRING_CHAR(s, index);
-            }
-          buf[index] = 0;
-          return result;
-	}
-      return NO;
-    }
-  else if (isByteEncoding(encoding))
-    {
-      if (maxLength > 0)
-	{
-	  BOOL	result = (length < maxLength) ? YES : NO;
-
-          if (maxLength <= length)
-            {
-              length = maxLength - 1;
-            }
-          for (index = 0; index < length; index++)
-            {
-              buffer[index] = (char)TINY_STRING_CHAR(s, index);
-            }
-          buffer[index] = 0;
-          return result;
-        }
-      return NO;
-    }
-  return [super getCString: buffer maxLength: maxLength encoding: encoding];
-}
-
-- (NSUInteger) hash
-{
-  uintptr_t s = (uintptr_t)self;
-  int   length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
-  uint32_t	ret = 0;
-
-  if (length > 0)
-    {
-      unichar   buf[10];
-      int	index;
-
-      for (index = 0; index < length; index++)
-        {
-          buf[index] = (char)TINY_STRING_CHAR(s, index);
-        }
-      ret = GSPrivateHash(0, buf, length * sizeof(unichar));
-
-      /*
-       * The hash caching in our concrete string classes uses zero to denote
-       * an empty cache value, so we MUST NOT return a hash of zero.
-       */
-      ret &= 0x0fffffff;
-      if (ret == 0)
-        {
-          ret = 0x0fffffff;
+        if (!isspace(c) && c != '0' && c != '-' && c != '+') {
+            break;
         }
     }
-  else
-    {
-      ret = 0x0ffffffe;	/* Hash for an empty string.	*/
+    return NO;
+}
+
+- (unichar)characterAtIndex:(NSUInteger)anIndex
+{
+    uintptr_t s = (uintptr_t)self;
+    NSUInteger length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+
+    if (anIndex >= length) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"-characterAtIndex: index out of range"];
     }
-  return ret;
+    // Implicit NULL terminator on slightly-too-long strings.
+    if (anIndex == 8) {
+        return '\0';
+    }
+    return TINY_STRING_CHAR(s, anIndex);
 }
 
-- (int) intValue
+- (void)getCharacters:(unichar *)buffer
 {
-  char  buf[9];
- 
-  tsbytes((uintptr_t)self, buf);
-  return strtol(buf, 0, 10);
+    uintptr_t s = (uintptr_t)self;
+    int length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    int index;
+
+    for (index = 0; index < length; index++) {
+        buffer[index] = (unichar)TINY_STRING_CHAR(s, index);
+    }
 }
 
-- (NSInteger) integerValue
+- (void)getCharacters:(unichar *)buffer range:(NSRange)aRange
 {
-  char  buf[9];
+    uintptr_t s = (uintptr_t)self;
+    int length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    int index;
+    int offset;
 
-  tsbytes((uintptr_t)self, buf);
+    GS_RANGE_CHECK(aRange, length);
+    length = NSMaxRange(aRange);
+    offset = 0;
+    for (index = aRange.location; index < length; index++) {
+        buffer[offset++] = (unichar)TINY_STRING_CHAR(s, index);
+    }
+}
+
+- (BOOL)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+          encoding:(NSStringEncoding)encoding
+{
+    uintptr_t s = (uintptr_t)self;
+    int length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    int index;
+
+    if (buffer == 0) {
+        return NO; // Can't fit in here
+    }
+    if (NSUnicodeStringEncoding == encoding) {
+        maxLength /= 2;
+        if (maxLength > 1) {
+            unichar *buf = (unichar *)(void *)buffer;
+            BOOL result = (length < maxLength) ? YES : NO;
+
+            if (maxLength <= length) {
+                length = maxLength - 1;
+            }
+            for (index = 0; index < length; index++) {
+                buf[index] = (unichar)TINY_STRING_CHAR(s, index);
+            }
+            buf[index] = 0;
+            return result;
+        }
+        return NO;
+    } else if (isByteEncoding(encoding)) {
+        if (maxLength > 0) {
+            BOOL result = (length < maxLength) ? YES : NO;
+
+            if (maxLength <= length) {
+                length = maxLength - 1;
+            }
+            for (index = 0; index < length; index++) {
+                buffer[index] = (char)TINY_STRING_CHAR(s, index);
+            }
+            buffer[index] = 0;
+            return result;
+        }
+        return NO;
+    }
+    return [super getCString:buffer maxLength:maxLength encoding:encoding];
+}
+
+- (NSUInteger)hash
+{
+    uintptr_t s = (uintptr_t)self;
+    int length = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    uint32_t ret = 0;
+
+    if (length > 0) {
+        unichar buf[10];
+        int index;
+
+        for (index = 0; index < length; index++) {
+            buf[index] = (char)TINY_STRING_CHAR(s, index);
+        }
+        ret = GSPrivateHash(0, buf, length * sizeof(unichar));
+
+        /*
+         * The hash caching in our concrete string classes uses zero to denote
+         * an empty cache value, so we MUST NOT return a hash of zero.
+         */
+        ret &= 0x0fffffff;
+        if (ret == 0) {
+            ret = 0x0fffffff;
+        }
+    } else {
+        ret = 0x0ffffffe; /* Hash for an empty string.	*/
+    }
+    return ret;
+}
+
+- (int)intValue
+{
+    char buf[9];
+
+    tsbytes((uintptr_t)self, buf);
+    return strtol(buf, 0, 10);
+}
+
+- (NSInteger)integerValue
+{
+    char buf[9];
+
+    tsbytes((uintptr_t)self, buf);
 #if GS_SIZEOF_VOIDP == GS_SIZEOF_LONG
-  return strtol(buf, 0, 10);
+    return strtol(buf, 0, 10);
 #else
-  return strtoll(buf, 0, 10);
+    return strtoll(buf, 0, 10);
 #endif
 }
 
-- (BOOL) isEqualToString: (NSString*)aString
+- (BOOL)isEqualToString:(NSString *)aString
 {
-  return tinyEqualToString((uintptr_t)self, aString);
+    return tinyEqualToString((uintptr_t)self, aString);
 }
 
-- (NSUInteger) length
+- (NSUInteger)length
 {
-  uintptr_t s = (uintptr_t)self;
-  return (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    uintptr_t s = (uintptr_t)self;
+    return (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
 }
 
-- (long long) longLongValue
+- (long long)longLongValue
 {
-  char  buf[9];
+    char buf[9];
 
-  tsbytes((uintptr_t)self, buf);
-  return strtoll(buf, 0, 10);
+    tsbytes((uintptr_t)self, buf);
+    return strtoll(buf, 0, 10);
 }
 
-- (id) mutableCopyWithZone: (NSZone*)z
+- (id)mutableCopyWithZone:(NSZone *)z
 {
-  uintptr_t             s = (uintptr_t)self;
-  NSUInteger            i;
-  NSUInteger            l;
-  GSMutableString	*obj;
-  char                  bytes[8];
+    uintptr_t s = (uintptr_t)self;
+    NSUInteger i;
+    NSUInteger l;
+    GSMutableString *obj;
+    char bytes[8];
 
-  l = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
-  for (i = 0; i < l; i++)
-    {
-      bytes[i] = (unichar)TINY_STRING_CHAR(s, i);
+    l = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    for (i = 0; i < l; i++) {
+        bytes[i] = (unichar)TINY_STRING_CHAR(s, i);
     }
-  obj = (GSMutableString*)NSAllocateObject(GSMutableStringClass, 0, z);
-  obj = [obj initWithBytes: bytes
-		    length: l
-		  encoding: internalEncoding];
-  return obj;
+    obj = (GSMutableString *)NSAllocateObject(GSMutableStringClass, 0, z);
+    obj = [obj initWithBytes:bytes
+                      length:l
+                    encoding:internalEncoding];
+    return obj;
 }
 
-- (NSRange) rangeOfComposedCharacterSequenceAtIndex: (NSUInteger)anIndex
+- (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
 {
-  uintptr_t s = (uintptr_t)self;
-  NSUInteger    l = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
+    uintptr_t s = (uintptr_t)self;
+    NSUInteger l = (s >> TINY_STRING_LENGTH_SHIFT) & TINY_STRING_LENGTH_MASK;
 
-  if (anIndex >= l)
-    [NSException raise: NSRangeException format:@"Invalid location."];
-  return NSMakeRange(anIndex, 1);
+    if (anIndex >= l)
+        [NSException raise:NSRangeException format:@"Invalid location."];
+    return NSMakeRange(anIndex, 1);
 }
 
-- (NSUInteger) sizeOfContentExcluding: (NSHashTable*)exclude
+- (NSUInteger)sizeOfContentExcluding:(NSHashTable *)exclude
 {
-  return 0;	// Tiny string uses no heap
+    return 0; // Tiny string uses no heap
 }
 
-- (NSUInteger) sizeOfInstance
+- (NSUInteger)sizeOfInstance
 {
-  return 0;	// Tiny string uses no heap
+    return 0; // Tiny string uses no heap
 }
 
-- (const char*) UTF8String
+- (const char *)UTF8String
 {
-  char  *buf = GSAutoreleasedBuffer(9);
+    char *buf = GSAutoreleasedBuffer(9);
 
-  tsbytes((uintptr_t)self, buf);
-  return buf;
+    tsbytes((uintptr_t)self, buf);
+    return buf;
 }
 
-+ (void) load
++ (void)load
 {
-  useTinyStrings = objc_registerSmallObjectClass_np(self, TINY_STRING_MASK);
+    useTinyStrings = objc_registerSmallObjectClass_np(self, TINY_STRING_MASK);
 #ifdef GS_PROFILE_TINY_STRINGS
-  atexit(logTinyStringCount);
+    atexit(logTinyStringCount);
 #endif
 }
 
-+ (id) alloc
++ (id)alloc
 {
-  return (id)TINY_STRING_MASK;
+    return (id)TINY_STRING_MASK;
 }
 
-+ (id) allocWithZone: (NSZone*)aZone
++ (id)allocWithZone:(NSZone *)aZone
 {
-  return (id)TINY_STRING_MASK;
+    return (id)TINY_STRING_MASK;
 }
 
-- (id) copy
+- (id)copy
 {
-  return self;
+    return self;
 }
 
-- (id) copyWithZone: (NSZone*)aZone
+- (id)copyWithZone:(NSZone *)aZone
 {
-  return self;
+    return self;
 }
 
-- (id) retain
+- (id)retain
 {
-  return self;
+    return self;
 }
 
-- (NSUInteger) retainCount
+- (NSUInteger)retainCount
 {
-  return UINT_MAX;
+    return UINT_MAX;
 }
 
-- (id) autorelease
+- (id)autorelease
 {
-  return self;
+    return self;
 }
 
-- (oneway void) release
+- (oneway void)release
 {
-  return;
+    return;
 }
 
-- (NSUInteger) sizeInBytesExcluding: (NSHashTable*)exclude
+- (NSUInteger)sizeInBytesExcluding:(NSHashTable *)exclude
 {
-  if (0 == NSHashGet(exclude, self))
-    {
-      return 0;
+    if (0 == NSHashGet(exclude, self)) {
+        return 0;
     }
-  return 8;
+    return 8;
 }
 
 @end
@@ -1185,47 +1073,45 @@ tsbytes(uintptr_t s, char *buf)
 static inline id
 createTinyString(const char *str, int length)
 {
-  unsigned int i;
-  uintptr_t s = TINY_STRING_MASK;
+    unsigned int i;
+    uintptr_t s = TINY_STRING_MASK;
 
-  /* No tiny string support detected at run time, give up
-   */
-  if (!useTinyStrings)
-    {
-      return nil;
+    /* No tiny string support detected at run time, give up
+     */
+    if (!useTinyStrings) {
+        return nil;
     }
 
-  /* String too long to fit in a pointer, give up
-   */
-  if (length > 9)
-    {
-      return nil;
+    /* String too long to fit in a pointer, give up
+     */
+    if (length > 9) {
+        return nil;
     }
 
-  /* String would fit if the last byte was an implicit 0, but it isn't.
-   */
-  if ((length == 9) && str[8] != '\0')
-    {
-      return nil;
+    /* String would fit if the last byte was an implicit 0, but it isn't.
+     */
+    if ((length == 9) && str[8] != '\0') {
+        return nil;
     }
-  
-  s |= length << TINY_STRING_LENGTH_SHIFT;
-  for (i = 0 ; i<length ; i++)
-    {
-      // If this is not a 7-bit character, we can't use it.
-      if (str[i] & 0x80) { return nil; }
-      s |= ((uintptr_t)str[i]) << (57 - (i*7));
+
+    s |= length << TINY_STRING_LENGTH_SHIFT;
+    for (i = 0; i < length; i++) {
+        // If this is not a 7-bit character, we can't use it.
+        if (str[i] & 0x80) {
+            return nil;
+        }
+        s |= ((uintptr_t)str[i]) << (57 - (i * 7));
     }
 #ifdef GS_PROFILE_TINY_STRINGS
-  __sync_fetch_and_add(&tinyStrings, 1);
+    __sync_fetch_and_add(&tinyStrings, 1);
 #endif
-  return (id)s;
+    return (id)s;
 }
 #else
 static inline id
 createTinyString(const char *str, int length)
 {
-  return nil;
+    return nil;
 }
 #endif
 /*
@@ -1236,197 +1122,162 @@ createTinyString(const char *str, int length)
  * on the initialisation method used.
  */
 @implementation GSPlaceholderString
-+ (id) allocWithZone: (NSZone*)z
++ (id)allocWithZone:(NSZone *)z
 {
-  GSPlaceholderString   *o = NSAllocateObject(self, 0, z);
-  o->myZone = z;
-  return o;
+    GSPlaceholderString *o = NSAllocateObject(self, 0, z);
+    o->myZone = z;
+    return o;
 }
 
-+ (void) initialize
++ (void)initialize
 {
-  setup(NO);
+    setup(NO);
 }
 
-- (id) autorelease
+- (id)autorelease
 {
-  NSWarnLog(@"-autorelease sent to uninitialised string");
-  return self;		// placeholders never get released.
+    NSWarnLog(@"-autorelease sent to uninitialised string");
+    return self; // placeholders never get released.
 }
 
-- (unichar) characterAtIndex: (NSUInteger)index
+- (unichar)characterAtIndex:(NSUInteger)index
 {
-  [NSException raise: NSInternalInconsistencyException
-	      format: @"attempt to use uninitialised string"];
-  return 0;
+    [NSException raise:NSInternalInconsistencyException
+                format:@"attempt to use uninitialised string"];
+    return 0;
 }
 
-- (void) dealloc
+- (void)dealloc
 {
-  NSLog(@"Warning ... attempt to deallocate instance of %@ in zone %p",
-    NSStringFromClass([self class]), [self zone]);
-  GSNOSUPERDEALLOC;	// Placeholders never get deallocated.
+    NSLog(@"Warning ... attempt to deallocate instance of %@ in zone %p",
+          NSStringFromClass([self class]), [self zone]);
+    GSNOSUPERDEALLOC; // Placeholders never get deallocated.
 }
 
 /*
  * Replace self with an empty inline unicode string.
  */
-- (id) init
+- (id)init
 {
-  return [self initWithBytes: 0 length: 0 encoding: internalEncoding];
+    return [self initWithBytes:0 length:0 encoding:internalEncoding];
 }
 
 /*
  * Remove any BOM and perform byte swapping if required.
  */
 static void
-fixBOM(unsigned char **bytes, NSUInteger*length, BOOL *owned,
-  NSStringEncoding encoding)
+fixBOM(unsigned char **bytes, NSUInteger *length, BOOL *owned,
+       NSStringEncoding encoding)
 {
-  unsigned char	*b = *bytes;
-  unsigned	len = *length;
+    unsigned char *b = *bytes;
+    unsigned len = *length;
 
-  if (encoding == NSUnicodeStringEncoding && *length >= 2
-    && ((b[0] == 0xFE && b[1] == 0xFF) || (b[0] == 0xFF && b[1] == 0xFE)))
-    {
-      // Got a byte order marker ... remove it.
-      if (len == sizeof(unichar))
-	{
-	  if (*owned)
-	    {
-	      NSZoneFree(NSZoneFromPointer(b), b);
-	      *owned = NO;
-	    }
-	  *length = 0;
-	  *bytes = 0;
-	}
-      else
-	{
-	  unsigned char	*from = b;
-	  unsigned char	*to;
-	  unichar	u;
+    if (encoding == NSUnicodeStringEncoding && *length >= 2 && ((b[0] == 0xFE && b[1] == 0xFF) || (b[0] == 0xFF && b[1] == 0xFE))) {
+        // Got a byte order marker ... remove it.
+        if (len == sizeof(unichar)) {
+            if (*owned) {
+                NSZoneFree(NSZoneFromPointer(b), b);
+                *owned = NO;
+            }
+            *length = 0;
+            *bytes = 0;
+        } else {
+            unsigned char *from = b;
+            unsigned char *to;
+            unichar u;
 
-	  // Got a byte order marker ... remove it.
-	  len -= sizeof(unichar);
-	  memcpy(&u, from, sizeof(unichar));
-	  from += sizeof(unichar);
-	  to = NSAllocateCollectable(len, 0);
-	  if (u == 0xFEFF)
-	    {
-	      // Native byte order
-	      memcpy(to, from, len);
-	    }
-	  else
-	    {
-	      unsigned	i;
+            // Got a byte order marker ... remove it.
+            len -= sizeof(unichar);
+            memcpy(&u, from, sizeof(unichar));
+            from += sizeof(unichar);
+            to = NSAllocateCollectable(len, 0);
+            if (u == 0xFEFF) {
+                // Native byte order
+                memcpy(to, from, len);
+            } else {
+                unsigned i;
 
-	      for (i = 0; i < len; i += 2)
-		{
-		  to[i] = from[i+1];
-		  to[i+1] = from[i];
-		}
-	    }
-	  if (*owned == YES)
-	    {
-	      NSZoneFree(NSZoneFromPointer(b), b);
-	    }
-	  else
-	    {
-	      *owned = YES;
-	    }
-	  *length = len;
-	  *bytes = to;
+                for (i = 0; i < len; i += 2) {
+                    to[i] = from[i + 1];
+                    to[i + 1] = from[i];
+                }
+            }
+            if (*owned == YES) {
+                NSZoneFree(NSZoneFromPointer(b), b);
+            } else {
+                *owned = YES;
+            }
+            *length = len;
+            *bytes = to;
         }
-    }
-  else if (encoding == NSUTF8StringEncoding && len >= 3
-    && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF)
-    {
-      if (len == 3)
-	{
-	  if (*owned)
-	    {
-	      NSZoneFree(NSZoneFromPointer(b), b);
-	      *owned = NO;
-	    }
-	  *length = 0;
-	  *bytes = 0;
-	}
-      else
-	{
-	  unsigned char	*from = b;
-	  unsigned char	*to;
+    } else if (encoding == NSUTF8StringEncoding && len >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF) {
+        if (len == 3) {
+            if (*owned) {
+                NSZoneFree(NSZoneFromPointer(b), b);
+                *owned = NO;
+            }
+            *length = 0;
+            *bytes = 0;
+        } else {
+            unsigned char *from = b;
+            unsigned char *to;
 
-	  // Got a byte order marker ... remove it.
-	  len -= 3;
-	  from += 3;
-	  to = NSAllocateCollectable(len, 0);
-	  memcpy(to, from, len);
-	  if (*owned == YES)
-	    {
-	      NSZoneFree(NSZoneFromPointer(b), b);
-	    }
-	  else
-	    {
-	      *owned = YES;
-	    }
-	  *length = len;
-	  *bytes = to;
-	}
+            // Got a byte order marker ... remove it.
+            len -= 3;
+            from += 3;
+            to = NSAllocateCollectable(len, 0);
+            memcpy(to, from, len);
+            if (*owned == YES) {
+                NSZoneFree(NSZoneFromPointer(b), b);
+            } else {
+                *owned = YES;
+            }
+            *length = len;
+            *bytes = to;
+        }
     }
 }
 
-- (id) initWithBytes: (const void*)bytes
-	      length: (NSUInteger)length
-	    encoding: (NSStringEncoding)encoding
+- (id)initWithBytes:(const void *)bytes
+             length:(NSUInteger)length
+           encoding:(NSStringEncoding)encoding
 {
-  const void	*original;
-  void		*chars = 0;
-  BOOL		flag = NO;
-  
-  if (0 == length)
-    {
-      return (id)@"";
+    const void *original;
+    void *chars = 0;
+    BOOL flag = NO;
+
+    if (0 == length) {
+        return (id) @"";
     }
 
-  if (0 == bytes)
-    {
-      [NSException raise: NSInvalidArgumentException
-                  format: @"-initWithBytes:lenth:encoding given nul bytes"];
+    if (0 == bytes) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"-initWithBytes:lenth:encoding given nul bytes"];
     }
 
 #if defined(OBJC_SMALL_OBJECT_SHIFT) && (OBJC_SMALL_OBJECT_SHIFT == 3)
-  if (useTinyStrings)
-    {
-      if (NSASCIIStringEncoding == encoding)
-        {
-          id tinyString = createTinyString(bytes, length);
+    if (useTinyStrings) {
+        if (NSASCIIStringEncoding == encoding) {
+            id tinyString = createTinyString(bytes, length);
 
-          if (tinyString)
-            {
-              return tinyString;
+            if (tinyString) {
+                return tinyString;
             }
         }
-      if (length < 9)
-        {
-          if (NSUTF8StringEncoding == encoding
-            || GSPrivateIsByteEncoding(encoding))
-            {
-              NSUInteger i;
+        if (length < 9) {
+            if (NSUTF8StringEncoding == encoding || GSPrivateIsByteEncoding(encoding)) {
+                NSUInteger i;
 
-              for (i = 0; i < length; i++)
-                {
-                  if (((const char*)bytes)[i] & 0x80)
-                    {
-                      break;
+                for (i = 0; i < length; i++) {
+                    if (((const char *)bytes)[i] & 0x80) {
+                        break;
                     }
                 }
-              if (i == length)
-                {
-                  id tinyString = createTinyString(bytes, length);
+                if (i == length) {
+                    id tinyString = createTinyString(bytes, length);
 
-                  if (tinyString)
-                    {
-                      return tinyString;
+                    if (tinyString) {
+                        return tinyString;
                     }
                 }
             }
@@ -1434,391 +1285,335 @@ fixBOM(unsigned char **bytes, NSUInteger*length, BOOL *owned,
     }
 #endif
 
-  original = bytes;
-  fixBOM((unsigned char**)&bytes, &length, &flag, encoding);
-  /*
-   * We need to copy the data if there is any, unless fixBOM()
-   * has already done it for us.
-   */
-  if (original == bytes)
-    {
-      chars = NSZoneMalloc(myZone, length);
-      memcpy(chars, bytes, length);
-    }
-  else
-    {
-      /*
-       * The fixBOM() function has already copied the data and allocated
-       * new memory, so we can just pass that to the designated initialiser
-       */
-      chars = (void*)bytes;
+    original = bytes;
+    fixBOM((unsigned char **)&bytes, &length, &flag, encoding);
+    /*
+     * We need to copy the data if there is any, unless fixBOM()
+     * has already done it for us.
+     */
+    if (original == bytes) {
+        chars = NSZoneMalloc(myZone, length);
+        memcpy(chars, bytes, length);
+    } else {
+        /*
+         * The fixBOM() function has already copied the data and allocated
+         * new memory, so we can just pass that to the designated initialiser
+         */
+        chars = (void *)bytes;
     }
 
-  return [self initWithBytesNoCopy: chars
-			    length: length
-			  encoding: encoding
-		      freeWhenDone: YES];
+    return [self initWithBytesNoCopy:chars
+                              length:length
+                            encoding:encoding
+                        freeWhenDone:YES];
 }
 
-- (id) initWithBytesNoCopy: (void*)bytes
-		    length: (NSUInteger)length
-		  encoding: (NSStringEncoding)encoding
-	      freeWhenDone: (BOOL)flag
+- (id)initWithBytesNoCopy:(void *)bytes
+                   length:(NSUInteger)length
+                 encoding:(NSStringEncoding)encoding
+             freeWhenDone:(BOOL)flag
 {
-  GSCharPtr	chars = { .u = 0 };
-  BOOL		isASCII = NO;
-  BOOL		isLatin1 = NO;
-  GSStr		me;
+    GSCharPtr chars = {.u = 0};
+    BOOL isASCII = NO;
+    BOOL isLatin1 = NO;
+    GSStr me;
 
-  if (0 == length)
-    {
-      if (YES == flag && 0 != bytes)
-        {
-          NSZoneFree(NSZoneFromPointer(bytes), bytes);
+    if (0 == length) {
+        if (YES == flag && 0 != bytes) {
+            NSZoneFree(NSZoneFromPointer(bytes), bytes);
         }
-      return (id)@"";
+        return (id) @"";
     }
-  if (0 == bytes)
-    {
-      [NSException raise: NSInvalidArgumentException
-                  format: @"-%@ given NULL pointer",
-        NSStringFromSelector(_cmd)];
+    if (0 == bytes) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"-%@ given NULL pointer",
+                           NSStringFromSelector(_cmd)];
     }
-  fixBOM((unsigned char**)&bytes, &length, &flag, encoding);
-  if (encoding == NSUnicodeStringEncoding)
-    {
-      chars.u = bytes;
-    }
-  else
-    {
-      chars.c = bytes;
+    fixBOM((unsigned char **)&bytes, &length, &flag, encoding);
+    if (encoding == NSUnicodeStringEncoding) {
+        chars.u = bytes;
+    } else {
+        chars.c = bytes;
     }
 
-  if (encoding == NSUTF8StringEncoding
-    || (encoding != internalEncoding && isByteEncoding(encoding) == YES))
-    {
-      unsigned i;
+    if (encoding == NSUTF8StringEncoding || (encoding != internalEncoding && isByteEncoding(encoding) == YES)) {
+        unsigned i;
 
-      for (i = 0; i < length; i++)
-        {
-	  if ((chars.c)[i] > 127)
-	    {
-	      if (encoding == NSASCIIStringEncoding)
-		{
-		  if (flag == YES)
-		    {
-		      NSZoneFree(NSZoneFromPointer(chars.c), chars.c);
-		    }
-		  return nil;	// Invalid data
-		}
-	      break;
-	    }
-        }
-      if (i == length)
-	{
-	  /*
-	   * This is actually ASCII data ... so we can just store it as if
-	   * in the internal 8bit encoding scheme.
-	   */
-	  encoding = internalEncoding;
-	}
-    }
-
-  if (encoding == internalEncoding)
-    {
-      me = (GSStr)NSAllocateObject(GSCBufferStringClass, 0, myZone);
-      me->_contents.c = chars.c;
-      me->_count = length;
-      me->_flags.wide = 0;
-      me->_flags.owned = flag;
-      return (id)me;
-    }
-
-  /*
-   * Any remaining encoding needs to be converted to UTF-16.
-   */
-  if (encoding != NSUnicodeStringEncoding)
-    {
-      unichar	*u = 0;
-      unsigned	l = 0;
-
-      if (GSPrivateIsEncodingSupported(encoding) == NO)
-        {
-          if (flag == YES && bytes != 0)
-            {
-              NSZoneFree(NSZoneFromPointer(bytes), bytes);
+        for (i = 0; i < length; i++) {
+            if ((chars.c)[i] > 127) {
+                if (encoding == NSASCIIStringEncoding) {
+                    if (flag == YES) {
+                        NSZoneFree(NSZoneFromPointer(chars.c), chars.c);
+                    }
+                    return nil; // Invalid data
+                }
+                break;
             }
-          return nil;	// Invalid encoding
         }
-
-      if (GSToUnicode(&u, &l, chars.c, length, encoding, myZone, 0) == NO)
-	{
-	  if (flag == YES && chars.c != 0)
-	    {
-	      NSZoneFree(NSZoneFromPointer(chars.c), chars.c);
-	    }
-	  return nil;	// Invalid data
-	}
-      if (flag == YES && chars.c != 0)
-	{
-	  NSZoneFree(NSZoneFromPointer(chars.c), chars.c);
-	}
-      chars.u = u;
-      length = l * sizeof(unichar);
-      flag = YES;
+        if (i == length) {
+            /*
+             * This is actually ASCII data ... so we can just store it as if
+             * in the internal 8bit encoding scheme.
+             */
+            encoding = internalEncoding;
+        }
     }
 
-  length /= sizeof(unichar);
-  if (GSUnicode(chars.u, length, &isASCII, &isLatin1) != length)
-    {
-      if (flag == YES && chars.u != 0)
-        {
-	  NSZoneFree(NSZoneFromPointer(chars.u), chars.u);
-        }
-      return nil;	// Invalid data
+    if (encoding == internalEncoding) {
+        me = (GSStr)NSAllocateObject(GSCBufferStringClass, 0, myZone);
+        me->_contents.c = chars.c;
+        me->_count = length;
+        me->_flags.wide = 0;
+        me->_flags.owned = flag;
+        return (id)me;
     }
 
-  if (isASCII == YES
-    || (internalEncoding == NSISOLatin1StringEncoding && isLatin1 == YES))
-    {
-      me = (GSStr)newCInline(length, myZone);
-      while (length-- > 0)
-        {
-	  me->_contents.c[length] = chars.u[length];
+    /*
+     * Any remaining encoding needs to be converted to UTF-16.
+     */
+    if (encoding != NSUnicodeStringEncoding) {
+        unichar *u = 0;
+        unsigned l = 0;
+
+        if (GSPrivateIsEncodingSupported(encoding) == NO) {
+            if (flag == YES && bytes != 0) {
+                NSZoneFree(NSZoneFromPointer(bytes), bytes);
+            }
+            return nil; // Invalid encoding
         }
-      if (flag == YES && chars.u != 0)
-        {
-	  NSZoneFree(NSZoneFromPointer(chars.u), chars.u);
+
+        if (GSToUnicode(&u, &l, chars.c, length, encoding, myZone, 0) == NO) {
+            if (flag == YES && chars.c != 0) {
+                NSZoneFree(NSZoneFromPointer(chars.c), chars.c);
+            }
+            return nil; // Invalid data
         }
+        if (flag == YES && chars.c != 0) {
+            NSZoneFree(NSZoneFromPointer(chars.c), chars.c);
+        }
+        chars.u = u;
+        length = l * sizeof(unichar);
+        flag = YES;
     }
-  else
-    {
-      me = (GSStr)NSAllocateObject(GSUnicodeBufferStringClass, 0, myZone);
-      me->_contents.u = chars.u;
-      me->_count = length;
-      me->_flags.wide = 1;
-      me->_flags.owned = flag;
+
+    length /= sizeof(unichar);
+    if (GSUnicode(chars.u, length, &isASCII, &isLatin1) != length) {
+        if (flag == YES && chars.u != 0) {
+            NSZoneFree(NSZoneFromPointer(chars.u), chars.u);
+        }
+        return nil; // Invalid data
     }
-  return (id)me;
+
+    if (isASCII == YES || (internalEncoding == NSISOLatin1StringEncoding && isLatin1 == YES)) {
+        me = (GSStr)newCInline(length, myZone);
+        while (length-- > 0) {
+            me->_contents.c[length] = chars.u[length];
+        }
+        if (flag == YES && chars.u != 0) {
+            NSZoneFree(NSZoneFromPointer(chars.u), chars.u);
+        }
+    } else {
+        me = (GSStr)NSAllocateObject(GSUnicodeBufferStringClass, 0, myZone);
+        me->_contents.u = chars.u;
+        me->_count = length;
+        me->_flags.wide = 1;
+        me->_flags.owned = flag;
+    }
+    return (id)me;
 }
 
-- (id) initWithFormat: (NSString*)format
-               locale: (NSDictionary*)locale
-	    arguments: (va_list)argList
+- (id)initWithFormat:(NSString *)format
+              locale:(NSDictionary *)locale
+           arguments:(va_list)argList
 {
-  GSStr		f;
-  unsigned char	buf[2048];
-  unichar	fbuf[1024];
-  unichar	*fmt = fbuf;
-  size_t	len;
-  GSStr		me;
+    GSStr f;
+    unsigned char buf[2048];
+    unichar fbuf[1024];
+    unichar *fmt = fbuf;
+    size_t len;
+    GSStr me;
 
-  if (NULL == format)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[GSPlaceholderString-initWithFormat:locale:arguments:]: NULL format"];
+    if (NULL == format)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[GSPlaceholderString-initWithFormat:locale:arguments:]: NULL format"];
 
-  if ([format isKindOfClass:[GSLocalizedString class]])
-    {
-      // Get the appropriate format according to the pluralization rules.
-      format = [(GSLocalizedString *) format getPluralizedFormat:argList];
+    if ([format isKindOfClass:[GSLocalizedString class]]) {
+        // Get the appropriate format according to the pluralization rules.
+        format = [(GSLocalizedString *)format getPluralizedFormat:argList];
     }
-  /*
-   * First we provide an array of unichar characters containing the
-   * format string.  For performance reasons we try to use an on-stack
-   * buffer if the format string is small enough ... it almost always
-   * will be.
-   */
-  len = [format length];
-  if (len >= 1024)
-    {
-      fmt = NSZoneMalloc(NSDefaultMallocZone(), (len+1)*sizeof(unichar));
+    /*
+     * First we provide an array of unichar characters containing the
+     * format string.  For performance reasons we try to use an on-stack
+     * buffer if the format string is small enough ... it almost always
+     * will be.
+     */
+    len = [format length];
+    if (len >= 1024) {
+        fmt = NSZoneMalloc(NSDefaultMallocZone(), (len + 1) * sizeof(unichar));
     }
-  [format getCharacters: fmt];
-  fmt[len] = '\0';
+    [format getCharacters:fmt];
+    fmt[len] = '\0';
 
-  /*
-   * Now set up 'f' as a GSMutableString object whose initial buffer is
-   * allocated on the stack.  The GSPrivateFormat function can write into it.
-   */
-  f = (GSStr)alloca(class_getInstanceSize(GSMutableStringClass));
-  object_setClass(f, GSMutableStringClass);
-  f->_zone = NSDefaultMallocZone();
-  f->_contents.c = buf;
-  f->_capacity = sizeof(buf);
-  f->_count = 0;
-  f->_flags.wide = 0;
-  f->_flags.owned = 0;
-  GSPrivateFormat(f, fmt, argList, locale);
-  if (fmt != fbuf)
-    {
-      NSZoneFree(NSDefaultMallocZone(), fmt);
+    /*
+     * Now set up 'f' as a GSMutableString object whose initial buffer is
+     * allocated on the stack.  The GSPrivateFormat function can write into it.
+     */
+    f = (GSStr)alloca(class_getInstanceSize(GSMutableStringClass));
+    object_setClass(f, GSMutableStringClass);
+    f->_zone = NSDefaultMallocZone();
+    f->_contents.c = buf;
+    f->_capacity = sizeof(buf);
+    f->_count = 0;
+    f->_flags.wide = 0;
+    f->_flags.owned = 0;
+    GSPrivateFormat(f, fmt, argList, locale);
+    if (fmt != fbuf) {
+        NSZoneFree(NSDefaultMallocZone(), fmt);
     }
 
-  /*
-   * Don't use noCopy because f->_contents.u may be memory on the stack,
-   * and even if it wasn't f->_capacity may be greater than f->_count so
-   * we could be wasting quite a bit of space.  Better to accept a
-   * performance hit due to copying data (and allocating/deallocating
-   * the temporary buffer) for large strings.  For most strings, the
-   * on-stack memory will have been used, so we will get better performance.
-   */
-  if (f->_flags.wide == 1)
-    {
-      me = (GSStr)newUInline(f->_count, myZone);
-      memcpy(me->_contents.u, f->_contents.u, f->_count*sizeof(unichar));
-    }
-  else
-    {
-      me = (GSStr)newCInline(f->_count, myZone);
-      memcpy(me->_contents.c, f->_contents.c, f->_count);
+    /*
+     * Don't use noCopy because f->_contents.u may be memory on the stack,
+     * and even if it wasn't f->_capacity may be greater than f->_count so
+     * we could be wasting quite a bit of space.  Better to accept a
+     * performance hit due to copying data (and allocating/deallocating
+     * the temporary buffer) for large strings.  For most strings, the
+     * on-stack memory will have been used, so we will get better performance.
+     */
+    if (f->_flags.wide == 1) {
+        me = (GSStr)newUInline(f->_count, myZone);
+        memcpy(me->_contents.u, f->_contents.u, f->_count * sizeof(unichar));
+    } else {
+        me = (GSStr)newCInline(f->_count, myZone);
+        memcpy(me->_contents.c, f->_contents.c, f->_count);
     }
 
-  /*
-   * If the string had to grow beyond the initial buffer size, we must
-   * release any allocated memory.
-   */
-  if (1 == f->_flags.owned)
-    {
-      NSZoneFree(f->_zone, f->_contents.c);
+    /*
+     * If the string had to grow beyond the initial buffer size, we must
+     * release any allocated memory.
+     */
+    if (1 == f->_flags.owned) {
+        NSZoneFree(f->_zone, f->_contents.c);
     }
-  return (id)me;
+    return (id)me;
 }
 
 /*
  * Replace self with an inline string matching the sort of information
  * given.
  */
-- (id) initWithString: (NSString*)string
+- (id)initWithString:(NSString *)string
 {
-  unsigned	length;
-  Class		c;
-  GSStr		me;
+    unsigned length;
+    Class c;
+    GSStr me;
 
-  if (string == nil)
-    [NSException raise: NSInvalidArgumentException
-		format: @"GSPlaceholderString-initWithString: given nil string"];
-  if (NO == [string isKindOfClass: NSStringClass])	// may be proxy
-    [NSException raise: NSInvalidArgumentException
-		format: @"-initWithString: given non-string object"];
+    if (string == nil)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"GSPlaceholderString-initWithString: given nil string"];
+    if (NO == [string isKindOfClass:NSStringClass]) // may be proxy
+        [NSException raise:NSInvalidArgumentException
+                    format:@"-initWithString: given non-string object"];
 
-  c = object_getClass(string);
-  length = [string length];
-  if (GSObjCIsKindOf(c, GSCStringClass) == YES
-    || (GSObjCIsKindOf(c, GSMutableStringClass) == YES
-      && ((GSStr)string)->_flags.wide == 0))
-    {
-      /*
-       * For a GSCString subclass, or an 8-bit GSMutableString,
-       * we can copy the bytes directly into an inline string.
-       */
-      me = (GSStr)newCInline(length, myZone);
-      memcpy(me->_contents.c, ((GSStr)string)->_contents.c, length);
+    c = object_getClass(string);
+    length = [string length];
+    if (GSObjCIsKindOf(c, GSCStringClass) == YES || (GSObjCIsKindOf(c, GSMutableStringClass) == YES && ((GSStr)string)->_flags.wide == 0)) {
+        /*
+         * For a GSCString subclass, or an 8-bit GSMutableString,
+         * we can copy the bytes directly into an inline string.
+         */
+        me = (GSStr)newCInline(length, myZone);
+        memcpy(me->_contents.c, ((GSStr)string)->_contents.c, length);
+    } else if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES || GSObjCIsKindOf(c, GSMutableStringClass) == YES) {
+        /*
+         * For a GSUnicodeString subclass, or a 16-bit GSMutableString,
+         * we can copy the bytes directly into an inline string.
+         */
+        me = (GSStr)newUInline(length, myZone);
+        memcpy(me->_contents.u, ((GSStr)string)->_contents.u,
+               length * sizeof(unichar));
+    } else {
+        /*
+         * For a string with an unknown class, we can initialise by
+         * having the string copy its content directly into our buffer.
+         */
+        me = (GSStr)newUInline(length, myZone);
+        [string getCharacters:me->_contents.u];
     }
-  else if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES
-    || GSObjCIsKindOf(c, GSMutableStringClass) == YES)
-    {
-      /*
-       * For a GSUnicodeString subclass, or a 16-bit GSMutableString,
-       * we can copy the bytes directly into an inline string.
-       */
-      me = (GSStr)newUInline(length, myZone);
-      memcpy(me->_contents.u, ((GSStr)string)->_contents.u,
-	length*sizeof(unichar));
-    }
-  else
-    {
-      /*
-       * For a string with an unknown class, we can initialise by
-       * having the string copy its content directly into our buffer.
-       */
-      me = (GSStr)newUInline(length, myZone);
-      [string getCharacters: me->_contents.u];
-    }
-  return (id)me;
+    return (id)me;
 }
 
-- (id) initWithUTF8String: (const char*)bytes
+- (id)initWithUTF8String:(const char *)bytes
 {
-  const uint8_t *b = (const uint8_t*)bytes;
-  BOOL		ascii = YES;
-  NSUInteger    length;
-  GSStr		me;
-  uint8_t       c;
+    const uint8_t *b = (const uint8_t *)bytes;
+    BOOL ascii = YES;
+    NSUInteger length;
+    GSStr me;
+    uint8_t c;
 
-  if (NULL == bytes)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[GSPlaceholderString-initWithUTF8String:]: NULL cString"];
-  /* Skip leading BOM
-   */
-  if (b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF)
-    {
-      b = &b[3];
+    if (NULL == bytes)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[GSPlaceholderString-initWithUTF8String:]: NULL cString"];
+    /* Skip leading BOM
+     */
+    if (b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF) {
+        b = &b[3];
     }
 
-  length = 0;
-  while ((c = b[length]))
-    {
-      length++;
-      if (c > 127)
-        {
-          ascii = NO;
-          while (b[length])
-            {
-              length++;
+    length = 0;
+    while ((c = b[length])) {
+        length++;
+        if (c > 127) {
+            ascii = NO;
+            while (b[length]) {
+                length++;
             }
-          break;
+            break;
         }
     }
 
-  if (YES == ascii)
-    {
-      id        o = createTinyString((const char*)b, length);
+    if (YES == ascii) {
+        id o = createTinyString((const char *)b, length);
 
-      if (nil == o)
-        {
-          me = (GSStr)newCInline(length, myZone);
-          memcpy(me->_contents.c, b, length);
-          o = (id)me;
+        if (nil == o) {
+            me = (GSStr)newCInline(length, myZone);
+            memcpy(me->_contents.c, b, length);
+            o = (id)me;
         }
-      return o;
+        return o;
+    } else {
+        unichar *u = 0;
+        unsigned l = 0;
+
+        if (GSToUnicode(&u, &l, b, length, NSUTF8StringEncoding, myZone, 0) == NO) {
+            return nil; // Invalid data
+        }
+        me = (GSStr)NSAllocateObject(GSUnicodeBufferStringClass, 0, myZone);
+        me->_contents.u = u;
+        me->_count = l;
+        me->_flags.wide = 1;
+        me->_flags.owned = YES;
     }
-  else
-    {
-      unichar	                *u = 0;
-      unsigned	                l = 0;
-
-      if (GSToUnicode(&u, &l, b, length, NSUTF8StringEncoding, myZone, 0) == NO)
-	{
-	  return nil;	// Invalid data
-	}
-      me = (GSStr)NSAllocateObject(GSUnicodeBufferStringClass, 0, myZone);
-      me->_contents.u = u;
-      me->_count = l;
-      me->_flags.wide = 1;
-      me->_flags.owned = YES;
-    }
-  return (id)me;
+    return (id)me;
 }
 
-- (NSUInteger) length
+- (NSUInteger)length
 {
-  [NSException raise: NSInternalInconsistencyException
-	      format: @"attempt to use uninitialised string"];
-  return 0;
+    [NSException raise:NSInternalInconsistencyException
+                format:@"attempt to use uninitialised string"];
+    return 0;
 }
 
-- (oneway void) release
+- (oneway void)release
 {
-  return;		// placeholders never get released.
+    return; // placeholders never get released.
 }
 
-- (id) retain
+- (id)retain
 {
-  return self;		// placeholders never get retained.
+    return self; // placeholders never get retained.
 }
 @end
 
-
 
 /*
  * The following inline functions are used by the concrete string classes
@@ -1835,604 +1630,504 @@ fixBOM(unsigned char **bytes, NSUInteger*length, BOOL *owned,
  * peculiar to its memory management (shrinking, growing, and converting).
  */
 
-static inline const char*
+static inline const char *
 UTF8String_c(GSStr self)
 {
-  unsigned char *r;
+    unsigned char *r;
 
-  if (self->_count == 0)
-    {
-      return "";
+    if (self->_count == 0) {
+        return "";
     }
-  if (internalEncoding == NSASCIIStringEncoding)
-    {
-      unsigned	i = self->_count;
+    if (internalEncoding == NSASCIIStringEncoding) {
+        unsigned i = self->_count;
 
-      r = (unsigned char*)GSAutoreleasedBuffer(self->_count+1);
-      while (i-- > 0)
-	{
-	  r[i] = self->_contents.c[i] & 0x7f;
-	}
-      r[self->_count] = '\0';
-    }
-  else
-    {
-      unichar	*u = 0;
-      unsigned	l = 0;
-      unsigned	s = 0;
+        r = (unsigned char *)GSAutoreleasedBuffer(self->_count + 1);
+        while (i-- > 0) {
+            r[i] = self->_contents.c[i] & 0x7f;
+        }
+        r[self->_count] = '\0';
+    } else {
+        unichar *u = 0;
+        unsigned l = 0;
+        unsigned s = 0;
 
-      /*
-       * We must convert from internal format to unicode and then to
-       * UTF8 string encoding.
-       */
-      if (GSToUnicode(&u, &l, self->_contents.c, self->_count, internalEncoding,
-	NSDefaultMallocZone(), 0) == NO)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't convert to Unicode string."];
-	}
-      r = 0;
-      if (GSFromUnicode((unsigned char**)&r, &s, u, l, NSUTF8StringEncoding,
-	NSDefaultMallocZone(), GSUniTerminate|GSUniTemporary|GSUniStrict) == NO)
-	{
-	  NSZoneFree(NSDefaultMallocZone(), u);
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't convert from Unicode to UTF8."];
-	}
-      NSZoneFree(NSDefaultMallocZone(), u);
+        /*
+         * We must convert from internal format to unicode and then to
+         * UTF8 string encoding.
+         */
+        if (GSToUnicode(&u, &l, self->_contents.c, self->_count, internalEncoding,
+                        NSDefaultMallocZone(), 0) == NO) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't convert to Unicode string."];
+        }
+        r = 0;
+        if (GSFromUnicode((unsigned char **)&r, &s, u, l, NSUTF8StringEncoding,
+                          NSDefaultMallocZone(), GSUniTerminate | GSUniTemporary | GSUniStrict) == NO) {
+            NSZoneFree(NSDefaultMallocZone(), u);
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't convert from Unicode to UTF8."];
+        }
+        NSZoneFree(NSDefaultMallocZone(), u);
     }
 
-  return (const char*)r;
+    return (const char *)r;
 }
 
-static inline const char*
+static inline const char *
 UTF8String_u(GSStr self)
 {
-  unsigned	c = self->_count;
+    unsigned c = self->_count;
 
-  if (c == 0)
-    {
-      return "";
-    }
-  else
-    {
-      unsigned int	l = 0;
-      unsigned char	*r = 0;
+    if (c == 0) {
+        return "";
+    } else {
+        unsigned int l = 0;
+        unsigned char *r = 0;
 
-      if (GSFromUnicode(&r, &l, self->_contents.u, c, NSUTF8StringEncoding,
-	NSDefaultMallocZone(), GSUniTerminate|GSUniTemporary|GSUniStrict) == NO)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't get UTF8 from Unicode string."];
-	}
-      return (const char*)r;
+        if (GSFromUnicode(&r, &l, self->_contents.u, c, NSUTF8StringEncoding,
+                          NSDefaultMallocZone(), GSUniTerminate | GSUniTemporary | GSUniStrict) == NO) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't get UTF8 from Unicode string."];
+        }
+        return (const char *)r;
     }
 }
 
 static inline BOOL
 boolValue_c(GSStr self)
 {
-  unsigned  count = self->_count;
-  unsigned  i;
+    unsigned count = self->_count;
+    unsigned i;
 
-  for (i = 0; i < count; i++)
-    {
-      char	c = self->_contents.c[i];
+    for (i = 0; i < count; i++) {
+        char c = self->_contents.c[i];
 
-      if (strchr("123456789yYtT", c) != 0)
-        {
-          return YES;
+        if (strchr("123456789yYtT", c) != 0) {
+            return YES;
         }
-      if (!isspace(c) && c != '0' && c != '-' && c != '+')
-	{
-	  break;
-	}
+        if (!isspace(c) && c != '0' && c != '-' && c != '+') {
+            break;
+        }
     }
-  return NO;
+    return NO;
 }
 
 static inline BOOL
 boolValue_u(GSStr self)
 {
-  unsigned  count = self->_count;
-  unsigned  i;
+    unsigned count = self->_count;
+    unsigned i;
 
-  for (i = 0; i < count; i++)
-    {
-      unichar	c = self->_contents.u[i];
+    for (i = 0; i < count; i++) {
+        unichar c = self->_contents.u[i];
 
-      if (c > 'y')
-	{
-	  break;
-	}
-      if (strchr("123456789yYtT", c) != 0)
-        {
-          return YES;
+        if (c > 'y') {
+            break;
         }
-      if (!isspace(c) && c != '0' && c != '-' && c != '+')
-	{
-	  break;
-	}
+        if (strchr("123456789yYtT", c) != 0) {
+            return YES;
+        }
+        if (!isspace(c) && c != '0' && c != '-' && c != '+') {
+            break;
+        }
     }
-  return NO;
+    return NO;
 }
 
 static inline void
 intBuf_c(GSStr self, char *buf)
 {
-  unsigned  c = self->_count;
-  unsigned  i = 0;
-  unsigned  j = 0;
+    unsigned c = self->_count;
+    unsigned i = 0;
+    unsigned j = 0;
 
-  while (i < c && isspace(self->_contents.c[i]))
-    {
-      i++;
+    while (i < c && isspace(self->_contents.c[i])) {
+        i++;
     }
-  if (i < c)
-    {
-      char      sign = self->_contents.c[i];
+    if (i < c) {
+        char sign = self->_contents.c[i];
 
-      if ('+' == sign || '-' == sign)
-        {
-          buf[j++] = sign;
-          i++;
+        if ('+' == sign || '-' == sign) {
+            buf[j++] = sign;
+            i++;
         }
     }
-  while (i < c && j < 20 && isdigit(self->_contents.c[i]))
-    {
-      buf[j++] = self->_contents.c[i++];
+    while (i < c && j < 20 && isdigit(self->_contents.c[i])) {
+        buf[j++] = self->_contents.c[i++];
     }
-  buf[j] = '\0';
+    buf[j] = '\0';
 }
 
 static inline void
 intBuf_u(GSStr self, char *buf)
 {
-  unsigned  c = self->_count;
-  unsigned  i = 0;
-  unsigned  j = 0;
+    unsigned c = self->_count;
+    unsigned i = 0;
+    unsigned j = 0;
 
-  while (i < c && isspace(self->_contents.u[i]))
-    {
-      i++;
+    while (i < c && isspace(self->_contents.u[i])) {
+        i++;
     }
-  if (i < c)
-    {
-      unichar   sign = self->_contents.u[i];
+    if (i < c) {
+        unichar sign = self->_contents.u[i];
 
-      if ('+' == sign || '-' == sign)
-        {
-          buf[j++] = (char)sign;
-          i++;
+        if ('+' == sign || '-' == sign) {
+            buf[j++] = (char)sign;
+            i++;
         }
     }
-  while (i < c && j < 20 && isdigit(self->_contents.u[i]))
-    {
-      buf[j++] = (char)self->_contents.u[i++];
+    while (i < c && j < 20 && isdigit(self->_contents.u[i])) {
+        buf[j++] = (char)self->_contents.u[i++];
     }
-  buf[j] = '\0';
+    buf[j] = '\0';
 }
 
 static inline BOOL
 canBeConvertedToEncoding_c(GSStr self, NSStringEncoding enc)
 {
-  unsigned	c = self->_count;
-  BOOL		result = YES;
+    unsigned c = self->_count;
+    BOOL result = YES;
 
-  /*
-   * If the length is zero, or we are already using the required encoding,
-   * or the required encoding is unicode (can hold any character) then we
-   * can assume that a conversion would succeed.
-   * We also know a conversion must succeed if the internal encoding is
-   * ascii and the required encoding has ascii as a subset.
-   */
-  if (c > 0
-    && enc != internalEncoding
-    && enc != NSUTF8StringEncoding
-    && enc != NSUnicodeStringEncoding
-    && ((internalEncoding != NSASCIIStringEncoding) || !isByteEncoding(enc)))
-    {
-      unsigned	l = 0;
-      unichar	*r = 0;
+    /*
+     * If the length is zero, or we are already using the required encoding,
+     * or the required encoding is unicode (can hold any character) then we
+     * can assume that a conversion would succeed.
+     * We also know a conversion must succeed if the internal encoding is
+     * ascii and the required encoding has ascii as a subset.
+     */
+    if (c > 0 && enc != internalEncoding && enc != NSUTF8StringEncoding && enc != NSUnicodeStringEncoding && ((internalEncoding != NSASCIIStringEncoding) || !isByteEncoding(enc))) {
+        unsigned l = 0;
+        unichar *r = 0;
 
-      /*
-       * To check whether conversion is possible, we first convert to
-       * unicode and then check to see whether it is possible to convert
-       * to the desired encoding.
-       */
-      result = GSToUnicode(&r, &l, self->_contents.c, self->_count,
-	internalEncoding, NSDefaultMallocZone(), GSUniStrict);
-      if (result == YES)
-        {
-	  if (enc == NSISOLatin1StringEncoding)
-	    {
-	      unsigned	i;
+        /*
+         * To check whether conversion is possible, we first convert to
+         * unicode and then check to see whether it is possible to convert
+         * to the desired encoding.
+         */
+        result = GSToUnicode(&r, &l, self->_contents.c, self->_count,
+                             internalEncoding, NSDefaultMallocZone(), GSUniStrict);
+        if (result == YES) {
+            if (enc == NSISOLatin1StringEncoding) {
+                unsigned i;
 
-	      /*
-	       * If all the unicode characters are in the 0 to 255 range
-	       * they are all latin1.
-	       */
-	      for (i = 0; i < l; i++)
-		{
-		  if (r[i] > 255)
-		    {
-		      result = NO;
-		      break;
-		    }
-		}
-	    }
-	  else if (enc == NSASCIIStringEncoding)
-	    {
-	      unsigned	i;
+                /*
+                 * If all the unicode characters are in the 0 to 255 range
+                 * they are all latin1.
+                 */
+                for (i = 0; i < l; i++) {
+                    if (r[i] > 255) {
+                        result = NO;
+                        break;
+                    }
+                }
+            } else if (enc == NSASCIIStringEncoding) {
+                unsigned i;
 
-	      /*
-	       * If all the unicode characters are in the 0 to 127 range
-	       * they are all ascii.
-	       */
-	      for (i = 0; i < l; i++)
-		{
-		  if (r[i] > 127)
-		    {
-		      result = NO;
-		      break;
-		    }
-		}
-	    }
-	  else
-	    {
-	      unsigned	dummy = 0;	// Hold returned length.
+                /*
+                 * If all the unicode characters are in the 0 to 127 range
+                 * they are all ascii.
+                 */
+                for (i = 0; i < l; i++) {
+                    if (r[i] > 127) {
+                        result = NO;
+                        break;
+                    }
+                }
+            } else {
+                unsigned dummy = 0; // Hold returned length.
 
-	      result = GSFromUnicode(0, &dummy, r, l, enc, 0, GSUniStrict);
-	    }
+                result = GSFromUnicode(0, &dummy, r, l, enc, 0, GSUniStrict);
+            }
 
-	  // Temporary unicode string no longer needed.
-          NSZoneFree(NSDefaultMallocZone(), r);
+            // Temporary unicode string no longer needed.
+            NSZoneFree(NSDefaultMallocZone(), r);
         }
     }
-  return result;
+    return result;
 }
 
 static inline BOOL
 canBeConvertedToEncoding_u(GSStr self, NSStringEncoding enc)
 {
-  unsigned	c = self->_count;
-  BOOL		result = YES;
+    unsigned c = self->_count;
+    BOOL result = YES;
 
-  if (c > 0)
-    {
-      if (enc == NSUTF8StringEncoding || enc == NSUnicodeStringEncoding)
-	{
-	  if (GSUnicode(self->_contents.u, c, 0, 0) != c)
-	    {
-	      return NO;
-	    }
-	}
-      else
-	{
-	  if (enc == NSISOLatin1StringEncoding)
-	    {
-	      unsigned	i;
+    if (c > 0) {
+        if (enc == NSUTF8StringEncoding || enc == NSUnicodeStringEncoding) {
+            if (GSUnicode(self->_contents.u, c, 0, 0) != c) {
+                return NO;
+            }
+        } else {
+            if (enc == NSISOLatin1StringEncoding) {
+                unsigned i;
 
-	      /*
-	       * If all the unicode characters are in the 0 to 255 range
-	       * they are all latin1.
-	       */
-	      for (i = 0; i < self->_count; i++)
-		{
-		  if (self->_contents.u[i] > 255)
-		    {
-		      result = NO;
-		      break;
-		    }
-		}
-	    }
-	  else if (enc == NSASCIIStringEncoding)
-	    {
-	      unsigned	i;
+                /*
+                 * If all the unicode characters are in the 0 to 255 range
+                 * they are all latin1.
+                 */
+                for (i = 0; i < self->_count; i++) {
+                    if (self->_contents.u[i] > 255) {
+                        result = NO;
+                        break;
+                    }
+                }
+            } else if (enc == NSASCIIStringEncoding) {
+                unsigned i;
 
-	      /*
-	       * If all the unicode characters are in the 0 to 127 range
-	       * they are all ascii.
-	       */
-	      for (i = 0; i < self->_count; i++)
-		{
-		  if (self->_contents.u[i] > 127)
-		    {
-		      result = NO;
-		      break;
-		    }
-		}
-	    }
-	  else
-	    {
-	      unsigned	dummy = 0;	// Hold returned length.
+                /*
+                 * If all the unicode characters are in the 0 to 127 range
+                 * they are all ascii.
+                 */
+                for (i = 0; i < self->_count; i++) {
+                    if (self->_contents.u[i] > 127) {
+                        result = NO;
+                        break;
+                    }
+                }
+            } else {
+                unsigned dummy = 0; // Hold returned length.
 
-	      result = GSFromUnicode(0, &dummy, self->_contents.u, c, enc,
-		0, GSUniStrict);
-	    }
-	}
+                result = GSFromUnicode(0, &dummy, self->_contents.u, c, enc,
+                                       0, GSUniStrict);
+            }
+        }
     }
-  return result;
+    return result;
 }
 
 static inline unichar
 characterAtIndex_c(GSStr self, unsigned index)
 {
-  unichar	u;
+    unichar u;
 
-  if (index >= self->_count)
-    [NSException raise: NSRangeException format: @"Invalid index."];
-  u = self->_contents.c[index];
-  if (u > 127)
-    {
-      unsigned char	c = (unsigned char)u;
-      unsigned int	s = 1;
-      unichar		*d = &u;
+    if (index >= self->_count)
+        [NSException raise:NSRangeException format:@"Invalid index."];
+    u = self->_contents.c[index];
+    if (u > 127) {
+        unsigned char c = (unsigned char)u;
+        unsigned int s = 1;
+        unichar *d = &u;
 
-      if (GSToUnicode(&d, &s, &c, 1, internalEncoding, 0, 0) == NO)
-        {
-          [NSException raise: NSInternalInconsistencyException
-                      format: @"unable to convert character to unicode"];
+        if (GSToUnicode(&d, &s, &c, 1, internalEncoding, 0, 0) == NO) {
+            [NSException raise:NSInternalInconsistencyException
+                        format:@"unable to convert character to unicode"];
         }
     }
-  return u;
+    return u;
 }
 
 static inline unichar
-characterAtIndex_u(GSStr self,unsigned index)
+characterAtIndex_u(GSStr self, unsigned index)
 {
-  if (index >= self->_count)
-    [NSException raise: NSRangeException format: @"Invalid index."];
-  return self->_contents.u[index];
+    if (index >= self->_count)
+        [NSException raise:NSRangeException format:@"Invalid index."];
+    return self->_contents.u[index];
 }
 
 static inline NSComparisonResult
 compare_c(GSStr self, NSString *aString, unsigned mask, NSRange aRange)
 {
-  Class	c;
+    Class c;
 
-  c = object_getClass(aString);
-  if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES
-    || (c == GSMutableStringClass && ((GSStr)aString)->_flags.wide == 1))
-    return strCompCsUs((id)self, aString, mask, aRange);
-  else if (GSObjCIsKindOf(c, GSCStringClass) == YES
-    || (c == GSMutableStringClass && ((GSStr)aString)->_flags.wide == 0))
-    return strCompCsCs((id)self, aString, mask, aRange);
-  else
-    return strCompCsNs((id)self, aString, mask, aRange);
+    c = object_getClass(aString);
+    if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES || (c == GSMutableStringClass && ((GSStr)aString)->_flags.wide == 1))
+        return strCompCsUs((id)self, aString, mask, aRange);
+    else if (GSObjCIsKindOf(c, GSCStringClass) == YES || (c == GSMutableStringClass && ((GSStr)aString)->_flags.wide == 0))
+        return strCompCsCs((id)self, aString, mask, aRange);
+    else
+        return strCompCsNs((id)self, aString, mask, aRange);
 }
 
 static inline NSComparisonResult
 compare_u(GSStr self, NSString *aString, unsigned mask, NSRange aRange)
 {
-  Class	c;
+    Class c;
 
-  c = object_getClass(aString);
-  if (GSObjCIsKindOf(c, GSUnicodeStringClass)
-    || (c == GSMutableStringClass && ((GSStr)aString)->_flags.wide == 1))
-    return strCompUsUs((id)self, aString, mask, aRange);
-  else if (GSObjCIsKindOf(c, GSCStringClass)
-    || (c == GSMutableStringClass && ((GSStr)aString)->_flags.wide == 0))
-    return strCompUsCs((id)self, aString, mask, aRange);
-  else
-    return strCompUsNs((id)self, aString, mask, aRange);
+    c = object_getClass(aString);
+    if (GSObjCIsKindOf(c, GSUnicodeStringClass) || (c == GSMutableStringClass && ((GSStr)aString)->_flags.wide == 1))
+        return strCompUsUs((id)self, aString, mask, aRange);
+    else if (GSObjCIsKindOf(c, GSCStringClass) || (c == GSMutableStringClass && ((GSStr)aString)->_flags.wide == 0))
+        return strCompUsCs((id)self, aString, mask, aRange);
+    else
+        return strCompUsNs((id)self, aString, mask, aRange);
 }
 
-static inline const char*
+static inline const char *
 cString_c(GSStr self, NSStringEncoding enc)
 {
-  unsigned char *r = 0;
+    unsigned char *r = 0;
 
-  if (self->_count == 0)
-    {
-      return "\0";
-    }
-  else if (enc == internalEncoding)
-    {
-      r = (unsigned char*)GSAutoreleasedBuffer(self->_count+1);
+    if (self->_count == 0) {
+        return "\0";
+    } else if (enc == internalEncoding) {
+        r = (unsigned char *)GSAutoreleasedBuffer(self->_count + 1);
 
-      if (self->_count > 0)
-	{
-	  memcpy(r, self->_contents.c, self->_count);
-	}
-      r[self->_count] = '\0';
-    }
-  else if (enc == NSUnicodeStringEncoding)
-    {
-      unsigned	l = 0;
+        if (self->_count > 0) {
+            memcpy(r, self->_contents.c, self->_count);
+        }
+        r[self->_count] = '\0';
+    } else if (enc == NSUnicodeStringEncoding) {
+        unsigned l = 0;
 
-      /*
-       * The external C string encoding  is unicode ... convert to it.
-       */
-      if (GSToUnicode((unichar**)&r, &l, self->_contents.c, self->_count,
-	internalEncoding, NSDefaultMallocZone(),
-	GSUniTerminate|GSUniTemporary|GSUniStrict) == NO)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't convert to Unicode string."];
-	}
-    }
-  else
-    {
-      unichar	*u = 0;
-      unsigned	l = 0;
-      unsigned	s = 0;
+        /*
+         * The external C string encoding  is unicode ... convert to it.
+         */
+        if (GSToUnicode((unichar **)&r, &l, self->_contents.c, self->_count,
+                        internalEncoding, NSDefaultMallocZone(),
+                        GSUniTerminate | GSUniTemporary | GSUniStrict) == NO) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't convert to Unicode string."];
+        }
+    } else {
+        unichar *u = 0;
+        unsigned l = 0;
+        unsigned s = 0;
 
-      /*
-       * The external C string encoding is not compatible with the internal
-       * 8-bit character strings ... we must convert from internal format to
-       * unicode and then to the external C string encoding.
-       */
-      if (GSToUnicode(&u, &l, self->_contents.c, self->_count, internalEncoding,
-	NSDefaultMallocZone(), 0) == NO)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't convert to Unicode string."];
-	}
-      if (GSFromUnicode((unsigned char**)&r, &s, u, l, enc,
-	NSDefaultMallocZone(), GSUniTerminate|GSUniTemporary|GSUniStrict) == NO)
-	{
-	  NSZoneFree(NSDefaultMallocZone(), u);
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't convert from Unicode string."];
-	}
-      NSZoneFree(NSDefaultMallocZone(), u);
+        /*
+         * The external C string encoding is not compatible with the internal
+         * 8-bit character strings ... we must convert from internal format to
+         * unicode and then to the external C string encoding.
+         */
+        if (GSToUnicode(&u, &l, self->_contents.c, self->_count, internalEncoding,
+                        NSDefaultMallocZone(), 0) == NO) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't convert to Unicode string."];
+        }
+        if (GSFromUnicode((unsigned char **)&r, &s, u, l, enc,
+                          NSDefaultMallocZone(), GSUniTerminate | GSUniTemporary | GSUniStrict) == NO) {
+            NSZoneFree(NSDefaultMallocZone(), u);
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't convert from Unicode string."];
+        }
+        NSZoneFree(NSDefaultMallocZone(), u);
     }
 
-  return (const char*)r;
+    return (const char *)r;
 }
 
-static inline const char*
+static inline const char *
 cString_u(GSStr self, NSStringEncoding enc)
 {
-  unsigned	c = self->_count;
+    unsigned c = self->_count;
 
-  if (c == 0)
-    {
-      return "\0";
-    }
-  else if (enc == NSUnicodeStringEncoding)
-    {
-      unichar	*tmp;
-      unsigned	l;
+    if (c == 0) {
+        return "\0";
+    } else if (enc == NSUnicodeStringEncoding) {
+        unichar *tmp;
+        unsigned l;
 
-      if ((l = GSUnicode(self->_contents.u, c, 0, 0)) != c)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"NSString is not legal UTF-16 at %u", l];
-	}
-      tmp = (unichar*)NSZoneMalloc(NSDefaultMallocZone(), (c + 1)*2);
-      memcpy(tmp, self->_contents.u, c*2);
-      tmp[c] = 0;
-      [NSDataClass dataWithBytesNoCopy: tmp
-				length: (c + 1)*2
-			  freeWhenDone: YES];
-      return (const char*)tmp;
-    }
-  else
-    {
-      unsigned int	l = 0;
-      unsigned char	*r = 0;
+        if ((l = GSUnicode(self->_contents.u, c, 0, 0)) != c) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"NSString is not legal UTF-16 at %u", l];
+        }
+        tmp = (unichar *)NSZoneMalloc(NSDefaultMallocZone(), (c + 1) * 2);
+        memcpy(tmp, self->_contents.u, c * 2);
+        tmp[c] = 0;
+        [NSDataClass dataWithBytesNoCopy:tmp
+                                  length:(c + 1) * 2
+                            freeWhenDone:YES];
+        return (const char *)tmp;
+    } else {
+        unsigned int l = 0;
+        unsigned char *r = 0;
 
-      if (GSFromUnicode(&r, &l, self->_contents.u, c, enc,
-	NSDefaultMallocZone(), GSUniTerminate|GSUniTemporary|GSUniStrict) == NO)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't get cString from Unicode string."];
-	}
-      return (const char*)r;
+        if (GSFromUnicode(&r, &l, self->_contents.u, c, enc,
+                          NSDefaultMallocZone(), GSUniTerminate | GSUniTemporary | GSUniStrict) == NO) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't get cString from Unicode string."];
+        }
+        return (const char *)r;
     }
 }
 
 static inline unsigned int
 cStringLength_c(GSStr self, NSStringEncoding enc)
 {
-  if (enc == internalEncoding)
-    {
-      return self->_count;
-    }
-  else
-    {
-      /*
-       * The external C string encoding is not compatible with the internal
-       * 8-bit character strings ... we must convert from internal format to
-       * unicode and then to the external C string encoding.
-       */
-      if (self->_count == 0)
-	{
-	  return 0;
-	}
-      else
-	{
-	  unichar	*u = 0;
-	  unsigned	l = 0;
-	  unsigned	s = 0;
+    if (enc == internalEncoding) {
+        return self->_count;
+    } else {
+        /*
+         * The external C string encoding is not compatible with the internal
+         * 8-bit character strings ... we must convert from internal format to
+         * unicode and then to the external C string encoding.
+         */
+        if (self->_count == 0) {
+            return 0;
+        } else {
+            unichar *u = 0;
+            unsigned l = 0;
+            unsigned s = 0;
 
-	  if (GSToUnicode(&u, &l, self->_contents.c, self->_count,
-	    internalEncoding, NSDefaultMallocZone(), 0) == NO)
-	    {
-	      [NSException raise: NSCharacterConversionException
-			  format: @"Can't convert to/from Unicode string."];
-	    }
-	  if (GSFromUnicode(0, &s, u, l, enc, 0, GSUniStrict) == NO)
-	    {
-	      NSZoneFree(NSDefaultMallocZone(), u);
-	      [NSException raise: NSCharacterConversionException
-			  format: @"Can't get cStringLength from string."];
-	    }
-	  NSZoneFree(NSDefaultMallocZone(), u);
-	  return s;
-	}
+            if (GSToUnicode(&u, &l, self->_contents.c, self->_count,
+                            internalEncoding, NSDefaultMallocZone(), 0) == NO) {
+                [NSException raise:NSCharacterConversionException
+                            format:@"Can't convert to/from Unicode string."];
+            }
+            if (GSFromUnicode(0, &s, u, l, enc, 0, GSUniStrict) == NO) {
+                NSZoneFree(NSDefaultMallocZone(), u);
+                [NSException raise:NSCharacterConversionException
+                            format:@"Can't get cStringLength from string."];
+            }
+            NSZoneFree(NSDefaultMallocZone(), u);
+            return s;
+        }
     }
 }
 
 static inline unsigned int
 cStringLength_u(GSStr self, NSStringEncoding enc)
 {
-  unsigned	c = self->_count;
+    unsigned c = self->_count;
 
-  if (c == 0)
-    {
-      return 0;
-    }
-  else
-    {
-      unsigned	l = 0;
+    if (c == 0) {
+        return 0;
+    } else {
+        unsigned l = 0;
 
-      if (GSFromUnicode(0, &l, self->_contents.u, c, enc, 0, GSUniStrict) == NO)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't get cStringLength from Unicode string."];
-	}
-      return l;
+        if (GSFromUnicode(0, &l, self->_contents.u, c, enc, 0, GSUniStrict) == NO) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't get cStringLength from Unicode string."];
+        }
+        return l;
     }
 }
 
 static inline void
 fillHole(GSStr self, unsigned index, unsigned size)
 {
-  NSCAssert(size > 0, @"size <= zero");
-  NSCAssert(index + size <= self->_count, @"index + size > length");
+    NSCAssert(size > 0, @"size <= zero");
+    NSCAssert(index + size <= self->_count, @"index + size > length");
 
-  self->_count -= size;
-  if (self->_flags.wide == 1)
-    {
-      memmove(self->_contents.u + index,
-	self->_contents.u + index + size,
-	sizeof(unichar)*(self->_count - index));
+    self->_count -= size;
+    if (self->_flags.wide == 1) {
+        memmove(self->_contents.u + index,
+                self->_contents.u + index + size,
+                sizeof(unichar) * (self->_count - index));
+    } else {
+        memmove(self->_contents.c + index,
+                self->_contents.c + index + size, (self->_count - index));
     }
-  else
-    {
-      memmove(self->_contents.c + index,
-	self->_contents.c + index + size, (self->_count - index));
-    }
-  self->_flags.hash = 0;
+    self->_flags.hash = 0;
 }
 
 static inline void
 getCharacters_c(GSStr self, unichar *buffer, NSRange aRange)
 {
-  if (aRange.length)
-    { 
-      if (NSISOLatin1StringEncoding == internalEncoding)
-        {
-          register NSUInteger   count = aRange.length;
-          register NSUInteger   base = aRange.location;
+    if (aRange.length) {
+        if (NSISOLatin1StringEncoding == internalEncoding) {
+            register NSUInteger count = aRange.length;
+            register NSUInteger base = aRange.location;
 
-          while (count-- > 0)
-            {
-              buffer[count] = self->_contents.c[base + count];
+            while (count-- > 0) {
+                buffer[count] = self->_contents.c[base + count];
             }
-        }
-      else
-        {
-          unsigned      len = aRange.length;
+        } else {
+            unsigned len = aRange.length;
 
-          if (!GSToUnicode(&buffer, &len, self->_contents.c + aRange.location,
-            aRange.length, internalEncoding, 0, 0))
-            {
-              [NSException raise: NSInternalInconsistencyException
-                          format: @"Can't convert to Unicode."];
+            if (!GSToUnicode(&buffer, &len, self->_contents.c + aRange.location,
+                             aRange.length, internalEncoding, 0, 0)) {
+                [NSException raise:NSInternalInconsistencyException
+                            format:@"Can't convert to Unicode."];
             }
         }
     }
@@ -2441,989 +2136,827 @@ getCharacters_c(GSStr self, unichar *buffer, NSRange aRange)
 static inline void
 getCharacters_u(GSStr self, unichar *buffer, NSRange aRange)
 {
-  memcpy(buffer, self->_contents.u + aRange.location,
-    aRange.length*sizeof(unichar));
+    memcpy(buffer, self->_contents.u + aRange.location,
+           aRange.length * sizeof(unichar));
 }
 
 static void
 getCString_c(GSStr self, char *buffer, unsigned int maxLength,
-  NSRange aRange, NSRange *leftoverRange)
+             NSRange aRange, NSRange *leftoverRange)
 {
-  GSMutableString *o;
-  int len;
+    GSMutableString *o;
+    int len;
 
-  if (maxLength > self->_count)
-    {
-      maxLength = self->_count;
+    if (maxLength > self->_count) {
+        maxLength = self->_count;
     }
-  if (maxLength < aRange.length)
-    {
-      len = maxLength;
-      if (leftoverRange != 0)
-	{
-	  leftoverRange->location = aRange.location + maxLength;
-	  leftoverRange->length = aRange.length - maxLength;
-	}
-    }
-  else
-    {
-      len = aRange.length;
-      if (leftoverRange != 0)
-	{
-	  leftoverRange->location = 0;
-	  leftoverRange->length = 0;
-	}
+    if (maxLength < aRange.length) {
+        len = maxLength;
+        if (leftoverRange != 0) {
+            leftoverRange->location = aRange.location + maxLength;
+            leftoverRange->length = aRange.length - maxLength;
+        }
+    } else {
+        len = aRange.length;
+        if (leftoverRange != 0) {
+            leftoverRange->location = 0;
+            leftoverRange->length = 0;
+        }
     }
 
-  if (externalEncoding == internalEncoding)
-    {
-      memcpy(buffer, &self->_contents.c[aRange.location], len);
-      buffer[len] = '\0';
-      return;
+    if (externalEncoding == internalEncoding) {
+        memcpy(buffer, &self->_contents.c[aRange.location], len);
+        buffer[len] = '\0';
+        return;
     }
 
-  if (isByteEncoding(internalEncoding))
-    {
-      if (externalEncoding == NSUTF8StringEncoding
-	|| isByteEncoding(externalEncoding))
-	{
-	  const unsigned char	*ptr = self->_contents.c + aRange.location;
-	  unsigned		i;
+    if (isByteEncoding(internalEncoding)) {
+        if (externalEncoding == NSUTF8StringEncoding || isByteEncoding(externalEncoding)) {
+            const unsigned char *ptr = self->_contents.c + aRange.location;
+            unsigned i;
 
-	  /*
-	   * Maybe we actually contain ascii data, which can be
-	   * copied out directly.
-	   */
-	  for (i = 0; i < len; i++)
-	    {
-	      unsigned char	c = ptr[i];
+            /*
+             * Maybe we actually contain ascii data, which can be
+             * copied out directly.
+             */
+            for (i = 0; i < len; i++) {
+                unsigned char c = ptr[i];
 
-	      if (c > 127)
-		{
-		  break;
-		}
-	      buffer[i] = c;
-	    }
-	  if (i == len)
-	    {
-	      buffer[i] = '\0';
-	      return;
-	    }
-	}
+                if (c > 127) {
+                    break;
+                }
+                buffer[i] = c;
+            }
+            if (i == len) {
+                buffer[i] = '\0';
+                return;
+            }
+        }
     }
 
-  /* As the internal and external encodings don't match, the simplest
-   * thing to do is widen the internal data to unicode and use the
-   * unicode function to get the cString.
-   */
-  o = (GSMutableString*)alloca(class_getInstanceSize(GSMutableStringClass));
-  object_setClass(o, GSMutableStringClass);
-  o->_count = self->_count;
-  o->_flags.wide = 0;
-  o->_flags.owned = 0;
-  o->_flags.unused = 0;
-  o->_flags.hash = 0;
-  o->_capacity = self->_count;
-  o->_contents.c = self->_contents.c;
-  o->_zone = NSDefaultMallocZone();
-  GSStrWiden(o);
-  getCString_u(o, buffer, maxLength, aRange, leftoverRange);
-  if (o->_flags.owned == 1)
-    {
-      NSZoneFree(o->_zone, o->_contents.u);
+    /* As the internal and external encodings don't match, the simplest
+     * thing to do is widen the internal data to unicode and use the
+     * unicode function to get the cString.
+     */
+    o = (GSMutableString *)alloca(class_getInstanceSize(GSMutableStringClass));
+    object_setClass(o, GSMutableStringClass);
+    o->_count = self->_count;
+    o->_flags.wide = 0;
+    o->_flags.owned = 0;
+    o->_flags.unused = 0;
+    o->_flags.hash = 0;
+    o->_capacity = self->_count;
+    o->_contents.c = self->_contents.c;
+    o->_zone = NSDefaultMallocZone();
+    GSStrWiden(o);
+    getCString_u(o, buffer, maxLength, aRange, leftoverRange);
+    if (o->_flags.owned == 1) {
+        NSZoneFree(o->_zone, o->_contents.u);
     }
 }
 
 static void
 getCString_u(GSStr self, char *buffer, unsigned int maxLength,
-  NSRange aRange, NSRange *leftoverRange)
+             NSRange aRange, NSRange *leftoverRange)
 {
-  /* The primitive we have for converting from unicode, GSFromUnicode,
-  can't deal with our leftoverRange case, so we need to use a bit of
-  complexity instead. */
-  unsigned int len;
+    /* The primitive we have for converting from unicode, GSFromUnicode,
+    can't deal with our leftoverRange case, so we need to use a bit of
+    complexity instead. */
+    unsigned int len;
 
-  /* TODO: this is an extremely ugly hack to work around buggy iconvs
-  that return -1/E2BIG for buffers larger than 0x40000acf */
-  if (maxLength > 0x40000000)
-    maxLength = 0x40000000;
+    /* TODO: this is an extremely ugly hack to work around buggy iconvs
+    that return -1/E2BIG for buffers larger than 0x40000acf */
+    if (maxLength > 0x40000000)
+        maxLength = 0x40000000;
 
-  /* First, try converting the whole thing. */
-  len = maxLength;
-  if (GSFromUnicode((unsigned char **)&buffer, &len,
-    self->_contents.u + aRange.location, aRange.length,
-    externalEncoding, 0, GSUniTerminate | GSUniStrict) == YES)
-    {
-      if (leftoverRange)
-	leftoverRange->location = leftoverRange->length = 0;
-      return;
-    }
-
-  /* The conversion failed. Either the buffer is too small for the whole
-  range, or there are characters in it we can't convert. Check for
-  unconvertable characters first. */
-  len = 0;
-  if (GSFromUnicode(NULL, &len,
-    self->_contents.u + aRange.location, aRange.length,
-    externalEncoding, 0, GSUniTerminate | GSUniStrict) == NO)
-    {
-      [NSException raise: NSCharacterConversionException
-		  format: @"Can't get cString from Unicode string."];
-      return;
-    }
-
-  /* The string can be converted, but not all of it. Do a binary search
-  to find the longest subrange that fits in the buffer. */
-  {
-    unsigned int lo, hi, mid;
-
-    lo = 0;
-    hi = aRange.length;
-    while (lo < hi)
-      {
-	mid = (lo + hi + 1) / 2; /* round up to get edge case right */
-	len = maxLength;
-	if (GSFromUnicode((unsigned char **)&buffer, &len,
-	  self->_contents.u + aRange.location, mid,
-	  externalEncoding, 0, GSUniTerminate | GSUniStrict) == YES)
-	  {
-	    lo = mid;
-	  }
-	else
-	  {
-	    hi = mid - 1;
-	  }
-      }
-
-    /* lo==hi characters fit. Do the real conversion. */
+    /* First, try converting the whole thing. */
     len = maxLength;
-    if (lo == 0)
-      {
-        buffer[0] = 0;
-      }
-    else if (GSFromUnicode((unsigned char **)&buffer, &len,
-      self->_contents.u + aRange.location, lo,
-      externalEncoding, 0, GSUniTerminate | GSUniStrict) == NO)
-      {
-        NSCAssert(NO, @"binary search gave inconsistent results");
-      }
+    if (GSFromUnicode((unsigned char **)&buffer, &len,
+                      self->_contents.u + aRange.location, aRange.length,
+                      externalEncoding, 0, GSUniTerminate | GSUniStrict) == YES) {
+        if (leftoverRange)
+            leftoverRange->location = leftoverRange->length = 0;
+        return;
+    }
 
-    if (leftoverRange)
-      {
-	leftoverRange->location = aRange.location + lo;
-	leftoverRange->length = NSMaxRange(aRange) - leftoverRange->location;
-      }
-  }
+    /* The conversion failed. Either the buffer is too small for the whole
+    range, or there are characters in it we can't convert. Check for
+    unconvertable characters first. */
+    len = 0;
+    if (GSFromUnicode(NULL, &len,
+                      self->_contents.u + aRange.location, aRange.length,
+                      externalEncoding, 0, GSUniTerminate | GSUniStrict) == NO) {
+        [NSException raise:NSCharacterConversionException
+                    format:@"Can't get cString from Unicode string."];
+        return;
+    }
+
+    /* The string can be converted, but not all of it. Do a binary search
+    to find the longest subrange that fits in the buffer. */
+    {
+        unsigned int lo, hi, mid;
+
+        lo = 0;
+        hi = aRange.length;
+        while (lo < hi) {
+            mid = (lo + hi + 1) / 2; /* round up to get edge case right */
+            len = maxLength;
+            if (GSFromUnicode((unsigned char **)&buffer, &len,
+                              self->_contents.u + aRange.location, mid,
+                              externalEncoding, 0, GSUniTerminate | GSUniStrict) == YES) {
+                lo = mid;
+            } else {
+                hi = mid - 1;
+            }
+        }
+
+        /* lo==hi characters fit. Do the real conversion. */
+        len = maxLength;
+        if (lo == 0) {
+            buffer[0] = 0;
+        } else if (GSFromUnicode((unsigned char **)&buffer, &len,
+                                 self->_contents.u + aRange.location, lo,
+                                 externalEncoding, 0, GSUniTerminate | GSUniStrict) == NO) {
+            NSCAssert(NO, @"binary search gave inconsistent results");
+        }
+
+        if (leftoverRange) {
+            leftoverRange->location = aRange.location + lo;
+            leftoverRange->length = NSMaxRange(aRange) - leftoverRange->location;
+        }
+    }
 }
 
 static inline BOOL
 getCStringE_c(GSStr self, char *buffer, unsigned int maxLength,
-  NSStringEncoding enc)
+              NSStringEncoding enc)
 {
-  if (buffer == 0)
-    {
-      return NO;	// Can't fit in here
+    if (buffer == 0) {
+        return NO; // Can't fit in here
     }
-  if (enc == NSUnicodeStringEncoding)
-    {
-      if (maxLength >= sizeof(unichar))
-	{
-	  unsigned	bytes = maxLength - sizeof(unichar);
-	  unichar	*u = (unichar*)(void*)buffer;
+    if (enc == NSUnicodeStringEncoding) {
+        if (maxLength >= sizeof(unichar)) {
+            unsigned bytes = maxLength - sizeof(unichar);
+            unichar *u = (unichar *)(void *)buffer;
 
-	  if (GSToUnicode(&u, &bytes, self->_contents.c, self->_count,
-	    internalEncoding, NSDefaultMallocZone(), GSUniTerminate) == NO)
-	    {
-	      [NSException raise: NSCharacterConversionException
-			  format: @"Can't convert to Unicode string."];
-	    }
-	  if (u == (unichar*)(void*)buffer)
-	    {
-	      return YES;
-	    }
-	  NSZoneFree(NSDefaultMallocZone(), u);
-	}
-      return NO;
-    }
-  else
-    {
-      if (maxLength > sizeof(char))
-	{
-	  unsigned	bytes = maxLength - sizeof(char);
+            if (GSToUnicode(&u, &bytes, self->_contents.c, self->_count,
+                            internalEncoding, NSDefaultMallocZone(), GSUniTerminate) == NO) {
+                [NSException raise:NSCharacterConversionException
+                            format:@"Can't convert to Unicode string."];
+            }
+            if (u == (unichar *)(void *)buffer) {
+                return YES;
+            }
+            NSZoneFree(NSDefaultMallocZone(), u);
+        }
+        return NO;
+    } else {
+        if (maxLength > sizeof(char)) {
+            unsigned bytes = maxLength - sizeof(char);
 
-	  if (enc == internalEncoding)
-	    {
-	      if (bytes > self->_count)
-		{
-		  bytes = self->_count;
-		}
-	      memcpy(buffer, self->_contents.c, bytes);
-	      buffer[bytes] = '\0';
-	      if (bytes < self->_count)
-		{
-		  return NO;
-		}
-	      return YES;
-	    }
+            if (enc == internalEncoding) {
+                if (bytes > self->_count) {
+                    bytes = self->_count;
+                }
+                memcpy(buffer, self->_contents.c, bytes);
+                buffer[bytes] = '\0';
+                if (bytes < self->_count) {
+                    return NO;
+                }
+                return YES;
+            }
 
-	  if (enc == NSUTF8StringEncoding
-	    && isByteEncoding(internalEncoding))
-	    {
-	      unsigned	i;
+            if (enc == NSUTF8StringEncoding && isByteEncoding(internalEncoding)) {
+                unsigned i;
 
-	      /*
-	       * Maybe we actually contain ascii data, which can be
-	       * copied out directly as a utf-8 string.
-	       */
-	      if (bytes > self->_count)
-		{
-		  bytes = self->_count;
-		}
-	      for (i = 0; i < bytes; i++)
-		{
-		  unsigned char	c = self->_contents.c[i];
+                /*
+                 * Maybe we actually contain ascii data, which can be
+                 * copied out directly as a utf-8 string.
+                 */
+                if (bytes > self->_count) {
+                    bytes = self->_count;
+                }
+                for (i = 0; i < bytes; i++) {
+                    unsigned char c = self->_contents.c[i];
 
-		  if (c > 127)
-		    {
-		      break;
-		    }
-		  buffer[i] = c;
-		}
-	      if (i == bytes)
-	        {
-	          buffer[bytes] = '\0';
-	          if (bytes < self->_count)
-		    {
-		      return NO;
-		    }
-	          return YES;
-		}
-	    }
+                    if (c > 127) {
+                        break;
+                    }
+                    buffer[i] = c;
+                }
+                if (i == bytes) {
+                    buffer[bytes] = '\0';
+                    if (bytes < self->_count) {
+                        return NO;
+                    }
+                    return YES;
+                }
+            }
 
-	  if (enc == NSASCIIStringEncoding
-	    && isByteEncoding(internalEncoding))
-	    {
-	      unsigned	i;
+            if (enc == NSASCIIStringEncoding && isByteEncoding(internalEncoding)) {
+                unsigned i;
 
-	      if (bytes > self->_count)
-		{
-		  bytes = self->_count;
-		}
-	      for (i = 0; i < bytes; i++)
-		{
-		  unsigned char	c = self->_contents.c[i];
+                if (bytes > self->_count) {
+                    bytes = self->_count;
+                }
+                for (i = 0; i < bytes; i++) {
+                    unsigned char c = self->_contents.c[i];
 
-		  if (c > 127)
-		    {
-		      [NSException raise: NSCharacterConversionException
-				  format: @"unable to convert to encoding"];
-		    }
-		  buffer[i] = c;
-		}
-	      buffer[bytes] = '\0';
-	      if (bytes < self->_count)
-		{
-		  return NO;
-		}
-	      return YES;
-	    }
-	  else
-	    {
-	      unichar		*u = 0;
-	      unsigned char	*c = (unsigned char*)buffer;
-	      unsigned		l = 0;
+                    if (c > 127) {
+                        [NSException raise:NSCharacterConversionException
+                                    format:@"unable to convert to encoding"];
+                    }
+                    buffer[i] = c;
+                }
+                buffer[bytes] = '\0';
+                if (bytes < self->_count) {
+                    return NO;
+                }
+                return YES;
+            } else {
+                unichar *u = 0;
+                unsigned char *c = (unsigned char *)buffer;
+                unsigned l = 0;
 
-	      /*
-	       * The specified C string encoding is not compatible with
-	       * the internal 8-bit character strings ... we must convert
-	       * from internal format to unicode and then to the specified
-	       * C string encoding.
-	       */
-              bytes = maxLength - sizeof(char);
-	      if (GSToUnicode(&u, &l, self->_contents.c, self->_count,
-		internalEncoding, NSDefaultMallocZone(), 0) == NO)
-		{
-		  [NSException raise: NSCharacterConversionException
-			      format: @"Can't convert to Unicode string."];
-		}
-	      if (GSFromUnicode((unsigned char**)&c, &bytes, u, l, enc,
-		0, GSUniTerminate|GSUniStrict) == NO)
-		{
-		  c = 0;	// Unable to convert
-		}
-	      NSZoneFree(NSDefaultMallocZone(), u);
-	      if (c == (unsigned char*)buffer)
-		{
-		  return YES;	// Fitted in original buffer
-		}
-	      else if (c != 0)
-		{
-		  NSZoneFree(NSDefaultMallocZone(), c);
-		}
-	    }
-	}
-      return NO;
+                /*
+                 * The specified C string encoding is not compatible with
+                 * the internal 8-bit character strings ... we must convert
+                 * from internal format to unicode and then to the specified
+                 * C string encoding.
+                 */
+                bytes = maxLength - sizeof(char);
+                if (GSToUnicode(&u, &l, self->_contents.c, self->_count,
+                                internalEncoding, NSDefaultMallocZone(), 0) == NO) {
+                    [NSException raise:NSCharacterConversionException
+                                format:@"Can't convert to Unicode string."];
+                }
+                if (GSFromUnicode((unsigned char **)&c, &bytes, u, l, enc,
+                                  0, GSUniTerminate | GSUniStrict) == NO) {
+                    c = 0; // Unable to convert
+                }
+                NSZoneFree(NSDefaultMallocZone(), u);
+                if (c == (unsigned char *)buffer) {
+                    return YES; // Fitted in original buffer
+                } else if (c != 0) {
+                    NSZoneFree(NSDefaultMallocZone(), c);
+                }
+            }
+        }
+        return NO;
     }
 }
 
 static inline BOOL
 getCStringE_u(GSStr self, char *buffer, unsigned int maxLength,
-  NSStringEncoding enc)
+              NSStringEncoding enc)
 {
-  if (enc == NSUnicodeStringEncoding)
-    {
-      if (maxLength >= sizeof(unichar))
-	{
-	  unsigned	bytes = maxLength - sizeof(unichar);
+    if (enc == NSUnicodeStringEncoding) {
+        if (maxLength >= sizeof(unichar)) {
+            unsigned bytes = maxLength - sizeof(unichar);
 
-	  if (bytes/sizeof(unichar) > self->_count)
-	    {
-	      bytes = self->_count * sizeof(unichar);
-	    }
-	  memcpy(buffer, self->_contents.u, bytes);
-	  buffer[bytes] = '\0';
-	  buffer[bytes + 1] = '\0';
-	  if (bytes/sizeof(unichar) == self->_count)
-	    {
-	      return YES;
-	    }
-	}
-      return NO;
-    }
-  else
-    {
-      if (maxLength >= 1)
-	{
-	  if (enc == NSISOLatin1StringEncoding)
-	    {
-	      unsigned	bytes = maxLength - sizeof(char);
-	      unsigned	i;
+            if (bytes / sizeof(unichar) > self->_count) {
+                bytes = self->_count * sizeof(unichar);
+            }
+            memcpy(buffer, self->_contents.u, bytes);
+            buffer[bytes] = '\0';
+            buffer[bytes + 1] = '\0';
+            if (bytes / sizeof(unichar) == self->_count) {
+                return YES;
+            }
+        }
+        return NO;
+    } else {
+        if (maxLength >= 1) {
+            if (enc == NSISOLatin1StringEncoding) {
+                unsigned bytes = maxLength - sizeof(char);
+                unsigned i;
 
-	      if (bytes > self->_count)
-		{
-		  bytes = self->_count;
-		}
-	      for (i = 0; i < bytes; i++)
-		{
-		  unichar	u = self->_contents.u[i];
+                if (bytes > self->_count) {
+                    bytes = self->_count;
+                }
+                for (i = 0; i < bytes; i++) {
+                    unichar u = self->_contents.u[i];
 
-		  if (u & 0xff00)
-		    {
-		      [NSException
-			 raise:NSCharacterConversionException
-			format:@"unable to convert to encoding"];
-		    }
-		  buffer[i] = (char)u;
-		}
-	      buffer[i] = '\0';
-	      if (bytes == self->_count)
-		{
-		  return YES;
-		}
-	    }
-	  else if (enc == NSASCIIStringEncoding)
-	    {
-	      unsigned	bytes = maxLength - sizeof(char);
-	      unsigned	i;
+                    if (u & 0xff00) {
+                        [NSException
+                             raise:NSCharacterConversionException
+                            format:@"unable to convert to encoding"];
+                    }
+                    buffer[i] = (char)u;
+                }
+                buffer[i] = '\0';
+                if (bytes == self->_count) {
+                    return YES;
+                }
+            } else if (enc == NSASCIIStringEncoding) {
+                unsigned bytes = maxLength - sizeof(char);
+                unsigned i;
 
-	      if (bytes > self->_count)
-		{
-		  bytes = self->_count;
-		}
-	      for (i = 0; i < bytes; i++)
-		{
-		  unichar	u = self->_contents.u[i];
+                if (bytes > self->_count) {
+                    bytes = self->_count;
+                }
+                for (i = 0; i < bytes; i++) {
+                    unichar u = self->_contents.u[i];
 
-		  if (u & 0xff80)
-		    {
-		      [NSException raise: NSCharacterConversionException
-				  format: @"unable to convert to encoding"];
-		    }
-		  buffer[i] = (char)u;
-		}
-	      buffer[i] = '\0';
-	      if (bytes == self->_count)
-		{
-		  return YES;
-		}
-	    }
-	  else
-	    {
-	      unsigned char	*c = (unsigned char*)buffer;
+                    if (u & 0xff80) {
+                        [NSException raise:NSCharacterConversionException
+                                    format:@"unable to convert to encoding"];
+                    }
+                    buffer[i] = (char)u;
+                }
+                buffer[i] = '\0';
+                if (bytes == self->_count) {
+                    return YES;
+                }
+            } else {
+                unsigned char *c = (unsigned char *)buffer;
 
-	      if (GSFromUnicode((unsigned char**)&c, &maxLength,
-		self->_contents.u, self->_count, enc,
-		0, GSUniTerminate|GSUniStrict) == NO)
-		{
-		  return NO;
-		}
-	      return YES;
-	    }
-	}
-      return NO;
+                if (GSFromUnicode((unsigned char **)&c, &maxLength,
+                                  self->_contents.u, self->_count, enc,
+                                  0, GSUniTerminate | GSUniStrict) == NO) {
+                    return NO;
+                }
+                return YES;
+            }
+        }
+        return NO;
     }
 }
 
 static inline BOOL
 isEqual_c(GSStr self, id anObject)
 {
-  Class	c;
+    Class c;
 
-  if (anObject == (id)self)
-    {
-      return YES;
+    if (anObject == (id)self) {
+        return YES;
     }
-  if (anObject == nil)
-    {
-      return NO;
+    if (anObject == nil) {
+        return NO;
     }
-  c = object_getClass(anObject);
-  if (class_isMetaClass(c) == YES)
-    {
-      return NO;
+    c = object_getClass(anObject);
+    if (class_isMetaClass(c) == YES) {
+        return NO;
     }
-  if (c == NSConstantStringClass)
-    {
-      return literalIsEqualInternal((NXConstantString*)anObject, (GSStr)self);
+    if (c == NSConstantStringClass) {
+        return literalIsEqualInternal((NXConstantString *)anObject, (GSStr)self);
     }
-  if (c == GSMutableStringClass || GSObjCIsKindOf(c, GSStringClass) == YES)
-    {
-      GSStr	other = (GSStr)anObject;
-      NSRange	r = {0, self->_count};
+    if (c == GSMutableStringClass || GSObjCIsKindOf(c, GSStringClass) == YES) {
+        GSStr other = (GSStr)anObject;
+        NSRange r = {0, self->_count};
 
-      /* First see if the hash is the same - if not, we can't be equal.
-       * However, it's not worth calculating hashes unless the strings
-       * are fairly long.
-       */
-      if (self->_count > 15)
-        {
-          if (self->_flags.hash == 0)
-            self->_flags.hash = (*hashImp)((id)self, hashSel);
-          if (other->_flags.hash == 0)
-            other->_flags.hash = (*hashImp)((id)other, hashSel);
-          if (self->_flags.hash != other->_flags.hash)
-            return NO;
-        }
-      else if (self->_flags.hash && other->_flags.hash)
-        {
-          if (self->_flags.hash != other->_flags.hash)
-            return NO;
+        /* First see if the hash is the same - if not, we can't be equal.
+         * However, it's not worth calculating hashes unless the strings
+         * are fairly long.
+         */
+        if (self->_count > 15) {
+            if (self->_flags.hash == 0)
+                self->_flags.hash = (*hashImp)((id)self, hashSel);
+            if (other->_flags.hash == 0)
+                other->_flags.hash = (*hashImp)((id)other, hashSel);
+            if (self->_flags.hash != other->_flags.hash)
+                return NO;
+        } else if (self->_flags.hash && other->_flags.hash) {
+            if (self->_flags.hash != other->_flags.hash)
+                return NO;
         }
 
-      /*
-       * Do a compare depending on the type of the other string.
-       */
-      if (other->_flags.wide == 1)
-	{
-	  if (strCompCsUs((id)self, (id)other, 0, r) == NSOrderedSame)
-	    return YES;
-	}
-      else
-	{
-	  if (other->_count == self->_count
-	    && memcmp(other->_contents.c, self->_contents.c, self->_count) == 0)
-	    return YES;
-	}
-      return NO;
-    }
-  else if (YES == [anObject isKindOfClass: NSStringClass]) // may be proxy
+        /*
+         * Do a compare depending on the type of the other string.
+         */
+        if (other->_flags.wide == 1) {
+            if (strCompCsUs((id)self, (id)other, 0, r) == NSOrderedSame)
+                return YES;
+        } else {
+            if (other->_count == self->_count && memcmp(other->_contents.c, self->_contents.c, self->_count) == 0)
+                return YES;
+        }
+        return NO;
+    } else if (YES == [anObject isKindOfClass:NSStringClass]) // may be proxy
     {
-      return (*equalImp)((id)self, equalSel, anObject);
-    }
-  else
-    {
-      return NO;
+        return (*equalImp)((id)self, equalSel, anObject);
+    } else {
+        return NO;
     }
 }
 
 static inline BOOL
 isEqual_u(GSStr self, id anObject)
 {
-  Class	c;
+    Class c;
 
-  if (anObject == (id)self)
-    {
-      return YES;
+    if (anObject == (id)self) {
+        return YES;
     }
-  if (anObject == nil)
-    {
-      return NO;
+    if (anObject == nil) {
+        return NO;
     }
-  c = object_getClass(anObject);
-  if (class_isMetaClass(c) == YES)
-    {
-      return NO;
+    c = object_getClass(anObject);
+    if (class_isMetaClass(c) == YES) {
+        return NO;
     }
-  if (c == NSConstantStringClass)
-    {
-      return literalIsEqualInternal((NXConstantString*)anObject, (GSStr)self);
+    if (c == NSConstantStringClass) {
+        return literalIsEqualInternal((NXConstantString *)anObject, (GSStr)self);
     }
-  if (c == GSMutableStringClass || GSObjCIsKindOf(c, GSStringClass) == YES)
-    {
-      GSStr	other = (GSStr)anObject;
-      NSRange	r = {0, self->_count};
+    if (c == GSMutableStringClass || GSObjCIsKindOf(c, GSStringClass) == YES) {
+        GSStr other = (GSStr)anObject;
+        NSRange r = {0, self->_count};
 
-      /* First see if the hash is the same - if not, we can't be equal.
-       * However, it's not worth calculating hashes unless the strings
-       * are fairly long.
-       */
-      if (self->_count > 15)
-        {
-          if (self->_flags.hash == 0)
-            self->_flags.hash = (*hashImp)((id)self, hashSel);
-          if (other->_flags.hash == 0)
-            other->_flags.hash = (*hashImp)((id)other, hashSel);
-          if (self->_flags.hash != other->_flags.hash)
-            return NO;
-        }
-      else if (self->_flags.hash && other->_flags.hash)
-        {
-          if (self->_flags.hash != other->_flags.hash)
-            return NO;
+        /* First see if the hash is the same - if not, we can't be equal.
+         * However, it's not worth calculating hashes unless the strings
+         * are fairly long.
+         */
+        if (self->_count > 15) {
+            if (self->_flags.hash == 0)
+                self->_flags.hash = (*hashImp)((id)self, hashSel);
+            if (other->_flags.hash == 0)
+                other->_flags.hash = (*hashImp)((id)other, hashSel);
+            if (self->_flags.hash != other->_flags.hash)
+                return NO;
+        } else if (self->_flags.hash && other->_flags.hash) {
+            if (self->_flags.hash != other->_flags.hash)
+                return NO;
         }
 
-      /*
-       * Do a compare depending on the type of the other string.
-       */
-      if (other->_flags.wide == 1)
-	{
-	  if (strCompUsUs((id)self, (id)other, 0, r) == NSOrderedSame)
-	    return YES;
-	}
-      else
-	{
-	  if (strCompUsCs((id)self, (id)other, 0, r) == NSOrderedSame)
-	    return YES;
-	}
-      return NO;
-    }
-  else if (YES == [anObject isKindOfClass: NSStringClass]) // may be proxy
+        /*
+         * Do a compare depending on the type of the other string.
+         */
+        if (other->_flags.wide == 1) {
+            if (strCompUsUs((id)self, (id)other, 0, r) == NSOrderedSame)
+                return YES;
+        } else {
+            if (strCompUsCs((id)self, (id)other, 0, r) == NSOrderedSame)
+                return YES;
+        }
+        return NO;
+    } else if (YES == [anObject isKindOfClass:NSStringClass]) // may be proxy
     {
-      return (*equalImp)((id)self, equalSel, anObject);
-    }
-  else
-    {
-      return NO;
+        return (*equalImp)((id)self, equalSel, anObject);
+    } else {
+        return NO;
     }
 }
 
-static inline const char*
+static inline const char *
 lossyCString_c(GSStr self)
 {
-  char *r;
+    char *r;
 
-  if (self->_count == 0)
-    {
-      return "";
+    if (self->_count == 0) {
+        return "";
     }
-  if (externalEncoding == internalEncoding)
-    {
-      r = (char*)GSAutoreleasedBuffer(self->_count+1);
+    if (externalEncoding == internalEncoding) {
+        r = (char *)GSAutoreleasedBuffer(self->_count + 1);
 
-      if (self->_count > 0)
-	{
-	  memcpy(r, self->_contents.c, self->_count);
-	}
-      r[self->_count] = '\0';
-    }
-  else
-    {
-      unichar	*u = 0;
-      unsigned	l = 0;
-      unsigned	s = 0;
+        if (self->_count > 0) {
+            memcpy(r, self->_contents.c, self->_count);
+        }
+        r[self->_count] = '\0';
+    } else {
+        unichar *u = 0;
+        unsigned l = 0;
+        unsigned s = 0;
 
-      /*
-       * The external C string encoding is not compatible with the internal
-       * 8-bit character strings ... we must convert from internal format to
-       * unicode and then to the external C string encoding.
-       */
-      if (GSToUnicode(&u, &l, self->_contents.c, self->_count,
-	internalEncoding, NSDefaultMallocZone(), 0) == NO)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't convert to/from Unicode string."];
-	}
-      if (GSFromUnicode((unsigned char**)&r, &s, u, l, externalEncoding,
-	NSDefaultMallocZone(), GSUniTerminate|GSUniTemporary) == NO)
-	{
-	  NSZoneFree(NSDefaultMallocZone(), u);
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't convert to/from Unicode string."];
-	}
-      NSZoneFree(NSDefaultMallocZone(), u);
+        /*
+         * The external C string encoding is not compatible with the internal
+         * 8-bit character strings ... we must convert from internal format to
+         * unicode and then to the external C string encoding.
+         */
+        if (GSToUnicode(&u, &l, self->_contents.c, self->_count,
+                        internalEncoding, NSDefaultMallocZone(), 0) == NO) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't convert to/from Unicode string."];
+        }
+        if (GSFromUnicode((unsigned char **)&r, &s, u, l, externalEncoding,
+                          NSDefaultMallocZone(), GSUniTerminate | GSUniTemporary) == NO) {
+            NSZoneFree(NSDefaultMallocZone(), u);
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't convert to/from Unicode string."];
+        }
+        NSZoneFree(NSDefaultMallocZone(), u);
     }
 
-  return r;
+    return r;
 }
 
-static inline const char*
+static inline const char *
 lossyCString_u(GSStr self)
 {
-  unsigned	l = 0;
-  unsigned char	*r = 0;
+    unsigned l = 0;
+    unsigned char *r = 0;
 
-  (void)GSFromUnicode(&r, &l, self->_contents.u, self->_count,
-    externalEncoding, NSDefaultMallocZone(), GSUniTemporary|GSUniTerminate);
-  return (const char*)r;
+    (void)GSFromUnicode(&r, &l, self->_contents.u, self->_count,
+                        externalEncoding, NSDefaultMallocZone(), GSUniTemporary | GSUniTerminate);
+    return (const char *)r;
 }
 
 static void GSStrMakeSpace(GSStr s, unsigned size)
 {
-  unsigned	want;
+    unsigned want;
 
-  want = size + s->_count + 1;
-  s->_capacity += s->_capacity/2;
-  if (want > s->_capacity)
-    {
-      s->_capacity = want;
+    want = size + s->_count + 1;
+    s->_capacity += s->_capacity / 2;
+    if (want > s->_capacity) {
+        s->_capacity = want;
     }
-  if (s->_flags.owned == 1)
-    {
-      /*
-       * If we own the character buffer, we can simply realloc.
-       */
-      if (s->_flags.wide == 1)
-	{
-	  s->_contents.u = NSZoneRealloc(s->_zone,
-	    s->_contents.u, s->_capacity*sizeof(unichar));
-	}
-      else
-	{
-	  s->_contents.c = NSZoneRealloc(s->_zone,
-	    s->_contents.c, s->_capacity);
-	}
-    }
-  else
-    {
-      /*
-       * If the initial data was not to be freed, we must allocate new
-       * buffer, copy the data, and set up the zone we are using.
-       */
-      if (s->_zone == 0)
-	{
-          s->_zone = [(NSString*)s zone];
-	}
-      if (s->_flags.wide == 1)
-	{
-	  unichar	*tmp = s->_contents.u;
+    if (s->_flags.owned == 1) {
+        /*
+         * If we own the character buffer, we can simply realloc.
+         */
+        if (s->_flags.wide == 1) {
+            s->_contents.u = NSZoneRealloc(s->_zone,
+                                           s->_contents.u, s->_capacity * sizeof(unichar));
+        } else {
+            s->_contents.c = NSZoneRealloc(s->_zone,
+                                           s->_contents.c, s->_capacity);
+        }
+    } else {
+        /*
+         * If the initial data was not to be freed, we must allocate new
+         * buffer, copy the data, and set up the zone we are using.
+         */
+        if (s->_zone == 0) {
+            s->_zone = [(NSString *)s zone];
+        }
+        if (s->_flags.wide == 1) {
+            unichar *tmp = s->_contents.u;
 
-	  s->_contents.u = NSZoneMalloc(s->_zone,
-	    s->_capacity*sizeof(unichar));
-	  if (s->_count > 0)
-	    {
-	      memcpy(s->_contents.u, tmp, s->_count*sizeof(unichar));
-	    }
-	}
-      else
-	{
-	  unsigned char	*tmp = s->_contents.c;
+            s->_contents.u = NSZoneMalloc(s->_zone,
+                                          s->_capacity * sizeof(unichar));
+            if (s->_count > 0) {
+                memcpy(s->_contents.u, tmp, s->_count * sizeof(unichar));
+            }
+        } else {
+            unsigned char *tmp = s->_contents.c;
 
-	  s->_contents.c = NSZoneMalloc(s->_zone, s->_capacity);
-	  if (s->_count > 0)
-	    {
-	      memcpy(s->_contents.c, tmp, s->_count);
-	    }
-	}
-      s->_flags.owned = 1;
+            s->_contents.c = NSZoneMalloc(s->_zone, s->_capacity);
+            if (s->_count > 0) {
+                memcpy(s->_contents.c, tmp, s->_count);
+            }
+        }
+        s->_flags.owned = 1;
     }
 }
 
 static void GSStrWiden(GSStr s)
 {
-  unichar	*tmp = 0;
-  unsigned	len = 0;
+    unichar *tmp = 0;
+    unsigned len = 0;
 
-  NSCAssert(s->_flags.wide == 0, @"string is not wide");
+    NSCAssert(s->_flags.wide == 0, @"string is not wide");
 
-  /*
-   * As a special case, where we are ascii or latin1 and the buffer size
-   * is big enough, we can widen to unicode without having to allocate
-   * more memory or call a character conversion function.
-   */
-  if (s->_count <= s->_capacity / 2)
-    {
-      if (internalEncoding == NSISOLatin1StringEncoding
-	|| internalEncoding == NSASCIIStringEncoding)
-	{
-	  len = s->_count;
-	  while (len-- > 0)
-	    {
-	      s->_contents.u[len] = s->_contents.c[len];
-	    }
-	  s->_capacity /= 2;
-	  s->_flags.wide = 1;
-	  return;
-	}
+    /*
+     * As a special case, where we are ascii or latin1 and the buffer size
+     * is big enough, we can widen to unicode without having to allocate
+     * more memory or call a character conversion function.
+     */
+    if (s->_count <= s->_capacity / 2) {
+        if (internalEncoding == NSISOLatin1StringEncoding || internalEncoding == NSASCIIStringEncoding) {
+            len = s->_count;
+            while (len-- > 0) {
+                s->_contents.u[len] = s->_contents.c[len];
+            }
+            s->_capacity /= 2;
+            s->_flags.wide = 1;
+            return;
+        }
     }
 
-  if (!s->_zone)
-    {
-      s->_zone = [(NSString*)s zone];
+    if (!s->_zone) {
+        s->_zone = [(NSString *)s zone];
     }
 
-  if (!GSToUnicode(&tmp, &len, s->_contents.c, s->_count,
-    internalEncoding, s->_zone, 0))
-    {
-      [NSException raise: NSInternalInconsistencyException
-		  format: @"widen of string failed"];
+    if (!GSToUnicode(&tmp, &len, s->_contents.c, s->_count,
+                     internalEncoding, s->_zone, 0)) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"widen of string failed"];
     }
-  if (s->_flags.owned == 1)
-    {
-      NSZoneFree(s->_zone, s->_contents.c);
+    if (s->_flags.owned == 1) {
+        NSZoneFree(s->_zone, s->_contents.c);
+    } else {
+        s->_flags.owned = 1;
     }
-  else
-    {
-      s->_flags.owned = 1;
-    }
-  s->_contents.u = tmp;
-  s->_flags.wide = 1;
-  s->_count = len;
-  s->_capacity = len;
+    s->_contents.u = tmp;
+    s->_flags.wide = 1;
+    s->_count = len;
+    s->_capacity = len;
 }
 
 static inline void
 makeHole(GSStr self, unsigned int index, unsigned int size)
 {
-  NSCAssert(size > 0, @"size < zero");
-  NSCAssert(index <= self->_count, @"index > length");
+    NSCAssert(size > 0, @"size < zero");
+    NSCAssert(index <= self->_count, @"index > length");
 
-  if (self->_count + size + 1 >= self->_capacity)
-    {
-      GSStrMakeSpace((GSStr)self, size);
+    if (self->_count + size + 1 >= self->_capacity) {
+        GSStrMakeSpace((GSStr)self, size);
     }
 
-  if (index < self->_count)
-    {
-      if (self->_flags.wide == 1)
-	{
-	  memmove(self->_contents.u + index + size,
-	    self->_contents.u + index,
-	    sizeof(unichar)*(self->_count - index));
-	}
-      else
-	{
-	  memmove(self->_contents.c + index + size,
-	    self->_contents.c + index,
-	    (self->_count - index));
-	}
+    if (index < self->_count) {
+        if (self->_flags.wide == 1) {
+            memmove(self->_contents.u + index + size,
+                    self->_contents.u + index,
+                    sizeof(unichar) * (self->_count - index));
+        } else {
+            memmove(self->_contents.c + index + size,
+                    self->_contents.c + index,
+                    (self->_count - index));
+        }
     }
 
-  self->_count += size;
-  self->_flags.hash = 0;
+    self->_count += size;
+    self->_flags.hash = 0;
 }
 
 static inline NSRange
 rangeOfSequence_c(GSStr self, unsigned anIndex)
 {
-  if (anIndex >= self->_count)
-    [NSException raise: NSRangeException format:@"Invalid location."];
+    if (anIndex >= self->_count)
+        [NSException raise:NSRangeException format:@"Invalid location."];
 
-  return (NSRange){anIndex, 1};
+    return (NSRange){anIndex, 1};
 }
 
 static inline NSRange
 rangeOfSequence_u(GSStr self, unsigned anIndex)
 {
-  unsigned	start;
-  unsigned	end;
+    unsigned start;
+    unsigned end;
 
-  if (anIndex >= self->_count)
-    [NSException raise: NSRangeException format:@"Invalid location."];
+    if (anIndex >= self->_count)
+        [NSException raise:NSRangeException format:@"Invalid location."];
 
-  start = anIndex;
-  while (uni_isnonsp(self->_contents.u[start]) && start > 0)
-    start--;
-  end = start + 1;
-  if (end < self->_count)
-    while ((end < self->_count) && (uni_isnonsp(self->_contents.u[end])))
-      end++;
-  return (NSRange){start, end-start};
+    start = anIndex;
+    while (uni_isnonsp(self->_contents.u[start]) && start > 0)
+        start--;
+    end = start + 1;
+    if (end < self->_count)
+        while ((end < self->_count) && (uni_isnonsp(self->_contents.u[end])))
+            end++;
+    return (NSRange){start, end - start};
 }
 
 static inline NSRange
 rangeOfCharacter_c(GSStr self, NSCharacterSet *aSet, unsigned mask,
-  NSRange aRange)
+                   NSRange aRange)
 {
-  int		i;
-  int		start;
-  int		stop;
-  int		step;
-  NSRange	range;
-  BOOL		(*mImp)(id, SEL, unichar);
+    int i;
+    int start;
+    int stop;
+    int step;
+    NSRange range;
+    BOOL (*mImp)
+    (id, SEL, unichar);
 
-  if (aSet == nil)
-    [NSException raise: NSInvalidArgumentException format: @"range of nil"];
+    if (aSet == nil)
+        [NSException raise:NSInvalidArgumentException format:@"range of nil"];
 
-  if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-    {
-      start = NSMaxRange(aRange) - 1;
-      stop = aRange.location - 1;
-      step = -1;
+    if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+        start = NSMaxRange(aRange) - 1;
+        stop = aRange.location - 1;
+        step = -1;
+    } else {
+        start = aRange.location;
+        stop = NSMaxRange(aRange);
+        step = 1;
     }
-  else
-    {
-      start = aRange.location;
-      stop = NSMaxRange(aRange);
-      step = 1;
-    }
-  range.location = NSNotFound;
-  range.length = 0;
+    range.location = NSNotFound;
+    range.length = 0;
 
-  mImp = (BOOL(*)(id,SEL,unichar))
-    [aSet methodForSelector: cMemberSel];
+    mImp = (BOOL(*)(id, SEL, unichar))
+        [aSet methodForSelector:cMemberSel];
 
-  for (i = start; i != stop; i += step)
-    {
-      unichar u = self->_contents.c[i];
+    for (i = start; i != stop; i += step) {
+        unichar u = self->_contents.c[i];
 
-      if (u > 127 && internalEncoding != NSISOLatin1StringEncoding)
-	{
-	  unsigned char	c = (unsigned char)u;
-	  unsigned int	s = 1;
-	  unichar	*d = &u;
+        if (u > 127 && internalEncoding != NSISOLatin1StringEncoding) {
+            unsigned char c = (unsigned char)u;
+            unsigned int s = 1;
+            unichar *d = &u;
 
-	  if (GSToUnicode(&d, &s, &c, 1, internalEncoding, 0, 0) == NO)
-            {
-              [NSException raise: NSInternalInconsistencyException
-                          format: @"unable to convert character to unicode"];
+            if (GSToUnicode(&d, &s, &c, 1, internalEncoding, 0, 0) == NO) {
+                [NSException raise:NSInternalInconsistencyException
+                            format:@"unable to convert character to unicode"];
             }
-	}
-      /* FIXME ... what about UTF-16 sequences of more than one 16bit value
-       * corresponding to a single UCS-32 codepoint?
-       */
-      if ((*mImp)(aSet, cMemberSel, u))
-	{
-	  range = NSMakeRange(i, 1);
-	  break;
-	}
+        }
+        /* FIXME ... what about UTF-16 sequences of more than one 16bit value
+         * corresponding to a single UCS-32 codepoint?
+         */
+        if ((*mImp)(aSet, cMemberSel, u)) {
+            range = NSMakeRange(i, 1);
+            break;
+        }
     }
 
-  return range;
+    return range;
 }
 
 static inline NSRange
 rangeOfCharacter_u(GSStr self, NSCharacterSet *aSet, unsigned mask,
-  NSRange aRange)
+                   NSRange aRange)
 {
-  int		i;
-  int		start;
-  int		stop;
-  int		step;
-  NSRange	range;
-  BOOL		(*mImp)(id, SEL, unichar);
+    int i;
+    int start;
+    int stop;
+    int step;
+    NSRange range;
+    BOOL (*mImp)
+    (id, SEL, unichar);
 
-  if (aSet == nil)
-    [NSException raise: NSInvalidArgumentException format: @"range of nil"];
+    if (aSet == nil)
+        [NSException raise:NSInvalidArgumentException format:@"range of nil"];
 
-  if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-    {
-      start = NSMaxRange(aRange) - 1;
-      stop = aRange.location - 1;
-      step = -1;
+    if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+        start = NSMaxRange(aRange) - 1;
+        stop = aRange.location - 1;
+        step = -1;
+    } else {
+        start = aRange.location;
+        stop = NSMaxRange(aRange);
+        step = 1;
     }
-  else
-    {
-      start = aRange.location;
-      stop = NSMaxRange(aRange);
-      step = 1;
-    }
-  range.location = NSNotFound;
-  range.length = 0;
+    range.location = NSNotFound;
+    range.length = 0;
 
-  mImp = (BOOL(*)(id,SEL,unichar))
-    [aSet methodForSelector: cMemberSel];
+    mImp = (BOOL(*)(id, SEL, unichar))
+        [aSet methodForSelector:cMemberSel];
 
-  /* FIXME ... what about UTF-16 sequences of more than one 16bit value
-   * corresponding to a single UCS-32 codepoint?
-   */
-  for (i = start; i != stop; i += step)
-    {
-      unichar letter = self->_contents.u[i];
+    /* FIXME ... what about UTF-16 sequences of more than one 16bit value
+     * corresponding to a single UCS-32 codepoint?
+     */
+    for (i = start; i != stop; i += step) {
+        unichar letter = self->_contents.u[i];
 
-      if ((*mImp)(aSet, cMemberSel, letter))
-	{
-	  range = NSMakeRange(i, 1);
-	  break;
-	}
+        if ((*mImp)(aSet, cMemberSel, letter)) {
+            range = NSMakeRange(i, 1);
+            break;
+        }
     }
 
-  return range;
+    return range;
 }
 
 GSRSFunc
 GSPrivateRangeOfString(NSString *receiver, NSString *target)
 {
-  Class	c;
+    Class c;
 
-  c = object_getClass(receiver);
-  if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES
-    || (c == GSMutableStringClass && ((GSStr)receiver)->_flags.wide == 1))
-    {
-      c = object_getClass(target);
-      if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES
-        || (c == GSMutableStringClass && ((GSStr)target)->_flags.wide == 1))
-        return (GSRSFunc)strRangeUsUs;
-      else if (GSObjCIsKindOf(c, GSCStringClass) == YES
-        || (c == GSMutableStringClass && ((GSStr)target)->_flags.wide == 0))
-        return (GSRSFunc)strRangeUsCs;
-      else
-        return (GSRSFunc)strRangeUsNs;
-    }
-  else if (GSObjCIsKindOf(c, GSCStringClass) == YES
-    || (c == GSMutableStringClass && ((GSStr)receiver)->_flags.wide == 0))
-    {
-      c = object_getClass(target);
-      if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES
-        || (c == GSMutableStringClass && ((GSStr)target)->_flags.wide == 1))
-        return (GSRSFunc)strRangeCsUs;
-      else if (GSObjCIsKindOf(c, GSCStringClass) == YES
-        || (c == GSMutableStringClass && ((GSStr)target)->_flags.wide == 0))
-        return (GSRSFunc)strRangeCsCs;
-      else
-        return (GSRSFunc)strRangeCsNs;
-    }
-  else
-    {
-      return (GSRSFunc)strRangeNsNs;
+    c = object_getClass(receiver);
+    if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES || (c == GSMutableStringClass && ((GSStr)receiver)->_flags.wide == 1)) {
+        c = object_getClass(target);
+        if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES || (c == GSMutableStringClass && ((GSStr)target)->_flags.wide == 1))
+            return (GSRSFunc)strRangeUsUs;
+        else if (GSObjCIsKindOf(c, GSCStringClass) == YES || (c == GSMutableStringClass && ((GSStr)target)->_flags.wide == 0))
+            return (GSRSFunc)strRangeUsCs;
+        else
+            return (GSRSFunc)strRangeUsNs;
+    } else if (GSObjCIsKindOf(c, GSCStringClass) == YES || (c == GSMutableStringClass && ((GSStr)receiver)->_flags.wide == 0)) {
+        c = object_getClass(target);
+        if (GSObjCIsKindOf(c, GSUnicodeStringClass) == YES || (c == GSMutableStringClass && ((GSStr)target)->_flags.wide == 1))
+            return (GSRSFunc)strRangeCsUs;
+        else if (GSObjCIsKindOf(c, GSCStringClass) == YES || (c == GSMutableStringClass && ((GSStr)target)->_flags.wide == 0))
+            return (GSRSFunc)strRangeCsCs;
+        else
+            return (GSRSFunc)strRangeCsNs;
+    } else {
+        return (GSRSFunc)strRangeNsNs;
     }
 }
 
-static inline NSString*
+static inline NSString *
 substring_c(GSStr self, NSRange aRange)
 {
-  GSCSubString	*o;
+    GSCSubString *o;
 
-  if (aRange.length == 0)
-    {
-      return @"";
+    if (aRange.length == 0) {
+        return @"";
     }
-  o = (__typeof__(o))NSAllocateObject(GSCSubStringClass,
-    0, NSDefaultMallocZone());
-  o->_contents.c = self->_contents.c + aRange.location;
-  o->_count = aRange.length;
-  o->_flags.wide = 0;
-  o->_flags.owned = 0;
-  ASSIGN(o->_parent, (id)self);
-  return AUTORELEASE((id)o);
+    o = (__typeof__(o))NSAllocateObject(GSCSubStringClass,
+                                        0, NSDefaultMallocZone());
+    o->_contents.c = self->_contents.c + aRange.location;
+    o->_count = aRange.length;
+    o->_flags.wide = 0;
+    o->_flags.owned = 0;
+    ASSIGN(o->_parent, (id)self);
+    return AUTORELEASE((id)o);
 }
 
-static inline NSString*
+static inline NSString *
 substring_u(GSStr self, NSRange aRange)
 {
-  GSCSubString	*o;
+    GSCSubString *o;
 
-  if (aRange.length == 0)
-    {
-      return @"";
+    if (aRange.length == 0) {
+        return @"";
     }
-  o = (__typeof__(o))NSAllocateObject(GSUnicodeSubStringClass,
-    0, NSDefaultMallocZone());
-  o->_contents.u = self->_contents.u + aRange.location;
-  o->_count = aRange.length;
-  o->_flags.wide = 1;
-  o->_flags.owned = 0;
-  ASSIGN(o->_parent, (id)self);
-  return AUTORELEASE((id)o);
+    o = (__typeof__(o))NSAllocateObject(GSUnicodeSubStringClass,
+                                        0, NSDefaultMallocZone());
+    o->_contents.u = self->_contents.u + aRange.location;
+    o->_count = aRange.length;
+    o->_flags.wide = 1;
+    o->_flags.owned = 0;
+    ASSIGN(o->_parent, (id)self);
+    return AUTORELEASE((id)o);
 }
 
 /* Function to examine the given string and see if it is one of our concrete
@@ -3435,82 +2968,65 @@ substring_u(GSStr self, NSRange aRange)
 static inline GSStr
 transmute(GSStr self, NSString *aString)
 {
-  GSStr	other = (GSStr)aString;
-  BOOL	transmute = YES;
-  Class	c = object_getClass(aString);	// NB aString must not be nil
+    GSStr other = (GSStr)aString;
+    BOOL transmute = YES;
+    Class c = object_getClass(aString); // NB aString must not be nil
 
-  /* If the string is an immutable proxy to a mutable string, we want to
-   * access the original (which we won't modify) for better performance.
-   */
-  if (c == GSImmutableStringClass)
-    {
-      aString = object_getIvar(aString, immutableIvar);
-      other = (GSStr)aString;
-      c = object_getClass(aString);
+    /* If the string is an immutable proxy to a mutable string, we want to
+     * access the original (which we won't modify) for better performance.
+     */
+    if (c == GSImmutableStringClass) {
+        aString = object_getIvar(aString, immutableIvar);
+        other = (GSStr)aString;
+        c = object_getClass(aString);
     }
 
-  if (self->_flags.wide == 1)
-    {
-      /* This is already a unicode string, so we don't need to transmute,
-       * but we still need to know if the other string is a unicode
-       * string whose GSStr we can access directly.
-       */
-      transmute = NO;
-      if (GSObjCIsKindOf(c, GSUnicodeStringClass) == NO
-	&& (c != GSMutableStringClass || other->_flags.wide != 1))
-	{
-	  other = 0;
-	}
-    }
-  else
-    {
-      /* This is a string held in the internal 8-bit encoding.
-       */
-      if (GSObjCIsKindOf(c, GSCStringClass)
-	|| (c == GSMutableStringClass && other->_flags.wide == 0))
-	{
-	  /* The other string is also held in the internal 8-bit encoding,
-	   * so we don't need to transmute, and we can use its GSStr.
-	   */
-	  transmute = NO;
-	}
-      else if ([aString canBeConvertedToEncoding: internalEncoding] == YES)
-	{
-	  /* The other string can be converted to the internal 8-bit encoding,
-	   * so we don't need to transmute, but we can *not* use its GSStr.
-	   */
-	  transmute = NO;
-	  other = 0;
-	}
-      else if ((c == GSMutableStringClass && other->_flags.wide == 1)
-	|| GSObjCIsKindOf(c, GSUnicodeStringClass) == YES)
-	{
-	  /* The other string can not be converted to the internal 8-bit
-	   * encoding, so we need to transmute, and will then be able to
-	   * use its GSStr.
-	   */
-	  transmute = YES;
-	}
-      else
-	{
-	  /* The other string can not be converted to the internal 8-bit
-	   * character string, so we need to transmute, but even then we
-	   * will not be able to use the other strings GSStr because that
-	   * string is not a known GSString subclass.
-	   */
-	  other = 0;
-	}
+    if (self->_flags.wide == 1) {
+        /* This is already a unicode string, so we don't need to transmute,
+         * but we still need to know if the other string is a unicode
+         * string whose GSStr we can access directly.
+         */
+        transmute = NO;
+        if (GSObjCIsKindOf(c, GSUnicodeStringClass) == NO && (c != GSMutableStringClass || other->_flags.wide != 1)) {
+            other = 0;
+        }
+    } else {
+        /* This is a string held in the internal 8-bit encoding.
+         */
+        if (GSObjCIsKindOf(c, GSCStringClass) || (c == GSMutableStringClass && other->_flags.wide == 0)) {
+            /* The other string is also held in the internal 8-bit encoding,
+             * so we don't need to transmute, and we can use its GSStr.
+             */
+            transmute = NO;
+        } else if ([aString canBeConvertedToEncoding:internalEncoding] == YES) {
+            /* The other string can be converted to the internal 8-bit encoding,
+             * so we don't need to transmute, but we can *not* use its GSStr.
+             */
+            transmute = NO;
+            other = 0;
+        } else if ((c == GSMutableStringClass && other->_flags.wide == 1) || GSObjCIsKindOf(c, GSUnicodeStringClass) == YES) {
+            /* The other string can not be converted to the internal 8-bit
+             * encoding, so we need to transmute, and will then be able to
+             * use its GSStr.
+             */
+            transmute = YES;
+        } else {
+            /* The other string can not be converted to the internal 8-bit
+             * character string, so we need to transmute, but even then we
+             * will not be able to use the other strings GSStr because that
+             * string is not a known GSString subclass.
+             */
+            other = 0;
+        }
     }
 
-  if (transmute == YES)
-    {
-      GSStrWiden((GSStr)self);
+    if (transmute == YES) {
+        GSStrWiden((GSStr)self);
     }
 
-  return other;
+    return other;
 }
 
-
 
 /*
  * The GSString class is actually only provided to provide a common ivar
@@ -3522,897 +3038,838 @@ transmute(GSStr self, NSString *aString)
  */
 @implementation GSString
 
-+ (void) initialize
++ (void)initialize
 {
-  setup(NO);
+    setup(NO);
 }
 
-+ (void) reinitialize
++ (void)reinitialize
 {
-  setup(YES);
+    setup(YES);
 }
 
 /*
  * Return a 28-bit hash value for the string contents - this
  * MUST match the algorithm used by the NSString base class.
  */
-- (NSUInteger) hash
+- (NSUInteger)hash
 {
-  if (self->_flags.hash == 0)
-    {
-      uint32_t	ret = 0;
-      int	len = (int)self->_count;
+    if (self->_flags.hash == 0) {
+        uint32_t ret = 0;
+        int len = (int)self->_count;
 
-      if (len > 0)
-	{
-	  if (self->_flags.wide)
-	    {
-	      const unichar	*p = self->_contents.u;
+        if (len > 0) {
+            if (self->_flags.wide) {
+                const unichar *p = self->_contents.u;
 
-              ret = GSPrivateHash(0, p, len * sizeof(unichar));
-	    }
-	  else if (len > 64)
-            {
-              return (self->_flags.hash = [super hash]);
-            }
-          else
-	    {
-              unichar                   buf[64];
-              unsigned	                index;
-	      const unsigned char	*p = self->_contents.c;
+                ret = GSPrivateHash(0, p, len * sizeof(unichar));
+            } else if (len > 64) {
+                return (self->_flags.hash = [super hash]);
+            } else {
+                unichar buf[64];
+                unsigned index;
+                const unsigned char *p = self->_contents.c;
 
-	      if (internalEncoding == NSISOLatin1StringEncoding)
-		{
-                  for (index = 0; index < len; index++)
-                    {
-                      buf[index] = p[index];
+                if (internalEncoding == NSISOLatin1StringEncoding) {
+                    for (index = 0; index < len; index++) {
+                        buf[index] = p[index];
+                    }
+                } else {
+                    for (index = 0; index < len; index++) {
+                        unichar u = p[index];
+
+                        if (u > 127) {
+                            return (self->_flags.hash = [super hash]);
+                        }
+                        buf[index] = u;
                     }
                 }
-	      else
-		{
-                  for (index = 0; index < len; index++)
-                    {
-		      unichar	u = p[index];
+                ret = GSPrivateHash(0, buf, len * sizeof(unichar));
+            }
 
-                      if (u > 127)
-                        {
-                          return (self->_flags.hash = [super hash]);
-                        }
-                      buf[index] = u;
-                    }
-		}
-              ret = GSPrivateHash(0, buf, len * sizeof(unichar));
-	    }
-
-	  /*
-	   * The hash caching in our concrete string classes uses zero to denote
-	   * an empty cache value, so we MUST NOT return a hash of zero.
-	   */
-	  ret &= 0x0fffffff;
-	  if (ret == 0)
-	    {
-	      ret = 0x0fffffff;
-	    }
-	}
-      else
-	{
-	  ret = 0x0ffffffe;	/* Hash for an empty string.	*/
-	}
-      self->_flags.hash = ret;
+            /*
+             * The hash caching in our concrete string classes uses zero to denote
+             * an empty cache value, so we MUST NOT return a hash of zero.
+             */
+            ret &= 0x0fffffff;
+            if (ret == 0) {
+                ret = 0x0fffffff;
+            }
+        } else {
+            ret = 0x0ffffffe; /* Hash for an empty string.	*/
+        }
+        self->_flags.hash = ret;
     }
 
-  return self->_flags.hash;
+    return self->_flags.hash;
 }
 
-- (id) initWithBytesNoCopy: (void*)chars
-		    length: (NSUInteger)length
-		  encoding: (NSStringEncoding)encoding
-	      freeWhenDone: (BOOL)flag
+- (id)initWithBytesNoCopy:(void *)chars
+                   length:(NSUInteger)length
+                 encoding:(NSStringEncoding)encoding
+             freeWhenDone:(BOOL)flag
 {
-  NSString	*c = NSStringFromClass([self class]);
-  NSString	*s = NSStringFromSelector(_cmd);
+    NSString *c = NSStringFromClass([self class]);
+    NSString *s = NSStringFromSelector(_cmd);
 
-  DESTROY(self);
-  [NSException raise: NSInternalInconsistencyException
-	      format: @"[%@-%@] called on string already initialised", c, s];
-  return nil;
+    DESTROY(self);
+    [NSException raise:NSInternalInconsistencyException
+                format:@"[%@-%@] called on string already initialised", c, s];
+    return nil;
 }
 
-- (BOOL) makeImmutable
+- (BOOL)makeImmutable
 {
-  return YES;
+    return YES;
 }
 
-- (NSUInteger) sizeInBytesExcluding: (NSHashTable*)exclude
+- (NSUInteger)sizeInBytesExcluding:(NSHashTable *)exclude
 {
-  NSUInteger    size = GSPrivateMemorySize(self, exclude);
+    NSUInteger size = GSPrivateMemorySize(self, exclude);
 
-  if (size > 0 && _flags.owned)
-    {
-      size += _count;
-      if (_flags.wide)
-        {
-          size += _count;
+    if (size > 0 && _flags.owned) {
+        size += _count;
+        if (_flags.wide) {
+            size += _count;
         }
     }
-  return size;
+    return size;
 }
 
 @end
 
-
 
 @implementation GSCString
 
-- (BOOL) boolValue
+- (BOOL)boolValue
 {
-  return boolValue_c((GSStr)self);
+    return boolValue_c((GSStr)self);
 }
 
-- (BOOL) canBeConvertedToEncoding: (NSStringEncoding)enc
+- (BOOL)canBeConvertedToEncoding:(NSStringEncoding)enc
 {
-  return canBeConvertedToEncoding_c((GSStr)self, enc);
+    return canBeConvertedToEncoding_c((GSStr)self, enc);
 }
 
-- (unichar) characterAtIndex: (NSUInteger)index
+- (unichar)characterAtIndex:(NSUInteger)index
 {
-  return characterAtIndex_c((GSStr)self, index);
+    return characterAtIndex_c((GSStr)self, index);
 }
 
-- (NSComparisonResult) compare: (NSString*)aString
-		       options: (NSUInteger)mask
-			 range: (NSRange)aRange
+- (NSComparisonResult)compare:(NSString *)aString
+                      options:(NSUInteger)mask
+                        range:(NSRange)aRange
 {
-  if (mask & NSNumericSearch)
-    {
-      return [super compare: aString options: mask range: aRange];
+    if (mask & NSNumericSearch) {
+        return [super compare:aString options:mask range:aRange];
     }
-  GS_RANGE_CHECK(aRange, _count);
-  if (aString == nil)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] nil string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
-  if (GSObjCIsInstance(aString) == NO)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] not a string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
-  return compare_c((GSStr)self, aString, mask, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    if (aString == nil)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[%@ -%@] nil string argument",
+                           NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    if (GSObjCIsInstance(aString) == NO)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[%@ -%@] not a string argument",
+                           NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    return compare_c((GSStr)self, aString, mask, aRange);
 }
 
 /*
 Default copy implementation. Retain if we own the buffer and the zones
 agree, create a new GSCInlineString otherwise.
 */
-- (id) copyWithZone: (NSZone*)z
+- (id)copyWithZone:(NSZone *)z
 {
-  if (!_flags.owned || NSShouldRetainWithZone(self, z) == NO)
-    {
-      GSCInlineString   *me = newCInline(_count, z);
+    if (!_flags.owned || NSShouldRetainWithZone(self, z) == NO) {
+        GSCInlineString *me = newCInline(_count, z);
 
-      memcpy(me->_contents.c, _contents.c, _count);
-      return me;
-    }
-  else
-    {
-      return RETAIN(self);
+        memcpy(me->_contents.c, _contents.c, _count);
+        return me;
+    } else {
+        return RETAIN(self);
     }
 }
 
-- (const char *) cString
+- (const char *)cString
 {
-  return cString_c((GSStr)self, externalEncoding);
+    return cString_c((GSStr)self, externalEncoding);
 }
 
-- (const char *) cStringUsingEncoding: (NSStringEncoding)encoding
+- (const char *)cStringUsingEncoding:(NSStringEncoding)encoding
 {
-  return cString_c((GSStr)self, encoding);
+    return cString_c((GSStr)self, encoding);
 }
 
-- (NSUInteger) cStringLength
+- (NSUInteger)cStringLength
 {
-  return cStringLength_c((GSStr)self, externalEncoding);
+    return cStringLength_c((GSStr)self, externalEncoding);
 }
 
-- (void) encodeWithCoder: (NSCoder*)aCoder
+- (void)encodeWithCoder:(NSCoder *)aCoder
 {
-  if ([aCoder allowsKeyedCoding])
-    {
-      [(NSKeyedArchiver*)aCoder _encodePropertyList: self forKey: @"NS.string"];
-      return;
+    if ([aCoder allowsKeyedCoding]) {
+        [(NSKeyedArchiver *)aCoder _encodePropertyList:self forKey:@"NS.string"];
+        return;
     }
 
-  [aCoder encodeValueOfObjCType: @encode(unsigned) at: &_count];
-  if (_count > 0)
-    {
-      [aCoder encodeValueOfObjCType: @encode(int)
-				 at: &internalEncoding];
-      [aCoder encodeArrayOfObjCType: @encode(unsigned char)
-			      count: _count
-				 at: _contents.c];
+    [aCoder encodeValueOfObjCType:@encode(unsigned) at:&_count];
+    if (_count > 0) {
+        [aCoder encodeValueOfObjCType:@encode(int)
+                                   at:&internalEncoding];
+        [aCoder encodeArrayOfObjCType:@encode(unsigned char)
+                                count:_count
+                                   at:_contents.c];
     }
 }
 
-- (NSStringEncoding) fastestEncoding
+- (NSStringEncoding)fastestEncoding
 {
-  return internalEncoding;
+    return internalEncoding;
 }
 
-- (void) getCharacters: (unichar*)buffer
+- (void)getCharacters:(unichar *)buffer
 {
-  getCharacters_c((GSStr)self, buffer, (NSRange){0, _count});
+    getCharacters_c((GSStr)self, buffer, (NSRange){0, _count});
 }
 
-- (void) getCharacters: (unichar*)buffer range: (NSRange)aRange
+- (void)getCharacters:(unichar *)buffer range:(NSRange)aRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  getCharacters_c((GSStr)self, buffer, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    getCharacters_c((GSStr)self, buffer, aRange);
 }
 
 - (void) getCString: (char*)buffer
 {
-  getCString_c((GSStr)self, buffer, NSMaximumStringLength,
-    (NSRange){0, _count}, 0);
+    getCString_c((GSStr)self, buffer, NSMaximumStringLength,
+                 (NSRange){0, _count}, 0);
 }
 
-- (void) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
+- (void)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
 {
-  getCString_c((GSStr)self, buffer, maxLength, (NSRange){0, _count}, 0);
+    getCString_c((GSStr)self, buffer, maxLength, (NSRange){0, _count}, 0);
 }
 
-- (BOOL) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	   encoding: (NSStringEncoding)encoding
+- (BOOL)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+          encoding:(NSStringEncoding)encoding
 {
-  return getCStringE_c((GSStr)self, buffer, maxLength, encoding);
+    return getCStringE_c((GSStr)self, buffer, maxLength, encoding);
 }
 
-- (void) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	      range: (NSRange)aRange
-     remainingRange: (NSRange*)leftoverRange
+- (void)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+             range:(NSRange)aRange
+    remainingRange:(NSRange *)leftoverRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  getCString_c((GSStr)self, buffer, maxLength, aRange, leftoverRange);
+    GS_RANGE_CHECK(aRange, _count);
+    getCString_c((GSStr)self, buffer, maxLength, aRange, leftoverRange);
 }
 
-- (int) intValue
+- (int)intValue
 {
-  char  buf[24];
+    char buf[24];
 
-  intBuf_c((GSStr)self, buf);
-  return strtol(buf, 0, 10);
+    intBuf_c((GSStr)self, buf);
+    return strtol(buf, 0, 10);
 }
 
-- (NSInteger) integerValue
+- (NSInteger)integerValue
 {
-  char  buf[24];
+    char buf[24];
 
-  intBuf_c((GSStr)self, buf);
+    intBuf_c((GSStr)self, buf);
 #if GS_SIZEOF_VOIDP == GS_SIZEOF_LONG
-  return strtol(buf, 0, 10);
+    return strtol(buf, 0, 10);
 #else
-  return strtoll(buf, 0, 10);
+    return strtoll(buf, 0, 10);
 #endif
 }
 
-- (BOOL) isEqual: (id)anObject
+- (BOOL)isEqual:(id)anObject
 {
-  return isEqual_c((GSStr)self, anObject);
+    return isEqual_c((GSStr)self, anObject);
 }
 
-- (BOOL) isEqualToString: (NSString*)anObject
+- (BOOL)isEqualToString:(NSString *)anObject
 {
-  return isEqual_c((GSStr)self, anObject);
+    return isEqual_c((GSStr)self, anObject);
 }
 
-- (NSUInteger) length
+- (NSUInteger)length
 {
-  return _count;
+    return _count;
 }
 
-- (NSUInteger) lengthOfBytesUsingEncoding: (NSStringEncoding)encoding
+- (NSUInteger)lengthOfBytesUsingEncoding:(NSStringEncoding)encoding
 {
-  return cStringLength_c((GSStr)self, encoding);
+    return cStringLength_c((GSStr)self, encoding);
 }
 
-- (long long) longLongValue
+- (long long)longLongValue
 {
-  char  buf[24];
+    char buf[24];
 
-  intBuf_c((GSStr)self, buf);
-  return strtoll(buf, 0, 10);
+    intBuf_c((GSStr)self, buf);
+    return strtoll(buf, 0, 10);
 }
 
-- (const char*) lossyCString
+- (const char *)lossyCString
 {
-  return lossyCString_c((GSStr)self);
+    return lossyCString_c((GSStr)self);
 }
 
-- (id) mutableCopy
+- (id)mutableCopy
 {
-  GSMutableString	*obj;
+    GSMutableString *obj;
 
-  obj = (GSMutableString*)NSAllocateObject(GSMutableStringClass, 0,
-    NSDefaultMallocZone());
-  obj = [obj initWithBytes: (char*)_contents.c
-		    length: _count
-		  encoding: internalEncoding];
-  return obj;
+    obj = (GSMutableString *)NSAllocateObject(GSMutableStringClass, 0,
+                                              NSDefaultMallocZone());
+    obj = [obj initWithBytes:(char *)_contents.c
+                      length:_count
+                    encoding:internalEncoding];
+    return obj;
 }
 
-- (id) mutableCopyWithZone: (NSZone*)z
+- (id)mutableCopyWithZone:(NSZone *)z
 {
-  GSMutableString	*obj;
+    GSMutableString *obj;
 
-  obj = (GSMutableString*)NSAllocateObject(GSMutableStringClass, 0, z);
-  obj = [obj initWithBytes: (char*)_contents.c
-		    length: _count
-		  encoding: internalEncoding];
-  return obj;
+    obj = (GSMutableString *)NSAllocateObject(GSMutableStringClass, 0, z);
+    obj = [obj initWithBytes:(char *)_contents.c
+                      length:_count
+                    encoding:internalEncoding];
+    return obj;
 }
 
-- (NSRange) rangeOfComposedCharacterSequenceAtIndex: (NSUInteger)anIndex
+- (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
 {
-  return rangeOfSequence_c((GSStr)self, anIndex);
+    return rangeOfSequence_c((GSStr)self, anIndex);
 }
 
-- (NSRange) rangeOfCharacterFromSet: (NSCharacterSet*)aSet
-			    options: (NSUInteger)mask
-			      range: (NSRange)aRange
+- (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+                           options:(NSUInteger)mask
+                             range:(NSRange)aRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  return rangeOfCharacter_c((GSStr)self, aSet, mask, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    return rangeOfCharacter_c((GSStr)self, aSet, mask, aRange);
 }
 
-- (NSStringEncoding) smallestEncoding
+- (NSStringEncoding)smallestEncoding
 {
-  return internalEncoding;
+    return internalEncoding;
 }
 
-- (NSString*) substringFromRange: (NSRange)aRange
+- (NSString *)substringFromRange:(NSRange)aRange
 {
-  if (!_flags.wide)
-    {
-      id tinyString;
+    if (!_flags.wide) {
+        id tinyString;
 
-      tinyString = createTinyString((char*)_contents.c + aRange.location,
-        aRange.length);
-      if (tinyString)
-        {
-          return tinyString;
+        tinyString = createTinyString((char *)_contents.c + aRange.location,
+                                      aRange.length);
+        if (tinyString) {
+            return tinyString;
         }
     }
-  if (_flags.owned)
-    {
-      GS_RANGE_CHECK(aRange, _count);
-      return substring_c((GSStr)self, aRange);
+    if (_flags.owned) {
+        GS_RANGE_CHECK(aRange, _count);
+        return substring_c((GSStr)self, aRange);
     }
-  return [super substringWithRange: aRange];
+    return [super substringWithRange:aRange];
 }
 
-- (NSString*) substringWithRange: (NSRange)aRange
+- (NSString *)substringWithRange:(NSRange)aRange
 {
-  if (_flags.owned)
-    {
-      GS_RANGE_CHECK(aRange, _count);
-      return substring_c((GSStr)self, aRange);
+    if (_flags.owned) {
+        GS_RANGE_CHECK(aRange, _count);
+        return substring_c((GSStr)self, aRange);
     }
-  if (!_flags.wide)
-    {
-      id tinyString;
+    if (!_flags.wide) {
+        id tinyString;
 
-      tinyString = createTinyString((char*)_contents.c + aRange.location,
-        aRange.length);
-      if (tinyString)
-        {
-          return tinyString;
+        tinyString = createTinyString((char *)_contents.c + aRange.location,
+                                      aRange.length);
+        if (tinyString) {
+            return tinyString;
         }
     }
-  return [super substringWithRange: aRange];
+    return [super substringWithRange:aRange];
 }
 
-- (const char *) UTF8String
+- (const char *)UTF8String
 {
-  return UTF8String_c((GSStr)self);
+    return UTF8String_c((GSStr)self);
 }
 
 // private method for Unicode level 3 implementation
-- (int) _baseLength
+- (int)_baseLength
 {
-  return _count;
+    return _count;
 }
 
 @end
 
-
 
 @implementation GSCBufferString
-- (void) dealloc
+- (void)dealloc
 {
-  if (_contents.c != 0)
-    {
-      if (_flags.owned)
-	{
-	  NSZoneFree(NSZoneFromPointer(_contents.c), _contents.c);
+    if (_contents.c != 0) {
+        if (_flags.owned) {
+            NSZoneFree(NSZoneFromPointer(_contents.c), _contents.c);
         }
-      _contents.c = 0;
+        _contents.c = 0;
     }
-  [super dealloc];
+    [super dealloc];
 }
 @end
 
-
 
-@implementation	GSCInlineString
-- (NSUInteger) sizeOfContentExcluding: (NSHashTable*)exclude
+@implementation GSCInlineString
+- (NSUInteger)sizeOfContentExcluding:(NSHashTable *)exclude
 {
-  return 0;	// Inline string content uses no heap
+    return 0; // Inline string content uses no heap
 }
-- (NSUInteger) sizeOfInstance
+- (NSUInteger)sizeOfInstance
 {
-  NSUInteger    size;
+    NSUInteger size;
 
-#if     HAVE_MALLOC_USABLE_SIZE
-  size = malloc_usable_size((void*)self - sizeof(intptr_t));
+#if HAVE_MALLOC_USABLE_SIZE
+    size = malloc_usable_size((void *)self - sizeof(intptr_t));
 #else
-  size = class_getInstanceSize(GSCInlineStringClass);
-  size += _count;
+    size = class_getInstanceSize(GSCInlineStringClass);
+    size += _count;
 #endif
-  return size;
+    return size;
 }
 @end
 
-
 
-@implementation	GSCSubString
+@implementation GSCSubString
 
 /*
  * Assume that a copy should be a new string, never just a retained substring.
  */
-- (id) copyWithZone: (NSZone*)z
+- (id)copyWithZone:(NSZone *)z
 {
-  GSCInlineString *o;
+    GSCInlineString *o;
 
-  o = newCInline(_count, z);
-  memcpy(o->_contents.c, _contents.c, _count);
-  return (id)o;
+    o = newCInline(_count, z);
+    memcpy(o->_contents.c, _contents.c, _count);
+    return (id)o;
 }
 
-- (void) dealloc
+- (void)dealloc
 {
-  DESTROY(_parent);
-  [super dealloc];
+    DESTROY(_parent);
+    [super dealloc];
 }
 
-- (NSString*) substringFromRange: (NSRange)aRange
+- (NSString *)substringFromRange:(NSRange)aRange
 {
-  id    s;
+    id s;
 
-  GS_RANGE_CHECK(aRange, _count);
-  s = createTinyString((char*)_contents.c + aRange.location, aRange.length);
-  if (nil == s)
-    {
-      aRange.location += (_contents.c - _parent->_contents.c);
-      s = substring_c((GSStr)_parent, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    s = createTinyString((char *)_contents.c + aRange.location, aRange.length);
+    if (nil == s) {
+        aRange.location += (_contents.c - _parent->_contents.c);
+        s = substring_c((GSStr)_parent, aRange);
     }
-  return s;
+    return s;
 }
 
-- (NSString*) substringWithRange: (NSRange)aRange
+- (NSString *)substringWithRange:(NSRange)aRange
 {
-  id    s;
+    id s;
 
-  GS_RANGE_CHECK(aRange, _count);
-  s = createTinyString((char*)_contents.c + aRange.location, aRange.length);
-  if (nil == s)
-    {
-      aRange.location += (_contents.c - _parent->_contents.c);
-      s = substring_c((GSStr)_parent, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    s = createTinyString((char *)_contents.c + aRange.location, aRange.length);
+    if (nil == s) {
+        aRange.location += (_contents.c - _parent->_contents.c);
+        s = substring_c((GSStr)_parent, aRange);
     }
-  return s;
+    return s;
 }
 
 @end
 
-
 
 @implementation GSUnicodeString
-- (const char *) UTF8String
+- (const char *)UTF8String
 {
-  return UTF8String_u((GSStr)self);
+    return UTF8String_u((GSStr)self);
 }
 
-- (BOOL) boolValue
+- (BOOL)boolValue
 {
-  return boolValue_u((GSStr)self);
+    return boolValue_u((GSStr)self);
 }
 
-- (BOOL) canBeConvertedToEncoding: (NSStringEncoding)enc
+- (BOOL)canBeConvertedToEncoding:(NSStringEncoding)enc
 {
-  return canBeConvertedToEncoding_u((GSStr)self, enc);
+    return canBeConvertedToEncoding_u((GSStr)self, enc);
 }
 
-- (unichar) characterAtIndex: (NSUInteger)index
+- (unichar)characterAtIndex:(NSUInteger)index
 {
-  return characterAtIndex_u((GSStr)self, index);
+    return characterAtIndex_u((GSStr)self, index);
 }
 
-- (NSComparisonResult) compare: (NSString*)aString
-		       options: (NSUInteger)mask
-			 range: (NSRange)aRange
+- (NSComparisonResult)compare:(NSString *)aString
+                      options:(NSUInteger)mask
+                        range:(NSRange)aRange
 {
-  if (mask & NSNumericSearch)
-    {
-      return [super compare: aString options: mask range: aRange];
+    if (mask & NSNumericSearch) {
+        return [super compare:aString options:mask range:aRange];
     }
-  GS_RANGE_CHECK(aRange, _count);
-  if (aString == nil)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] nil string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
-  if (GSObjCIsInstance(aString) == NO)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] not a string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
-  return compare_u((GSStr)self, aString, mask, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    if (aString == nil)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[%@ -%@] nil string argument",
+                           NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    if (GSObjCIsInstance(aString) == NO)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[%@ -%@] not a string argument",
+                           NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    return compare_u((GSStr)self, aString, mask, aRange);
 }
 
-- (const char *) cString
+- (const char *)cString
 {
-  return cString_u((GSStr)self, externalEncoding);
+    return cString_u((GSStr)self, externalEncoding);
 }
 
-- (const char *) cStringUsingEncoding: (NSStringEncoding)encoding
+- (const char *)cStringUsingEncoding:(NSStringEncoding)encoding
 {
-  return cString_u((GSStr)self, encoding);
+    return cString_u((GSStr)self, encoding);
 }
 
-- (NSUInteger) cStringLength
+- (NSUInteger)cStringLength
 {
-  return cStringLength_u((GSStr)self, externalEncoding);
+    return cStringLength_u((GSStr)self, externalEncoding);
 }
 
-- (void) encodeWithCoder: (NSCoder*)aCoder
+- (void)encodeWithCoder:(NSCoder *)aCoder
 {
-  if ([aCoder allowsKeyedCoding])
-    {
-      [(NSKeyedArchiver*)aCoder _encodePropertyList: self forKey: @"NS.string"];
-      return;
+    if ([aCoder allowsKeyedCoding]) {
+        [(NSKeyedArchiver *)aCoder _encodePropertyList:self forKey:@"NS.string"];
+        return;
     }
 
-  [aCoder encodeValueOfObjCType: @encode(unsigned) at: &_count];
-  if (_count > 0)
-    {
-      NSStringEncoding	enc = NSUnicodeStringEncoding;
+    [aCoder encodeValueOfObjCType:@encode(unsigned) at:&_count];
+    if (_count > 0) {
+        NSStringEncoding enc = NSUnicodeStringEncoding;
 
-      [aCoder encodeValueOfObjCType: @encode(int) at: &enc];
-      [aCoder encodeArrayOfObjCType: @encode(unichar)
-			      count: _count
-				 at: _contents.u];
+        [aCoder encodeValueOfObjCType:@encode(int) at:&enc];
+        [aCoder encodeArrayOfObjCType:@encode(unichar)
+                                count:_count
+                                   at:_contents.u];
     }
 }
 
-- (NSStringEncoding) fastestEncoding
+- (NSStringEncoding)fastestEncoding
 {
-  return NSUnicodeStringEncoding;
+    return NSUnicodeStringEncoding;
 }
 
-- (void) getCharacters: (unichar*)buffer
+- (void)getCharacters:(unichar *)buffer
 {
-  getCharacters_u((GSStr)self, buffer, (NSRange){0, _count});
+    getCharacters_u((GSStr)self, buffer, (NSRange){0, _count});
 }
 
-- (void) getCharacters: (unichar*)buffer range: (NSRange)aRange
+- (void)getCharacters:(unichar *)buffer range:(NSRange)aRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  getCharacters_u((GSStr)self, buffer, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    getCharacters_u((GSStr)self, buffer, aRange);
 }
 
 - (void) getCString: (char*)buffer
 {
-  getCString_u((GSStr)self, buffer, NSMaximumStringLength,
-    (NSRange){0, _count}, 0);
+    getCString_u((GSStr)self, buffer, NSMaximumStringLength,
+                 (NSRange){0, _count}, 0);
 }
 
-- (void) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
+- (void)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
 {
-  getCString_u((GSStr)self, buffer, maxLength, (NSRange){0, _count}, 0);
+    getCString_u((GSStr)self, buffer, maxLength, (NSRange){0, _count}, 0);
 }
 
-- (BOOL) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	   encoding: (NSStringEncoding)encoding
+- (BOOL)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+          encoding:(NSStringEncoding)encoding
 {
-  return getCStringE_u((GSStr)self, buffer, maxLength, encoding);
+    return getCStringE_u((GSStr)self, buffer, maxLength, encoding);
 }
 
-- (void) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	      range: (NSRange)aRange
-     remainingRange: (NSRange*)leftoverRange
+- (void)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+             range:(NSRange)aRange
+    remainingRange:(NSRange *)leftoverRange
 {
-  GS_RANGE_CHECK(aRange, _count);
+    GS_RANGE_CHECK(aRange, _count);
 
-  getCString_u((GSStr)self, buffer, maxLength, aRange, leftoverRange);
+    getCString_u((GSStr)self, buffer, maxLength, aRange, leftoverRange);
 }
 
-- (int) intValue
+- (int)intValue
 {
-  char  buf[24];
+    char buf[24];
 
-  intBuf_u((GSStr)self, buf);
-  return strtol(buf, 0, 10);
+    intBuf_u((GSStr)self, buf);
+    return strtol(buf, 0, 10);
 }
 
-- (NSInteger) integerValue
+- (NSInteger)integerValue
 {
-  char  buf[24];
+    char buf[24];
 
-  intBuf_u((GSStr)self, buf);
+    intBuf_u((GSStr)self, buf);
 #if GS_SIZEOF_VOIDP == GS_SIZEOF_LONG
-  return strtol(buf, 0, 10);
+    return strtol(buf, 0, 10);
 #else
-  return strtoll(buf, 0, 10);
+    return strtoll(buf, 0, 10);
 #endif
 }
 
-- (BOOL) isEqual: (id)anObject
+- (BOOL)isEqual:(id)anObject
 {
-  return isEqual_u((GSStr)self, anObject);
+    return isEqual_u((GSStr)self, anObject);
 }
 
-- (BOOL) isEqualToString: (NSString*)anObject
+- (BOOL)isEqualToString:(NSString *)anObject
 {
-  return isEqual_u((GSStr)self, anObject);
+    return isEqual_u((GSStr)self, anObject);
 }
 
-- (NSUInteger) length
+- (NSUInteger)length
 {
-  return _count;
+    return _count;
 }
 
-- (NSUInteger) lengthOfBytesUsingEncoding: (NSStringEncoding)encoding
+- (NSUInteger)lengthOfBytesUsingEncoding:(NSStringEncoding)encoding
 {
-  return cStringLength_u((GSStr)self, encoding);
+    return cStringLength_u((GSStr)self, encoding);
 }
 
-- (long long) longLongValue
+- (long long)longLongValue
 {
-  char  buf[24];
+    char buf[24];
 
-  intBuf_u((GSStr)self, buf);
-  return strtoll(buf, 0, 10);
+    intBuf_u((GSStr)self, buf);
+    return strtoll(buf, 0, 10);
 }
 
-- (const char*) lossyCString
+- (const char *)lossyCString
 {
-  return lossyCString_u((GSStr)self);
+    return lossyCString_u((GSStr)self);
 }
 
-- (id) lowercaseString
+- (id)lowercaseString
 {
-  GSUInlineString	*o;
-  unsigned		i;
+    GSUInlineString *o;
+    unsigned i;
 
-  o = [newUInline(_count, [self zone]) autorelease];
-  i = _count;
-  while (i-- > 0)
-    {
-      o->_contents.u[i] = uni_tolower(_contents.u[i]);
+    o = [newUInline(_count, [self zone]) autorelease];
+    i = _count;
+    while (i-- > 0) {
+        o->_contents.u[i] = uni_tolower(_contents.u[i]);
     }
-  return o;
+    return o;
 }
 
-- (id) mutableCopy
+- (id)mutableCopy
 {
-  GSMutableString	*obj;
+    GSMutableString *obj;
 
-  obj = (GSMutableString*)NSAllocateObject(GSMutableStringClass, 0,
-    NSDefaultMallocZone());
-  obj = [obj initWithBytes: (const void*)_contents.u
-		    length: _count * sizeof(unichar)
-		  encoding: NSUnicodeStringEncoding];
-  return obj;
+    obj = (GSMutableString *)NSAllocateObject(GSMutableStringClass, 0,
+                                              NSDefaultMallocZone());
+    obj = [obj initWithBytes:(const void *)_contents.u
+                      length:_count * sizeof(unichar)
+                    encoding:NSUnicodeStringEncoding];
+    return obj;
 }
 
-- (id) mutableCopyWithZone: (NSZone*)z
+- (id)mutableCopyWithZone:(NSZone *)z
 {
-  GSMutableString	*obj;
+    GSMutableString *obj;
 
-  obj = (GSMutableString*)NSAllocateObject(GSMutableStringClass, 0, z);
-  obj = [obj initWithBytes: (const void*)_contents.u
-		    length: _count * sizeof(unichar)
-		  encoding: NSUnicodeStringEncoding];
-  return obj;
+    obj = (GSMutableString *)NSAllocateObject(GSMutableStringClass, 0, z);
+    obj = [obj initWithBytes:(const void *)_contents.u
+                      length:_count * sizeof(unichar)
+                    encoding:NSUnicodeStringEncoding];
+    return obj;
 }
 
-- (NSRange) rangeOfComposedCharacterSequenceAtIndex: (NSUInteger)anIndex
+- (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
 {
-  return rangeOfSequence_u((GSStr)self, anIndex);
+    return rangeOfSequence_u((GSStr)self, anIndex);
 }
 
-- (NSRange) rangeOfCharacterFromSet: (NSCharacterSet*)aSet
-			    options: (NSUInteger)mask
-			      range: (NSRange)aRange
+- (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+                           options:(NSUInteger)mask
+                             range:(NSRange)aRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  return rangeOfCharacter_u((GSStr)self, aSet, mask, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    return rangeOfCharacter_u((GSStr)self, aSet, mask, aRange);
 }
 
-- (NSStringEncoding) smallestEncoding
+- (NSStringEncoding)smallestEncoding
 {
-  return NSUnicodeStringEncoding;
+    return NSUnicodeStringEncoding;
 }
 
-- (NSString*) substringFromRange: (NSRange)aRange
+- (NSString *)substringFromRange:(NSRange)aRange
 {
-  if (!_flags.wide)
-    {
-      id tinyString;
+    if (!_flags.wide) {
+        id tinyString;
 
-      tinyString = createTinyString((char*)_contents.c + aRange.location,
-        aRange.length);
-      if (tinyString)
-        {
-          return tinyString;
+        tinyString = createTinyString((char *)_contents.c + aRange.location,
+                                      aRange.length);
+        if (tinyString) {
+            return tinyString;
         }
     }
-  if (_flags.owned)
-    {
-      GS_RANGE_CHECK(aRange, _count);
-      return substring_u((GSStr)self, aRange);
+    if (_flags.owned) {
+        GS_RANGE_CHECK(aRange, _count);
+        return substring_u((GSStr)self, aRange);
     }
-  return [super substringWithRange: aRange];
+    return [super substringWithRange:aRange];
 }
 
-- (NSString*) substringWithRange: (NSRange)aRange
+- (NSString *)substringWithRange:(NSRange)aRange
 {
-  if (!_flags.wide)
-    {
-      id tinyString;
+    if (!_flags.wide) {
+        id tinyString;
 
-      tinyString = createTinyString((char*)_contents.c + aRange.location,
-        aRange.length);
-      if (tinyString)
-        {
-          return tinyString;
+        tinyString = createTinyString((char *)_contents.c + aRange.location,
+                                      aRange.length);
+        if (tinyString) {
+            return tinyString;
         }
     }
-  if (_flags.owned)
-    {
-      GS_RANGE_CHECK(aRange, _count);
-      return substring_u((GSStr)self, aRange);
+    if (_flags.owned) {
+        GS_RANGE_CHECK(aRange, _count);
+        return substring_u((GSStr)self, aRange);
     }
-  return [super substringWithRange: aRange];
+    return [super substringWithRange:aRange];
 }
 
-- (id) uppercaseString
+- (id)uppercaseString
 {
-  GSUInlineString	*o;
-  unsigned		i;
+    GSUInlineString *o;
+    unsigned i;
 
-  o = [newUInline(_count, [self zone]) autorelease];
-  i = _count;
-  while (i-- > 0)
-    {
-      o->_contents.u[i] = uni_toupper(_contents.u[i]);
+    o = [newUInline(_count, [self zone]) autorelease];
+    i = _count;
+    while (i-- > 0) {
+        o->_contents.u[i] = uni_toupper(_contents.u[i]);
     }
-  return o;
+    return o;
 }
 
 // private method for Unicode level 3 implementation
-- (int) _baseLength
+- (int)_baseLength
 {
-  unsigned int count = 0;
-  unsigned int blen = 0;
+    unsigned int count = 0;
+    unsigned int blen = 0;
 
-  while (count < _count)
-    if (!uni_isnonsp(_contents.u[count++]))
-      blen++;
-  return blen;
+    while (count < _count)
+        if (!uni_isnonsp(_contents.u[count++]))
+            blen++;
+    return blen;
 }
 
 /*
 Default -copy implementation. Retain if we own the buffer and the zones
 agree, create a new GSUInlineString otherwise.
 */
-- (id) copyWithZone: (NSZone*)z
+- (id)copyWithZone:(NSZone *)z
 {
-  if (!_flags.owned || NSShouldRetainWithZone(self, z) == NO)
-    {
-      GSUInlineString *o;
+    if (!_flags.owned || NSShouldRetainWithZone(self, z) == NO) {
+        GSUInlineString *o;
 
-      o = newUInline(_count, z);
-      memcpy(o->_contents.u, _contents.u, _count * sizeof(unichar));
-      return o;
-    }
-  else
-    {
-      return RETAIN(self);
+        o = newUInline(_count, z);
+        memcpy(o->_contents.u, _contents.u, _count * sizeof(unichar));
+        return o;
+    } else {
+        return RETAIN(self);
     }
 }
 
 @end
 
-
 
-@implementation	GSUnicodeBufferString
-- (void) dealloc
+@implementation GSUnicodeBufferString
+- (void)dealloc
 {
-  if (_contents.u != 0)
-    {
-      if (_flags.owned)
-        {
-          NSZoneFree(NSZoneFromPointer(_contents.u), _contents.u);
-	}
-      _contents.u = 0;
+    if (_contents.u != 0) {
+        if (_flags.owned) {
+            NSZoneFree(NSZoneFromPointer(_contents.u), _contents.u);
+        }
+        _contents.u = 0;
     }
-  [super dealloc];
+    [super dealloc];
 }
 @end
 
-
 
-@implementation	GSUInlineString
-- (NSUInteger) sizeOfContentExcluding: (NSHashTable*)exclude
+@implementation GSUInlineString
+- (NSUInteger)sizeOfContentExcluding:(NSHashTable *)exclude
 {
-  return 0;	// Inline string content uses no heap
+    return 0; // Inline string content uses no heap
 }
-- (NSUInteger) sizeOfInstance
+- (NSUInteger)sizeOfInstance
 {
-  NSUInteger    size;
+    NSUInteger size;
 
-#if     HAVE_MALLOC_USABLE_SIZE
-  size = malloc_usable_size((void*)self - sizeof(intptr_t));
+#if HAVE_MALLOC_USABLE_SIZE
+    size = malloc_usable_size((void *)self - sizeof(intptr_t));
 #else
-  size = class_getInstanceSize(GSUInlineStringClass);
-  size += _count * sizeof(unichar);
+    size = class_getInstanceSize(GSUInlineStringClass);
+    size += _count * sizeof(unichar);
 #endif
-  return size;
+    return size;
 }
 @end
 
-
 
-@implementation	GSUnicodeSubString
+@implementation GSUnicodeSubString
 
 /*
  * Assume that a copy should be a new string, never just a retained substring.
  */
-- (id) copyWithZone: (NSZone*)z
+- (id)copyWithZone:(NSZone *)z
 {
-  GSUInlineString *o;
+    GSUInlineString *o;
 
-  o = newUInline(_count, z);
-  memcpy(o->_contents.u, _contents.u, _count * sizeof(unichar));
-  return o;
+    o = newUInline(_count, z);
+    memcpy(o->_contents.u, _contents.u, _count * sizeof(unichar));
+    return o;
 }
 
-- (void) dealloc
+- (void)dealloc
 {
-  DESTROY(_parent);
-  [super dealloc];
+    DESTROY(_parent);
+    [super dealloc];
 }
 
-- (NSString*) substringFromRange: (NSRange)aRange
+- (NSString *)substringFromRange:(NSRange)aRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  aRange.location += (_contents.u - _parent->_contents.u);
-  return substring_u((GSStr)_parent, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    aRange.location += (_contents.u - _parent->_contents.u);
+    return substring_u((GSStr)_parent, aRange);
 }
 
-- (NSString*) substringWithRange: (NSRange)aRange
+- (NSString *)substringWithRange:(NSRange)aRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  aRange.location += (_contents.u - _parent->_contents.u);
-  return substring_u((GSStr)_parent, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    aRange.location += (_contents.u - _parent->_contents.u);
+    return substring_u((GSStr)_parent, aRange);
 }
 
 @end
 
-
 
 /*
  * The GSMutableString class shares a common initial ivar layout with
@@ -4424,1135 +3881,988 @@ agree, create a new GSUInlineString otherwise.
  */
 @implementation GSMutableString
 
-+ (void) initialize
++ (void)initialize
 {
-  setup(NO);
-  GSObjCAddClassBehavior(self, [GSString class]);
+    setup(NO);
+    GSObjCAddClassBehavior(self, [GSString class]);
 }
 
-- (void) appendFormat: (NSString*)format, ...
+- (void)appendFormat:(NSString *)format, ...
 {
-  va_list	ap;
-  unichar	buf[1024];
-  unichar	*fmt = buf;
-  size_t	len;
+    va_list ap;
+    unichar buf[1024];
+    unichar *fmt = buf;
+    size_t len;
 
-  va_start(ap, format);
+    va_start(ap, format);
 
-  /*
-   * Make sure we have the format string in a nul terminated array of
-   * unichars for passing to GSPrivateFormat.  Use on-stack memory for
-   * performance unless the size of the format string is really big
-   * (a rare occurrence).
-   */
-  len = [format length];
-  if (len >= 1024)
-    {
-      fmt = NSZoneMalloc(NSDefaultMallocZone(), (len+1)*sizeof(unichar));
+    /*
+     * Make sure we have the format string in a nul terminated array of
+     * unichars for passing to GSPrivateFormat.  Use on-stack memory for
+     * performance unless the size of the format string is really big
+     * (a rare occurrence).
+     */
+    len = [format length];
+    if (len >= 1024) {
+        fmt = NSZoneMalloc(NSDefaultMallocZone(), (len + 1) * sizeof(unichar));
     }
-  [format getCharacters: fmt];
-  fmt[len] = '\0';
+    [format getCharacters:fmt];
+    fmt[len] = '\0';
 
-  /*
-   * If no zone is set, make sure we have one so any memory mangement
-   * (buffer growth) is done with the correct zone.
-   */
-  if (_zone == 0)
-    {
-      _zone = [self zone];
+    /*
+     * If no zone is set, make sure we have one so any memory mangement
+     * (buffer growth) is done with the correct zone.
+     */
+    if (_zone == 0) {
+        _zone = [self zone];
     }
-  GSPrivateFormat((GSStr)self, fmt, ap, nil);
-  _flags.hash = 0;	// Invalidate the hash for this string.
-  if (fmt != buf)
-    {
-      NSZoneFree(NSDefaultMallocZone(), fmt);
+    GSPrivateFormat((GSStr)self, fmt, ap, nil);
+    _flags.hash = 0; // Invalidate the hash for this string.
+    if (fmt != buf) {
+        NSZoneFree(NSDefaultMallocZone(), fmt);
     }
-  va_end(ap);
+    va_end(ap);
 }
 
-- (BOOL) boolValue
+- (BOOL)boolValue
 {
-  if (_flags.wide == 1)
-    return boolValue_u((GSStr)self);
-  else
-    return boolValue_c((GSStr)self);
+    if (_flags.wide == 1)
+        return boolValue_u((GSStr)self);
+    else
+        return boolValue_c((GSStr)self);
 }
 
-- (BOOL) canBeConvertedToEncoding: (NSStringEncoding)enc
+- (BOOL)canBeConvertedToEncoding:(NSStringEncoding)enc
 {
-  if (_flags.wide == 1)
-    return canBeConvertedToEncoding_u((GSStr)self, enc);
-  else
-    return canBeConvertedToEncoding_c((GSStr)self, enc);
+    if (_flags.wide == 1)
+        return canBeConvertedToEncoding_u((GSStr)self, enc);
+    else
+        return canBeConvertedToEncoding_c((GSStr)self, enc);
 }
 
-- (unichar) characterAtIndex: (NSUInteger)index
+- (unichar)characterAtIndex:(NSUInteger)index
 {
-  if (_flags.wide == 1)
-    return characterAtIndex_u((GSStr)self, index);
-  else
-    return characterAtIndex_c((GSStr)self, index);
+    if (_flags.wide == 1)
+        return characterAtIndex_u((GSStr)self, index);
+    else
+        return characterAtIndex_c((GSStr)self, index);
 }
 
-- (NSComparisonResult) compare: (NSString*)aString
-		       options: (NSUInteger)mask
-			 range: (NSRange)aRange
+- (NSComparisonResult)compare:(NSString *)aString
+                      options:(NSUInteger)mask
+                        range:(NSRange)aRange
 {
-  if (mask & NSNumericSearch)
-    {
-      return [super compare: aString options: mask range: aRange];
+    if (mask & NSNumericSearch) {
+        return [super compare:aString options:mask range:aRange];
     }
-  GS_RANGE_CHECK(aRange, _count);
-  if (aString == nil)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] nil string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
-  if (GSObjCIsInstance(aString) == NO)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[%@ -%@] not a string argument",
-      NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
-  if (_flags.wide == 1)
-    return compare_u((GSStr)self, aString, mask, aRange);
-  else
-    return compare_c((GSStr)self, aString, mask, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    if (aString == nil)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[%@ -%@] nil string argument",
+                           NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    if (GSObjCIsInstance(aString) == NO)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[%@ -%@] not a string argument",
+                           NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    if (_flags.wide == 1)
+        return compare_u((GSStr)self, aString, mask, aRange);
+    else
+        return compare_c((GSStr)self, aString, mask, aRange);
 }
 
-- (id) copyWithZone: (NSZone*)z
+- (id)copyWithZone:(NSZone *)z
 {
-  if (_flags.wide == 1)
-    {
-      GSUInlineString *o;
+    if (_flags.wide == 1) {
+        GSUInlineString *o;
 
-      o = newUInline(_count, z);
-      memcpy(o->_contents.u, _contents.u, _count * sizeof(unichar));
-      return o;
-    }
-  else
-    {
-      GSCInlineString *o;
+        o = newUInline(_count, z);
+        memcpy(o->_contents.u, _contents.u, _count * sizeof(unichar));
+        return o;
+    } else {
+        GSCInlineString *o;
 
-      o = newCInline(_count, z);
-      memcpy(o->_contents.c, _contents.c, _count);
-      return o;
+        o = newCInline(_count, z);
+        memcpy(o->_contents.c, _contents.c, _count);
+        return o;
     }
 }
 
-- (const char *) cString
+- (const char *)cString
 {
-  if (_flags.wide == 1)
-    return cString_u((GSStr)self, externalEncoding);
-  else
-    return cString_c((GSStr)self, externalEncoding);
+    if (_flags.wide == 1)
+        return cString_u((GSStr)self, externalEncoding);
+    else
+        return cString_c((GSStr)self, externalEncoding);
 }
 
-- (const char *) cStringUsingEncoding: (NSStringEncoding)encoding
+- (const char *)cStringUsingEncoding:(NSStringEncoding)encoding
 {
-  if (_flags.wide == 1)
-    return cString_u((GSStr)self, encoding);
-  else
-    return cString_c((GSStr)self, encoding);
+    if (_flags.wide == 1)
+        return cString_u((GSStr)self, encoding);
+    else
+        return cString_c((GSStr)self, encoding);
 }
 
-- (NSUInteger) cStringLength
+- (NSUInteger)cStringLength
 {
-  if (_flags.wide == 1)
-    return cStringLength_u((GSStr)self, externalEncoding);
-  else
-    return cStringLength_c((GSStr)self, externalEncoding);
+    if (_flags.wide == 1)
+        return cStringLength_u((GSStr)self, externalEncoding);
+    else
+        return cStringLength_c((GSStr)self, externalEncoding);
 }
 
-- (void) dealloc
+- (void)dealloc
 {
-  if (_contents.c != 0)
-    {
-NSAssert(_flags.owned == 1 && _zone != 0, NSInternalInconsistencyException);
-      NSZoneFree(self->_zone, self->_contents.c);
-      self->_contents.c = 0;
-      self->_zone = 0;
+    if (_contents.c != 0) {
+        NSAssert(_flags.owned == 1 && _zone != 0, NSInternalInconsistencyException);
+        NSZoneFree(self->_zone, self->_contents.c);
+        self->_contents.c = 0;
+        self->_zone = 0;
     }
-  [super dealloc];
+    [super dealloc];
 }
 
-- (void) deleteCharactersInRange: (NSRange)range
+- (void)deleteCharactersInRange:(NSRange)range
 {
-  GS_RANGE_CHECK(range, _count);
-  if (range.length > 0)
-    {
-      fillHole((GSStr)self, range.location, range.length);
+    GS_RANGE_CHECK(range, _count);
+    if (range.length > 0) {
+        fillHole((GSStr)self, range.location, range.length);
     }
 }
 
-- (void) encodeWithCoder: (NSCoder*)aCoder
+- (void)encodeWithCoder:(NSCoder *)aCoder
 {
-  if ([aCoder allowsKeyedCoding])
-    {
-      [(NSKeyedArchiver*)aCoder _encodePropertyList: self forKey: @"NS.string"];
-      return;
+    if ([aCoder allowsKeyedCoding]) {
+        [(NSKeyedArchiver *)aCoder _encodePropertyList:self forKey:@"NS.string"];
+        return;
     }
 
-  [aCoder encodeValueOfObjCType: @encode(unsigned) at: &_count];
-  if (_count > 0)
-    {
-      if (_flags.wide == 1)
-	{
-	  NSStringEncoding	enc = NSUnicodeStringEncoding;
+    [aCoder encodeValueOfObjCType:@encode(unsigned) at:&_count];
+    if (_count > 0) {
+        if (_flags.wide == 1) {
+            NSStringEncoding enc = NSUnicodeStringEncoding;
 
-	  [aCoder encodeValueOfObjCType: @encode(int) at: &enc];
-	  [aCoder encodeArrayOfObjCType: @encode(unichar)
-				  count: _count
-				     at: _contents.u];
-	}
-      else
-	{
-	  [aCoder encodeValueOfObjCType: @encode(int)
-				     at: &internalEncoding];
-	  [aCoder encodeArrayOfObjCType: @encode(unsigned char)
-				  count: _count
-				     at: _contents.c];
-	}
+            [aCoder encodeValueOfObjCType:@encode(int) at:&enc];
+            [aCoder encodeArrayOfObjCType:@encode(unichar)
+                                    count:_count
+                                       at:_contents.u];
+        } else {
+            [aCoder encodeValueOfObjCType:@encode(int)
+                                       at:&internalEncoding];
+            [aCoder encodeArrayOfObjCType:@encode(unsigned char)
+                                    count:_count
+                                       at:_contents.c];
+        }
     }
 }
 
-- (NSStringEncoding) fastestEncoding
+- (NSStringEncoding)fastestEncoding
 {
-  if (_flags.wide == 1)
-    return NSUnicodeStringEncoding;
-  else
-    return internalEncoding;
+    if (_flags.wide == 1)
+        return NSUnicodeStringEncoding;
+    else
+        return internalEncoding;
 }
 
-- (void) getCharacters: (unichar*)buffer
+- (void)getCharacters:(unichar *)buffer
 {
-  if (_flags.wide == 1)
-    getCharacters_u((GSStr)self, buffer, (NSRange){0, _count});
-  else
-    getCharacters_c((GSStr)self, buffer, (NSRange){0, _count});
+    if (_flags.wide == 1)
+        getCharacters_u((GSStr)self, buffer, (NSRange){0, _count});
+    else
+        getCharacters_c((GSStr)self, buffer, (NSRange){0, _count});
 }
 
-- (void) getCharacters: (unichar*)buffer range: (NSRange)aRange
+- (void)getCharacters:(unichar *)buffer range:(NSRange)aRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  if (_flags.wide == 1)
-    {
-      getCharacters_u((GSStr)self, buffer, aRange);
-    }
-  else
-    {
-      getCharacters_c((GSStr)self, buffer, aRange);
+    GS_RANGE_CHECK(aRange, _count);
+    if (_flags.wide == 1) {
+        getCharacters_u((GSStr)self, buffer, aRange);
+    } else {
+        getCharacters_c((GSStr)self, buffer, aRange);
     }
 }
 
 - (void) getCString: (char*)buffer
 {
-  if (_flags.wide == 1)
-    getCString_u((GSStr)self, buffer, NSMaximumStringLength,
-      (NSRange){0, _count}, 0);
-  else
-    getCString_c((GSStr)self, buffer, NSMaximumStringLength,
-      (NSRange){0, _count}, 0);
+    if (_flags.wide == 1)
+        getCString_u((GSStr)self, buffer, NSMaximumStringLength,
+                     (NSRange){0, _count}, 0);
+    else
+        getCString_c((GSStr)self, buffer, NSMaximumStringLength,
+                     (NSRange){0, _count}, 0);
 }
 
-- (void) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
+- (void)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
 {
-  if (_flags.wide == 1)
-    getCString_u((GSStr)self, buffer, maxLength, (NSRange){0, _count}, 0);
-  else
-    getCString_c((GSStr)self, buffer, maxLength, (NSRange){0, _count}, 0);
+    if (_flags.wide == 1)
+        getCString_u((GSStr)self, buffer, maxLength, (NSRange){0, _count}, 0);
+    else
+        getCString_c((GSStr)self, buffer, maxLength, (NSRange){0, _count}, 0);
 }
 
-- (BOOL) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	   encoding: (NSStringEncoding)encoding
+- (BOOL)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+          encoding:(NSStringEncoding)encoding
 {
-  if (_flags.wide == 1)
-    return getCStringE_u((GSStr)self, buffer, maxLength, encoding);
-  else
-    return getCStringE_c((GSStr)self, buffer, maxLength, encoding);
+    if (_flags.wide == 1)
+        return getCStringE_u((GSStr)self, buffer, maxLength, encoding);
+    else
+        return getCStringE_c((GSStr)self, buffer, maxLength, encoding);
 }
 
-- (void) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	      range: (NSRange)aRange
-     remainingRange: (NSRange*)leftoverRange
+- (void)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+             range:(NSRange)aRange
+    remainingRange:(NSRange *)leftoverRange
 {
-  GS_RANGE_CHECK(aRange, _count);
-  if (_flags.wide == 1)
-    {
-      getCString_u((GSStr)self, buffer, maxLength, aRange, leftoverRange);
-    }
-  else
-    {
-      getCString_c((GSStr)self, buffer, maxLength, aRange, leftoverRange);
+    GS_RANGE_CHECK(aRange, _count);
+    if (_flags.wide == 1) {
+        getCString_u((GSStr)self, buffer, maxLength, aRange, leftoverRange);
+    } else {
+        getCString_c((GSStr)self, buffer, maxLength, aRange, leftoverRange);
     }
 }
 
-- (id) init
+- (id)init
 {
-  return [self initWithCapacity: 0];
+    return [self initWithCapacity:0];
 }
 
-- (id) initWithBytes: (const void*)bytes
-	      length: (NSUInteger)length
-	    encoding: (NSStringEncoding)encoding
+- (id)initWithBytes:(const void *)bytes
+             length:(NSUInteger)length
+           encoding:(NSStringEncoding)encoding
 {
-  unsigned char	*chars = 0;
-  BOOL		isASCII = NO;
-  BOOL		isLatin1 = NO;
-  BOOL		shouldFree = NO;
+    unsigned char *chars = 0;
+    BOOL isASCII = NO;
+    BOOL isLatin1 = NO;
+    BOOL shouldFree = NO;
 
-  _flags.owned = YES;
-  _zone = [self zone];
+    _flags.owned = YES;
+    _zone = [self zone];
 
-  if (length > 0)
-    {
-      fixBOM((unsigned char**)&bytes, &length, &shouldFree, encoding);
-      chars = (unsigned char*)bytes;
+    if (length > 0) {
+        fixBOM((unsigned char **)&bytes, &length, &shouldFree, encoding);
+        chars = (unsigned char *)bytes;
     }
-  if (0 == length)
-    {
-      return [self initWithCapacity: 0];
+    if (0 == length) {
+        return [self initWithCapacity:0];
     }
-  if (0 == chars)
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"-initWithBytes:lenth:encoding given nul bytes"];
+    if (0 == chars) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"-initWithBytes:lenth:encoding given nul bytes"];
     }
 
-  if (encoding == NSUTF8StringEncoding)
-    {
-      unsigned i;
+    if (encoding == NSUTF8StringEncoding) {
+        unsigned i;
 
-      for (i = 0; i < length; i++)
-        {
-	  if (chars[i] > 127)
-	    {
-	      break;
-	    }
+        for (i = 0; i < length; i++) {
+            if (chars[i] > 127) {
+                break;
+            }
         }
-      if (i == length)
-	{
-	  /*
-	   * This is actually ASCII data ... so we can just store it as if
-	   * in the internal 8bit encoding scheme.
-	   */
-	  encoding = internalEncoding;
-	}
-    }
-  else if (encoding != internalEncoding && isByteEncoding(encoding) == YES)
-    {
-      unsigned i;
-
-      for (i = 0; i < length; i++)
-        {
-	  if (((unsigned char*)chars)[i] > 127)
-	    {
-	      if (encoding == NSASCIIStringEncoding)
-		{
-		  DESTROY(self);
-		  if (shouldFree == YES)
-		    {
-		      NSZoneFree(NSZoneFromPointer(chars), chars);
-		    }
-		  return nil;	// Invalid data
-		}
-	      break;
-	    }
+        if (i == length) {
+            /*
+             * This is actually ASCII data ... so we can just store it as if
+             * in the internal 8bit encoding scheme.
+             */
+            encoding = internalEncoding;
         }
-      if (i == length)
-	{
-	  /*
-	   * This is actually ASCII data ... so we can just store it as if
-	   * in the internal 8bit encoding scheme.
-	   */
-	  encoding = internalEncoding;
-	}
-    }
+    } else if (encoding != internalEncoding && isByteEncoding(encoding) == YES) {
+        unsigned i;
 
-  if (encoding == internalEncoding)
-    {
-      if (0 != chars)
-	{
-	  if (shouldFree == YES)
-	    {
-	      _zone = NSZoneFromPointer(chars);
-	      _contents.c = chars;
-	    }
-	  else
-	    {
-	      _contents.c = NSZoneMalloc(_zone, length);
-	      memcpy(_contents.c, chars, length);
-	    }
-	}
-      _count = length;
-      _flags.wide = 0;
-      return self;
-    }
-
-  /*
-   * Any remaining encoding needs to be converted to UTF-16.
-   */
-  if (encoding != NSUnicodeStringEncoding)
-    {
-      unichar	*u = 0;
-      unsigned	l = 0;
-
-      if (GSToUnicode(&u, &l, (unsigned char*)chars, length, encoding,
-	_zone, 0) == NO)
-	{
-	  DESTROY(self);
-	  if (shouldFree == YES)
-	    {
-	      NSZoneFree(NSZoneFromPointer(chars), chars);
-	    }
-	  return nil;	// Invalid data
-	}
-      chars = (unsigned char*)u;
-      length = l * sizeof(unichar);
-      shouldFree = YES;
-    }
-
-  length /= sizeof(unichar);
-  if (GSUnicode((unichar*)(void*)chars, length, &isASCII, &isLatin1) != length)
-    {
-      if (shouldFree == YES && chars != 0)
-        {
-	  NSZoneFree(NSZoneFromPointer(chars), chars);
+        for (i = 0; i < length; i++) {
+            if (((unsigned char *)chars)[i] > 127) {
+                if (encoding == NSASCIIStringEncoding) {
+                    DESTROY(self);
+                    if (shouldFree == YES) {
+                        NSZoneFree(NSZoneFromPointer(chars), chars);
+                    }
+                    return nil; // Invalid data
+                }
+                break;
+            }
         }
-      return nil;	// Invalid data
-    }
-
-  if (isASCII == YES
-    || (internalEncoding == NSISOLatin1StringEncoding && isLatin1 == YES))
-    {
-      _contents.c = NSZoneMalloc(_zone, length);
-      _count = length;
-      _flags.wide = 0;
-      while (length-- > 0)
-        {
-	  _contents.c[length] = ((unichar*)(void*)chars)[length];
+        if (i == length) {
+            /*
+             * This is actually ASCII data ... so we can just store it as if
+             * in the internal 8bit encoding scheme.
+             */
+            encoding = internalEncoding;
         }
-      if (shouldFree == YES && chars != 0)
-        {
-	  NSZoneFree(NSZoneFromPointer(chars), chars);
+    }
+
+    if (encoding == internalEncoding) {
+        if (0 != chars) {
+            if (shouldFree == YES) {
+                _zone = NSZoneFromPointer(chars);
+                _contents.c = chars;
+            } else {
+                _contents.c = NSZoneMalloc(_zone, length);
+                memcpy(_contents.c, chars, length);
+            }
         }
-      return self;
+        _count = length;
+        _flags.wide = 0;
+        return self;
     }
-  else
-    {
-      if (shouldFree == YES)
-        {
-	  _zone = NSZoneFromPointer(chars);
-	  _contents.u = (unichar*)(void*)chars;
+
+    /*
+     * Any remaining encoding needs to be converted to UTF-16.
+     */
+    if (encoding != NSUnicodeStringEncoding) {
+        unichar *u = 0;
+        unsigned l = 0;
+
+        if (GSToUnicode(&u, &l, (unsigned char *)chars, length, encoding,
+                        _zone, 0) == NO) {
+            DESTROY(self);
+            if (shouldFree == YES) {
+                NSZoneFree(NSZoneFromPointer(chars), chars);
+            }
+            return nil; // Invalid data
         }
-      else
-	{
-	  _contents.u = NSZoneMalloc(_zone, length * sizeof(unichar));
-	  memcpy(_contents.u, chars, length * sizeof(unichar));
-	}
-      _count = length;
-      _flags.wide = 1;
-      return self;
+        chars = (unsigned char *)u;
+        length = l * sizeof(unichar);
+        shouldFree = YES;
+    }
+
+    length /= sizeof(unichar);
+    if (GSUnicode((unichar *)(void *)chars, length, &isASCII, &isLatin1) != length) {
+        if (shouldFree == YES && chars != 0) {
+            NSZoneFree(NSZoneFromPointer(chars), chars);
+        }
+        return nil; // Invalid data
+    }
+
+    if (isASCII == YES || (internalEncoding == NSISOLatin1StringEncoding && isLatin1 == YES)) {
+        _contents.c = NSZoneMalloc(_zone, length);
+        _count = length;
+        _flags.wide = 0;
+        while (length-- > 0) {
+            _contents.c[length] = ((unichar *)(void *)chars)[length];
+        }
+        if (shouldFree == YES && chars != 0) {
+            NSZoneFree(NSZoneFromPointer(chars), chars);
+        }
+        return self;
+    } else {
+        if (shouldFree == YES) {
+            _zone = NSZoneFromPointer(chars);
+            _contents.u = (unichar *)(void *)chars;
+        } else {
+            _contents.u = NSZoneMalloc(_zone, length * sizeof(unichar));
+            memcpy(_contents.u, chars, length * sizeof(unichar));
+        }
+        _count = length;
+        _flags.wide = 1;
+        return self;
     }
 }
 
-- (id) initWithBytesNoCopy: (void*)bytes
-		    length: (NSUInteger)length
-		  encoding: (NSStringEncoding)encoding
-	      freeWhenDone: (BOOL)flag
+- (id)initWithBytesNoCopy:(void *)bytes
+                   length:(NSUInteger)length
+                 encoding:(NSStringEncoding)encoding
+             freeWhenDone:(BOOL)flag
 {
-  self = [self initWithBytes: bytes
-		      length: length
-		    encoding: encoding];
-  if (flag == YES && bytes != 0)
-    {
-      NSZoneFree(NSZoneFromPointer(bytes), bytes);
+    self = [self initWithBytes:bytes
+                        length:length
+                      encoding:encoding];
+    if (flag == YES && bytes != 0) {
+        NSZoneFree(NSZoneFromPointer(bytes), bytes);
     }
-  return self;
+    return self;
 }
 
-- (id) initWithCapacity: (NSUInteger)capacity
+- (id)initWithCapacity:(NSUInteger)capacity
 {
-  if (capacity < 2)
-    {
-      capacity = 2;
+    if (capacity < 2) {
+        capacity = 2;
     }
-  _count = 0;
-  _capacity = capacity;
-  _zone = [self zone];
-  _contents.c = NSZoneMalloc(_zone, capacity + 1);
-  _flags.wide = 0;
-  _flags.owned = 1;
-  return self;
+    _count = 0;
+    _capacity = capacity;
+    _zone = [self zone];
+    _contents.c = NSZoneMalloc(_zone, capacity + 1);
+    _flags.wide = 0;
+    _flags.owned = 1;
+    return self;
 }
 
-- (id) initWithCharactersNoCopy: (unichar*)chars
-			 length: (NSUInteger)length
-		   freeWhenDone: (BOOL)flag
+- (id)initWithCharactersNoCopy:(unichar *)chars
+                        length:(NSUInteger)length
+                  freeWhenDone:(BOOL)flag
 {
-  return [self initWithBytesNoCopy: (void*)chars
-   			    length: length*sizeof(unichar)
-			  encoding: NSUnicodeStringEncoding
-		      freeWhenDone: flag];
+    return [self initWithBytesNoCopy:(void *)chars
+                              length:length * sizeof(unichar)
+                            encoding:NSUnicodeStringEncoding
+                        freeWhenDone:flag];
 }
 
-- (id) initWithCStringNoCopy: (char*)chars
-		      length: (NSUInteger)length
-	        freeWhenDone: (BOOL)flag
+- (id)initWithCStringNoCopy:(char *)chars
+                     length:(NSUInteger)length
+               freeWhenDone:(BOOL)flag
 {
-  return [self initWithBytesNoCopy: (void*)chars
-   			    length: length
-			  encoding: externalEncoding
-		      freeWhenDone: flag];
+    return [self initWithBytesNoCopy:(void *)chars
+                              length:length
+                            encoding:externalEncoding
+                        freeWhenDone:flag];
 }
 
-- (id) initWithFormat: (NSString*)format
-               locale: (NSDictionary*)locale
-	    arguments: (va_list)argList
+- (id)initWithFormat:(NSString *)format
+              locale:(NSDictionary *)locale
+           arguments:(va_list)argList
 {
-  unichar	fbuf[1024];
-  unichar	*fmt = fbuf;
-  size_t	len;
+    unichar fbuf[1024];
+    unichar *fmt = fbuf;
+    size_t len;
 
-  if (NULL == format)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[GSMutableString-initWithFormat:locale:arguments:]: NULL format"];
-  /*
-   * First we provide an array of unichar characters containing the
-   * format string.  For performance reasons we try to use an on-stack
-   * buffer if the format string is small enough ... it almost always
-   * will be.
-   */
-  len = [format length];
-  if (len >= 1024)
-    {
-      fmt = NSZoneMalloc(NSDefaultMallocZone(), (len+1)*sizeof(unichar));
+    if (NULL == format)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[GSMutableString-initWithFormat:locale:arguments:]: NULL format"];
+    /*
+     * First we provide an array of unichar characters containing the
+     * format string.  For performance reasons we try to use an on-stack
+     * buffer if the format string is small enough ... it almost always
+     * will be.
+     */
+    len = [format length];
+    if (len >= 1024) {
+        fmt = NSZoneMalloc(NSDefaultMallocZone(), (len + 1) * sizeof(unichar));
     }
-  [format getCharacters: fmt];
-  fmt[len] = '\0';
+    [format getCharacters:fmt];
+    fmt[len] = '\0';
 
-  GSPrivateFormat((GSStr)self, fmt, argList, locale);
-  if (fmt != fbuf)
-    {
-      NSZoneFree(NSDefaultMallocZone(), fmt);
+    GSPrivateFormat((GSStr)self, fmt, argList, locale);
+    if (fmt != fbuf) {
+        NSZoneFree(NSDefaultMallocZone(), fmt);
     }
-  return self;
+    return self;
 }
 
-- (int) intValue
+- (int)intValue
 {
-  char  buf[24];
+    char buf[24];
 
-  if (_flags.wide == 1)
-    intBuf_u((GSStr)self, buf);
-  else
-    intBuf_c((GSStr)self, buf);
-  return strtol(buf, 0, 10);
+    if (_flags.wide == 1)
+        intBuf_u((GSStr)self, buf);
+    else
+        intBuf_c((GSStr)self, buf);
+    return strtol(buf, 0, 10);
 }
 
-- (NSInteger) integerValue
+- (NSInteger)integerValue
 {
-  char  buf[24];
+    char buf[24];
 
-  if (_flags.wide == 1)
-    intBuf_u((GSStr)self, buf);
-  else
-    intBuf_c((GSStr)self, buf);
+    if (_flags.wide == 1)
+        intBuf_u((GSStr)self, buf);
+    else
+        intBuf_c((GSStr)self, buf);
 #if GS_SIZEOF_VOIDP == GS_SIZEOF_LONG
-  return strtol(buf, 0, 10);
+    return strtol(buf, 0, 10);
 #else
-  return strtoll(buf, 0, 10);
+    return strtoll(buf, 0, 10);
 #endif
 }
 
-- (BOOL) isEqual: (id)anObject
+- (BOOL)isEqual:(id)anObject
 {
-  if (_flags.wide == 1)
-    return isEqual_u((GSStr)self, anObject);
-  else
-    return isEqual_c((GSStr)self, anObject);
+    if (_flags.wide == 1)
+        return isEqual_u((GSStr)self, anObject);
+    else
+        return isEqual_c((GSStr)self, anObject);
 }
 
-- (BOOL) isEqualToString: (NSString*)anObject
+- (BOOL)isEqualToString:(NSString *)anObject
 {
-  if (_flags.wide == 1)
-    return isEqual_u((GSStr)self, anObject);
-  else
-    return isEqual_c((GSStr)self, anObject);
+    if (_flags.wide == 1)
+        return isEqual_u((GSStr)self, anObject);
+    else
+        return isEqual_c((GSStr)self, anObject);
 }
 
-- (NSUInteger) length
+- (NSUInteger)length
 {
-  return _count;
-}
-
-- (NSUInteger) lengthOfBytesUsingEncoding: (NSStringEncoding)encoding
-{
-  if (_flags.wide == 1)
-    return cStringLength_u((GSStr)self, encoding);
-  else
-    return cStringLength_c((GSStr)self, encoding);
-}
-
-- (long long) longLongValue
-{
-  char  buf[24];
-
-  if (_flags.wide == 1)
-    intBuf_u((GSStr)self, buf);
-  else
-    intBuf_c((GSStr)self, buf);
-  return strtoll(buf, 0, 10);
-}
-
-- (const char*) lossyCString
-{
-  if (_flags.wide == 1)
-    return lossyCString_u((GSStr)self);
-  else
-    return lossyCString_c((GSStr)self);
-}
-
-- (id) lowercaseString
-{
-  if (_flags.wide == 1)
-    {
-      GSUInlineString	*o;
-      unsigned          i;
-
-      o = newUInline(_count, [self zone]);
-      i = _count;
-      while (i-- > 0)
-	{
-          o->_contents.u[i] = uni_tolower(_contents.u[i]);
-	}
-      return [o autorelease];
-    }
-  return [super lowercaseString];
-}
-
-- (BOOL) makeImmutable
-{
-NSAssert(_flags.owned == 1 && _zone != 0, NSInternalInconsistencyException);
-  if (_flags.wide == 1)
-    {
-      GSClassSwizzle(self, [GSUnicodeBufferString class]);
-    }
-  else
-    {
-      GSClassSwizzle(self, [GSCBufferString class]);
-    }
-  return YES;
-}
-
-- (id) makeImmutableCopyOnFail: (BOOL)force
-{
-NSAssert(_flags.owned == 1 && _zone != 0, NSInternalInconsistencyException);
-  if (_flags.wide == 1)
-    {
-      GSClassSwizzle(self, [GSUnicodeBufferString class]);
-    }
-  else
-    {
-      GSClassSwizzle(self, [GSCBufferString class]);
-    }
-  return self;
-}
-
-- (id) mutableCopy
-{
-  GSMutableString	*obj;
-
-  obj = (GSMutableString*)NSAllocateObject(GSMutableStringClass, 0,
-    NSDefaultMallocZone());
-
-  if (_flags.wide == 1)
-    obj = [obj initWithBytes: (void*)_contents.u
-		      length: _count * sizeof(unichar)
-		    encoding: NSUnicodeStringEncoding];
-  else
-    obj = [obj initWithBytes: (void*)_contents.c
-		      length: _count
-		    encoding: internalEncoding];
-  return obj;
-}
-
-- (id) mutableCopyWithZone: (NSZone*)z
-{
-  GSMutableString	*obj;
-
-  obj = (GSMutableString*)NSAllocateObject(GSMutableStringClass, 0, z);
-
-  if (_flags.wide == 1)
-    obj = [obj initWithBytes: (void*)_contents.u
-		      length: _count * sizeof(unichar)
-		    encoding: NSUnicodeStringEncoding];
-  else
-    obj = [obj initWithBytes: (char*)_contents.c
-		      length: _count
-		    encoding: internalEncoding];
-  return obj;
-}
-
-- (NSRange) rangeOfComposedCharacterSequenceAtIndex: (NSUInteger)anIndex
-{
-  if (_flags.wide == 1)
-    return rangeOfSequence_u((GSStr)self, anIndex);
-  else
-    return rangeOfSequence_c((GSStr)self, anIndex);
-}
-
-- (NSRange) rangeOfCharacterFromSet: (NSCharacterSet*)aSet
-			    options: (NSUInteger)mask
-			      range: (NSRange)aRange
-{
-  GS_RANGE_CHECK(aRange, _count);
-  if (_flags.wide == 1)
-    return rangeOfCharacter_u((GSStr)self, aSet, mask, aRange);
-  else
-    return rangeOfCharacter_c((GSStr)self, aSet, mask, aRange);
-}
-
-- (void) replaceCharactersInRange: (NSRange)aRange
-		       withString: (NSString*)aString
-{
-  unsigned	length = 0;
-
-  GS_RANGE_CHECK(aRange, _count);
-  if (aString != nil)
-    {
-      if (GSObjCIsInstance(aString) == NO)
-	{
-	  [NSException raise: NSInvalidArgumentException
-		      format: @"replace characters with non-string"];
-	}
-      length = [aString length];
-    }
-
-  /* Either we have data to copy into the string (possibly requiring
-   * length adjustment first), or we have no data but possibly a gap
-   * (the range specified) needing to be closed.
-   */
-  if (length > 0)
-    {
-      int	offset = length - aRange.length;
-      GSStr	other = 0;
-
-      /* We must change into a unicode string (if necessary) *before*
-       * adjusting length and capacity, so that the transmute doesn't
-       * mess up due to any hole in the string etc.
-       */
-      other = transmute((GSStr)self, aString);
-
-      if (other == self)
-	{
-	  if (aRange.length == _count)
-	    {
-	      // NSLog(@"replace all characters with self ... nothing to do");
-	      return;
-	    }
-	  else if (aRange.length == 0
-	    && (aRange.location == _count || aRange.location == 0))
-	    {
-	      /* We are appending self at the end of self, or we are
-	       * prepending self at the start of the self.
-	       * Either way in effect we double the string, so we can
-	       * do an efficient size extension and copy.
-	       */
-	      makeHole((GSStr)self, length, length);
-	      if (_flags.wide)
-		{
-		  memcpy(&_contents.u[length], _contents.u,
-		    length * sizeof(unichar));
-		}
-	      else
-		{
-		  memcpy(&_contents.c[length], _contents.c,
-		    length * sizeof(char));
-		}
-	      _flags.hash = 0;
-	      return;
-	    }
-	  // NSLog(@"replace characters in range with self");
-	}
-      if (0 == other || other == self)
-	{
-	  /* Either we couldn't get access to the internal of the string
-	   * to be copied, or we are copying from ourself and need to
-           * use an intermediate buffer to prevent overwriting.
-	   */
-	  if (_flags.wide)
-	    {
-	      GS_BEGINITEMBUF(buf, (length * sizeof(unichar)), unichar);
-
-	      [aString getCharacters: buf];
-	      if (offset < 0)
-		{
-		  fillHole((GSStr)self, NSMaxRange(aRange) + offset, -offset);
-		}
-	      else if (offset > 0)
-		{
-		  makeHole((GSStr)self, NSMaxRange(aRange), (NSUInteger)offset);
-		}
-	      memcpy(&_contents.u[aRange.location], buf,
-		length * sizeof(unichar));
-	      GS_ENDITEMBUF()
-	    }
-	  else
-	    {
-	      GS_BEGINITEMBUF(buf, ((length+1) * sizeof(char)), char);
-
-	      [aString getCString: buf
-			maxLength: length+1
-			 encoding: internalEncoding];
-	      if (offset < 0)
-		{
-		  fillHole((GSStr)self, NSMaxRange(aRange) + offset, -offset);
-		}
-	      else if (offset > 0)
-		{
-		  makeHole((GSStr)self, NSMaxRange(aRange), (NSUInteger)offset);
-		}
-	      memcpy(&_contents.c[aRange.location], buf,
-		length * sizeof(char));
-	      GS_ENDITEMBUF()
-	    }
-	}
-      else
-	{
-	  if (offset < 0)
-	    {
-	      fillHole((GSStr)self, NSMaxRange(aRange) + offset, -offset);
-	    }
-	  else if (offset > 0)
-	    {
-	      makeHole((GSStr)self, NSMaxRange(aRange), (NSUInteger)offset);
-	    }
-	  if (_flags.wide == 1)
-	    {
-	      memcpy(&_contents.u[aRange.location], other->_contents.u,
-		length * sizeof(unichar));
-	    }
-	  else
-	    {
-	      memcpy(&_contents.c[aRange.location], other->_contents.c,
-		length * sizeof(char));
-	    }
-	}
-      _flags.hash = 0;
-    }
-  else if (aRange.length > 0)
-    {
-      fillHole((GSStr)self, aRange.location, aRange.length);
-      _flags.hash = 0;
-    }
-}
-
-- (void) setString: (NSString*)aString
-{
-  unsigned int	len = (aString == nil) ? 0 : [aString length];
-  GSStr	other;
-
-  if (len == 0)
-    {
-      _count = 0;
-      return;
-    }
-  other = transmute((GSStr)self, aString);
-  if (_count < len)
-    {
-      makeHole((GSStr)self, _count, (NSUInteger)(len - _count));
-    }
-  else
-    {
-      _count = len;
-      _flags.hash = 0;
-    }
-
-  if (_flags.wide == 1)
-    {
-      if (other == 0)
-	{
-	  [aString getCharacters: _contents.u];
-	}
-      else
-	{
-	  memcpy(_contents.u, other->_contents.u, len * sizeof(unichar));
-	}
-    }
-  else
-    {
-      if (other == 0)
-	{
-	  unsigned	l;
-	  unsigned	s = 1;
-	  unichar	u;
-	  unsigned char	*d;
-
-	  /*
-	   * Since getCString appends a '\0' terminator, we must ask for
-	   * one character less than we actually want, then get the last
-	   * character separately.
-	   */
-	  l = len - 1;
-	  if (l > 0)
-	    {
-	      [aString getCString: (char*)_contents.c
-			maxLength: l+1
-			 encoding: internalEncoding];
-	    }
-	  u = [aString characterAtIndex: l];
-	  d = _contents.c + l;
-          GSFromUnicode(&d, &s, &u, 1, internalEncoding, 0, GSUniStrict);
-	}
-      else
-	{
-	  memcpy(_contents.c, other->_contents.c, len);
-	}
-    }
-}
-
-- (NSStringEncoding) smallestEncoding
-{
-  if (_flags.wide == 1)
-    {
-      return NSUnicodeStringEncoding;
-    }
-  else
-    {
-      return internalEncoding;
-    }
-}
-
-- (NSString*) substringFromRange: (NSRange)aRange
-{
-  GS_RANGE_CHECK(aRange, _count);
-
-  if (aRange.length == 0)
-    {
-      return @"";
-    }
-  if (_flags.wide == 1)
-    {
-      GSUInlineString *o;
-
-      o = [newUInline(aRange.length, [self zone]) autorelease];
-      memcpy(o->_contents.u, _contents.u + aRange.location,
-	aRange.length * sizeof(unichar));
-      return o;
-    }
-  else
-    {
-      id tinyString;
-
-      tinyString = createTinyString((char*)_contents.c + aRange.location,
-        aRange.length);
-      if (tinyString)
-        {
-          return tinyString;
-        }
-      else
-        {
-          GSCInlineString *o;
-
-          o = [newCInline(aRange.length, [self zone]) autorelease];
-          memcpy(o->_contents.c, _contents.c + aRange.location, aRange.length);
-          return o;
-        }
-    }
-}
-
-- (NSString*) substringWithRange: (NSRange)aRange
-{
-  GS_RANGE_CHECK(aRange, _count);
-
-  if (aRange.length == 0)
-    {
-      return @"";
-    }
-  if (_flags.wide == 1)
-    {
-      GSUInlineString *o;
-
-      o = [newUInline(aRange.length, [self zone]) autorelease];
-      memcpy(o->_contents.u, _contents.u + aRange.location,
-	aRange.length * sizeof(unichar));
-      return o;
-    }
-  else
-    {
-      id tinyString;
-
-      tinyString = createTinyString((char*)_contents.c + aRange.location,
-        aRange.length);
-      if (tinyString)
-        {
-          return tinyString;
-        }
-      else
-        {
-          GSCInlineString *o;
-
-          o = [newCInline(aRange.length, [self zone]) autorelease];
-          memcpy(o->_contents.c, _contents.c + aRange.location, aRange.length);
-          return o;
-        }
-    }
-}
-
-- (id) uppercaseString
-{
-  if (_flags.wide == 1)
-    {
-      GSUInlineString	*o;
-      unsigned		i;
-
-      o = [newUInline(_count, [self zone]) autorelease];
-      i = _count;
-      while (i-- > 0)
-	{
-          o->_contents.u[i] = uni_toupper(_contents.u[i]);
-	}
-      return o;
-    }
-  return [super uppercaseString];
-}
-
-- (const char *) UTF8String
-{
-  if (_flags.wide == 1)
-    return UTF8String_u((GSStr)self);
-  return UTF8String_c((GSStr)self);
-}
-
-// private method for Unicode level 3 implementation
-- (int) _baseLength
-{
-  if (_flags.wide == 1)
-    {
-      unsigned int count = 0;
-      unsigned int blen = 0;
-
-      while (count < _count)
-	if (!uni_isnonsp(_contents.u[count++]))
-	  blen++;
-      return blen;
-    }
-  else
     return _count;
 }
 
-- (NSUInteger) sizeInBytesExcluding: (NSHashTable*)exclude
+- (NSUInteger)lengthOfBytesUsingEncoding:(NSStringEncoding)encoding
 {
-  NSUInteger    size = GSPrivateMemorySize(self, exclude);
+    if (_flags.wide == 1)
+        return cStringLength_u((GSStr)self, encoding);
+    else
+        return cStringLength_c((GSStr)self, encoding);
+}
 
-  if (size > 0 && _flags.owned)
-    {
-      size += _capacity;
-      if (_flags.wide)
-        {
-          size += _capacity;
+- (long long)longLongValue
+{
+    char buf[24];
+
+    if (_flags.wide == 1)
+        intBuf_u((GSStr)self, buf);
+    else
+        intBuf_c((GSStr)self, buf);
+    return strtoll(buf, 0, 10);
+}
+
+- (const char *)lossyCString
+{
+    if (_flags.wide == 1)
+        return lossyCString_u((GSStr)self);
+    else
+        return lossyCString_c((GSStr)self);
+}
+
+- (id)lowercaseString
+{
+    if (_flags.wide == 1) {
+        GSUInlineString *o;
+        unsigned i;
+
+        o = newUInline(_count, [self zone]);
+        i = _count;
+        while (i-- > 0) {
+            o->_contents.u[i] = uni_tolower(_contents.u[i]);
+        }
+        return [o autorelease];
+    }
+    return [super lowercaseString];
+}
+
+- (BOOL)makeImmutable
+{
+    NSAssert(_flags.owned == 1 && _zone != 0, NSInternalInconsistencyException);
+    if (_flags.wide == 1) {
+        GSClassSwizzle(self, [GSUnicodeBufferString class]);
+    } else {
+        GSClassSwizzle(self, [GSCBufferString class]);
+    }
+    return YES;
+}
+
+- (id)makeImmutableCopyOnFail:(BOOL)force
+{
+    NSAssert(_flags.owned == 1 && _zone != 0, NSInternalInconsistencyException);
+    if (_flags.wide == 1) {
+        GSClassSwizzle(self, [GSUnicodeBufferString class]);
+    } else {
+        GSClassSwizzle(self, [GSCBufferString class]);
+    }
+    return self;
+}
+
+- (id)mutableCopy
+{
+    GSMutableString *obj;
+
+    obj = (GSMutableString *)NSAllocateObject(GSMutableStringClass, 0,
+                                              NSDefaultMallocZone());
+
+    if (_flags.wide == 1)
+        obj = [obj initWithBytes:(void *)_contents.u
+                          length:_count * sizeof(unichar)
+                        encoding:NSUnicodeStringEncoding];
+    else
+        obj = [obj initWithBytes:(void *)_contents.c
+                          length:_count
+                        encoding:internalEncoding];
+    return obj;
+}
+
+- (id)mutableCopyWithZone:(NSZone *)z
+{
+    GSMutableString *obj;
+
+    obj = (GSMutableString *)NSAllocateObject(GSMutableStringClass, 0, z);
+
+    if (_flags.wide == 1)
+        obj = [obj initWithBytes:(void *)_contents.u
+                          length:_count * sizeof(unichar)
+                        encoding:NSUnicodeStringEncoding];
+    else
+        obj = [obj initWithBytes:(char *)_contents.c
+                          length:_count
+                        encoding:internalEncoding];
+    return obj;
+}
+
+- (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
+{
+    if (_flags.wide == 1)
+        return rangeOfSequence_u((GSStr)self, anIndex);
+    else
+        return rangeOfSequence_c((GSStr)self, anIndex);
+}
+
+- (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+                           options:(NSUInteger)mask
+                             range:(NSRange)aRange
+{
+    GS_RANGE_CHECK(aRange, _count);
+    if (_flags.wide == 1)
+        return rangeOfCharacter_u((GSStr)self, aSet, mask, aRange);
+    else
+        return rangeOfCharacter_c((GSStr)self, aSet, mask, aRange);
+}
+
+- (void)replaceCharactersInRange:(NSRange)aRange
+                      withString:(NSString *)aString
+{
+    unsigned length = 0;
+
+    GS_RANGE_CHECK(aRange, _count);
+    if (aString != nil) {
+        if (GSObjCIsInstance(aString) == NO) {
+            [NSException raise:NSInvalidArgumentException
+                        format:@"replace characters with non-string"];
+        }
+        length = [aString length];
+    }
+
+    /* Either we have data to copy into the string (possibly requiring
+     * length adjustment first), or we have no data but possibly a gap
+     * (the range specified) needing to be closed.
+     */
+    if (length > 0) {
+        int offset = length - aRange.length;
+        GSStr other = 0;
+
+        /* We must change into a unicode string (if necessary) *before*
+         * adjusting length and capacity, so that the transmute doesn't
+         * mess up due to any hole in the string etc.
+         */
+        other = transmute((GSStr)self, aString);
+
+        if (other == self) {
+            if (aRange.length == _count) {
+                // NSLog(@"replace all characters with self ... nothing to do");
+                return;
+            } else if (aRange.length == 0 && (aRange.location == _count || aRange.location == 0)) {
+                /* We are appending self at the end of self, or we are
+                 * prepending self at the start of the self.
+                 * Either way in effect we double the string, so we can
+                 * do an efficient size extension and copy.
+                 */
+                makeHole((GSStr)self, length, length);
+                if (_flags.wide) {
+                    memcpy(&_contents.u[length], _contents.u,
+                           length * sizeof(unichar));
+                } else {
+                    memcpy(&_contents.c[length], _contents.c,
+                           length * sizeof(char));
+                }
+                _flags.hash = 0;
+                return;
+            }
+            // NSLog(@"replace characters in range with self");
+        }
+        if (0 == other || other == self) {
+            /* Either we couldn't get access to the internal of the string
+             * to be copied, or we are copying from ourself and need to
+             * use an intermediate buffer to prevent overwriting.
+             */
+            if (_flags.wide) {
+                GS_BEGINITEMBUF(buf, (length * sizeof(unichar)), unichar);
+
+                [aString getCharacters:buf];
+                if (offset < 0) {
+                    fillHole((GSStr)self, NSMaxRange(aRange) + offset, -offset);
+                } else if (offset > 0) {
+                    makeHole((GSStr)self, NSMaxRange(aRange), (NSUInteger)offset);
+                }
+                memcpy(&_contents.u[aRange.location], buf,
+                       length * sizeof(unichar));
+                GS_ENDITEMBUF()
+            } else {
+                GS_BEGINITEMBUF(buf, ((length + 1) * sizeof(char)), char);
+
+                [aString getCString:buf
+                          maxLength:length + 1
+                           encoding:internalEncoding];
+                if (offset < 0) {
+                    fillHole((GSStr)self, NSMaxRange(aRange) + offset, -offset);
+                } else if (offset > 0) {
+                    makeHole((GSStr)self, NSMaxRange(aRange), (NSUInteger)offset);
+                }
+                memcpy(&_contents.c[aRange.location], buf,
+                       length * sizeof(char));
+                GS_ENDITEMBUF()
+            }
+        } else {
+            if (offset < 0) {
+                fillHole((GSStr)self, NSMaxRange(aRange) + offset, -offset);
+            } else if (offset > 0) {
+                makeHole((GSStr)self, NSMaxRange(aRange), (NSUInteger)offset);
+            }
+            if (_flags.wide == 1) {
+                memcpy(&_contents.u[aRange.location], other->_contents.u,
+                       length * sizeof(unichar));
+            } else {
+                memcpy(&_contents.c[aRange.location], other->_contents.c,
+                       length * sizeof(char));
+            }
+        }
+        _flags.hash = 0;
+    } else if (aRange.length > 0) {
+        fillHole((GSStr)self, aRange.location, aRange.length);
+        _flags.hash = 0;
+    }
+}
+
+- (void)setString:(NSString *)aString
+{
+    unsigned int len = (aString == nil) ? 0 : [aString length];
+    GSStr other;
+
+    if (len == 0) {
+        _count = 0;
+        return;
+    }
+    other = transmute((GSStr)self, aString);
+    if (_count < len) {
+        makeHole((GSStr)self, _count, (NSUInteger)(len - _count));
+    } else {
+        _count = len;
+        _flags.hash = 0;
+    }
+
+    if (_flags.wide == 1) {
+        if (other == 0) {
+            [aString getCharacters:_contents.u];
+        } else {
+            memcpy(_contents.u, other->_contents.u, len * sizeof(unichar));
+        }
+    } else {
+        if (other == 0) {
+            unsigned l;
+            unsigned s = 1;
+            unichar u;
+            unsigned char *d;
+
+            /*
+             * Since getCString appends a '\0' terminator, we must ask for
+             * one character less than we actually want, then get the last
+             * character separately.
+             */
+            l = len - 1;
+            if (l > 0) {
+                [aString getCString:(char *)_contents.c
+                          maxLength:l + 1
+                           encoding:internalEncoding];
+            }
+            u = [aString characterAtIndex:l];
+            d = _contents.c + l;
+            GSFromUnicode(&d, &s, &u, 1, internalEncoding, 0, GSUniStrict);
+        } else {
+            memcpy(_contents.c, other->_contents.c, len);
         }
     }
-  return size;
+}
+
+- (NSStringEncoding)smallestEncoding
+{
+    if (_flags.wide == 1) {
+        return NSUnicodeStringEncoding;
+    } else {
+        return internalEncoding;
+    }
+}
+
+- (NSString *)substringFromRange:(NSRange)aRange
+{
+    GS_RANGE_CHECK(aRange, _count);
+
+    if (aRange.length == 0) {
+        return @"";
+    }
+    if (_flags.wide == 1) {
+        GSUInlineString *o;
+
+        o = [newUInline(aRange.length, [self zone]) autorelease];
+        memcpy(o->_contents.u, _contents.u + aRange.location,
+               aRange.length * sizeof(unichar));
+        return o;
+    } else {
+        id tinyString;
+
+        tinyString = createTinyString((char *)_contents.c + aRange.location,
+                                      aRange.length);
+        if (tinyString) {
+            return tinyString;
+        } else {
+            GSCInlineString *o;
+
+            o = [newCInline(aRange.length, [self zone]) autorelease];
+            memcpy(o->_contents.c, _contents.c + aRange.location, aRange.length);
+            return o;
+        }
+    }
+}
+
+- (NSString *)substringWithRange:(NSRange)aRange
+{
+    GS_RANGE_CHECK(aRange, _count);
+
+    if (aRange.length == 0) {
+        return @"";
+    }
+    if (_flags.wide == 1) {
+        GSUInlineString *o;
+
+        o = [newUInline(aRange.length, [self zone]) autorelease];
+        memcpy(o->_contents.u, _contents.u + aRange.location,
+               aRange.length * sizeof(unichar));
+        return o;
+    } else {
+        id tinyString;
+
+        tinyString = createTinyString((char *)_contents.c + aRange.location,
+                                      aRange.length);
+        if (tinyString) {
+            return tinyString;
+        } else {
+            GSCInlineString *o;
+
+            o = [newCInline(aRange.length, [self zone]) autorelease];
+            memcpy(o->_contents.c, _contents.c + aRange.location, aRange.length);
+            return o;
+        }
+    }
+}
+
+- (id)uppercaseString
+{
+    if (_flags.wide == 1) {
+        GSUInlineString *o;
+        unsigned i;
+
+        o = [newUInline(_count, [self zone]) autorelease];
+        i = _count;
+        while (i-- > 0) {
+            o->_contents.u[i] = uni_toupper(_contents.u[i]);
+        }
+        return o;
+    }
+    return [super uppercaseString];
+}
+
+- (const char *)UTF8String
+{
+    if (_flags.wide == 1)
+        return UTF8String_u((GSStr)self);
+    return UTF8String_c((GSStr)self);
+}
+
+// private method for Unicode level 3 implementation
+- (int)_baseLength
+{
+    if (_flags.wide == 1) {
+        unsigned int count = 0;
+        unsigned int blen = 0;
+
+        while (count < _count)
+            if (!uni_isnonsp(_contents.u[count++]))
+                blen++;
+        return blen;
+    } else
+        return _count;
+}
+
+- (NSUInteger)sizeInBytesExcluding:(NSHashTable *)exclude
+{
+    NSUInteger size = GSPrivateMemorySize(self, exclude);
+
+    if (size > 0 && _flags.owned) {
+        size += _capacity;
+        if (_flags.wide) {
+            size += _capacity;
+        }
+    }
+    return size;
 }
 
 @end
 
-
 
 #ifndef GNUSTEP_NEW_STRING_ABI
 static BOOL
 literalIsEqual(NXConstantString *self, id anObject)
 {
-  Class	c;
+    Class c;
 
-  if (anObject == (id)self)
-    {
-      return YES;
+    if (anObject == (id)self) {
+        return YES;
     }
-  if (anObject == nil)
-    {
-      return NO;
+    if (anObject == nil) {
+        return NO;
     }
 #if defined(OBJC_SMALL_OBJECT_SHIFT) && (OBJC_SMALL_OBJECT_SHIFT == 3)
-  if (useTinyStrings)
-    {
-      uintptr_t s = (uintptr_t)anObject;
+    if (useTinyStrings) {
+        uintptr_t s = (uintptr_t)anObject;
 
-      if (s & TINY_STRING_MASK)
-        {
-          return tinyEqualToString((uintptr_t)anObject, self);
+        if (s & TINY_STRING_MASK) {
+            return tinyEqualToString((uintptr_t)anObject, self);
         }
     }
 #endif
-  if (GSObjCIsInstance(anObject) == NO)
-    {
-      return NO;
+    if (GSObjCIsInstance(anObject) == NO) {
+        return NO;
     }
-  c = object_getClass(anObject);
-  if (c == NSConstantStringClass)
-    {
-      NXConstantString	*other = (NXConstantString*)anObject;
+    c = object_getClass(anObject);
+    if (c == NSConstantStringClass) {
+        NXConstantString *other = (NXConstantString *)anObject;
 
-      if (other->nxcslen != self->nxcslen
-	|| strcmp(other->nxcsptr, self->nxcsptr) != 0)
-	{
-	  return NO;
-	}
-      return YES;
-    }
-  else if (c == GSMutableStringClass || GSObjCIsKindOf(c, GSStringClass) == YES)
+        if (other->nxcslen != self->nxcslen || strcmp(other->nxcsptr, self->nxcsptr) != 0) {
+            return NO;
+        }
+        return YES;
+    } else if (c == GSMutableStringClass || GSObjCIsKindOf(c, GSStringClass) == YES) {
+        return literalIsEqualInternal(self, (GSStr)anObject);
+    } else if (YES == [anObject isKindOfClass:NSStringClass]) // may be proxy
     {
-      return literalIsEqualInternal(self, (GSStr)anObject);
-    }
-  else if (YES == [anObject isKindOfClass: NSStringClass]) // may be proxy
-    {
-      unichar		(*imp)(id, SEL, NSUInteger);
-      NSUInteger	len = [anObject length];
-      NSUInteger	pos = 0;
-      unichar		n = 0;
-      unsigned		i = 0;
-      unichar		u;
+        unichar (*imp)(id, SEL, NSUInteger);
+        NSUInteger len = [anObject length];
+        NSUInteger pos = 0;
+        unichar n = 0;
+        unsigned i = 0;
+        unichar u;
 
-      if (len > self->nxcslen)
-	{
-	  /* Since UTF-8 is a multibyte character set, it must have at least
-	   * as many bytes as another string of the same length. So if the
-	   * UTF-8 string is shorter, the two cannot be equal.
-	   */
-	  return NO;
-	}
+        if (len > self->nxcslen) {
+            /* Since UTF-8 is a multibyte character set, it must have at least
+             * as many bytes as another string of the same length. So if the
+             * UTF-8 string is shorter, the two cannot be equal.
+             */
+            return NO;
+        }
 
-      /* Do a character by character comparison using characterAtIndex:
-       */
-      imp = (unichar(*)(id,SEL,NSUInteger))[anObject methodForSelector:
-	@selector(characterAtIndex:)];
-      while (i < self->nxcslen || n > 0)
-	{
-	  u = nextUTF8((const uint8_t *)self->nxcsptr,
-	    self->nxcslen, &i, &n);
-	  if (pos >= len
-	    || (*imp)(anObject, @selector(characterAtIndex:), pos) != u)
-	    {
-	      return NO;
-	    }
-	  pos++;
-	}
-      if (pos != len)
-	{
-	  return NO;
-	}
-      return YES;
+        /* Do a character by character comparison using characterAtIndex:
+         */
+        imp = (unichar(*)(id, SEL, NSUInteger))[anObject methodForSelector:
+                                                             @selector(characterAtIndex:)];
+        while (i < self->nxcslen || n > 0) {
+            u = nextUTF8((const uint8_t *)self->nxcsptr,
+                         self->nxcslen, &i, &n);
+            if (pos >= len || (*imp)(anObject, @selector(characterAtIndex:), pos) != u) {
+                return NO;
+            }
+            pos++;
+        }
+        if (pos != len) {
+            return NO;
+        }
+        return YES;
     }
-  return NO;
+    return NO;
 }
 #endif
 
 #ifdef GNUSTEP_NEW_STRING_ABI
-#  define CONSTANT_STRING_ENCODING() (flags & 3)
-#  define CONSTANT_STRING_HAS_HASH() ((flags & (1<<16)) == (1<<16))
-#  define CONSTANT_STRING_SET_HAS_HASH() do { flags |= (1<<16); } while(0)
+#define CONSTANT_STRING_ENCODING() (flags & 3)
+#define CONSTANT_STRING_HAS_HASH() ((flags & (1 << 16)) == (1 << 16))
+#define CONSTANT_STRING_SET_HAS_HASH() \
+    do {                               \
+        flags |= (1 << 16);            \
+    } while (0)
 #endif
 
 
@@ -5560,244 +4870,221 @@ literalIsEqual(NXConstantString *self, id anObject)
  * <p>The NXConstantString class is used by the compiler for constant
  * strings, as such its ivar layout is determined by the compiler
  * and consists of a pointer (_contents.c) and a character count
- * (_count). 
+ * (_count).
  */
 @implementation NXConstantString
 
-+ (void) initialize
++ (void)initialize
 {
-  if (self == [NXConstantString class])
-    {
-      NSConstantStringClass = self;
+    if (self == [NXConstantString class]) {
+        NSConstantStringClass = self;
     }
 }
 
-- (const char*) UTF8String
+- (const char *)UTF8String
 {
 #ifdef GNUSTEP_NEW_STRING_ABI
-  switch (CONSTANT_STRING_ENCODING())
-  {
-      case 0: // ASCII
-      case 1: // UTF-8
-	  return nxcsptr;
-      case 2: // UTF-16
-	{
-	  unsigned int l = 0;
-	  unsigned char *r = 0;
+    switch (CONSTANT_STRING_ENCODING()) {
+        case 0: // ASCII
+        case 1: // UTF-8
+            return nxcsptr;
+        case 2: // UTF-16
+        {
+            unsigned int l = 0;
+            unsigned char *r = 0;
 
-	  if (GSFromUnicode(&r, &l, (const unichar*)(void*)nxcsptr, nxcslen, NSUTF8StringEncoding,
-	    NSDefaultMallocZone(), GSUniTerminate|GSUniTemporary|GSUniStrict) == NO)
-	    {
-	      [NSException raise: NSCharacterConversionException
-			  format: @"Can't get UTF8 from Unicode string."];
-	    }
-	  return (const char*)r;
-	}
-      case 4: // UTF-32
-	return [super UTF8String];
-  }
-  GS_UNREACHABLE();
+            if (GSFromUnicode(&r, &l, (const unichar *)(void *)nxcsptr, nxcslen, NSUTF8StringEncoding,
+                              NSDefaultMallocZone(), GSUniTerminate | GSUniTemporary | GSUniStrict) == NO) {
+                [NSException raise:NSCharacterConversionException
+                            format:@"Can't get UTF8 from Unicode string."];
+            }
+            return (const char *)r;
+        }
+        case 4: // UTF-32
+            return [super UTF8String];
+    }
+    GS_UNREACHABLE();
 #else
-  return nxcsptr;
+    return nxcsptr;
 #endif
 }
 
-- (unichar) characterAtIndex: (NSUInteger)index
+- (unichar)characterAtIndex:(NSUInteger)index
 {
 #ifdef GNUSTEP_NEW_STRING_ABI
-  if (index >= nxcslen)
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"-characterAtIndex: index out of range"];
+    if (index >= nxcslen) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"-characterAtIndex: index out of range"];
     }
-  switch (CONSTANT_STRING_ENCODING())
-  {
-      case 0: // ASCII
-      case 1: // UTF-8
-	  return nxcsptr[index];
-      case 2: // UTF-16
-	  return ((unichar*)(void*)nxcsptr)[index];
-  }
-  GS_UNREACHABLE();
+    switch (CONSTANT_STRING_ENCODING()) {
+        case 0: // ASCII
+        case 1: // UTF-8
+            return nxcsptr[index];
+        case 2: // UTF-16
+            return ((unichar *)(void *)nxcsptr)[index];
+    }
+    GS_UNREACHABLE();
 #else
-  NSUInteger	l = 0;
-  unichar	u;
-  unichar	n = 0;
-  unsigned	i = 0;
+    NSUInteger l = 0;
+    unichar u;
+    unichar n = 0;
+    unsigned i = 0;
 
-  while (i < nxcslen || n > 0)
-    {
-      u = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-      if (l++ == index)
-	{
-	  return u;
-	}
+    while (i < nxcslen || n > 0) {
+        u = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+        if (l++ == index) {
+            return u;
+        }
     }
 
-  [NSException raise: NSInvalidArgumentException
-	      format: @"-characterAtIndex: index out of range"];
-  return 0;
+    [NSException raise:NSInvalidArgumentException
+                format:@"-characterAtIndex: index out of range"];
+    return 0;
 #endif
 }
 
 #ifndef GNUSTEP_NEW_STRING_ABI
 
-- (BOOL) canBeConvertedToEncoding: (NSStringEncoding)encoding
+- (BOOL)canBeConvertedToEncoding:(NSStringEncoding)encoding
 {
-  /* If the string contains bad (non-utf8) data, the lengthUTF8() function
-   * will raise an exception ... we catch it and return NO in that case
-   * since this method is not expected to raise exceptions.
-   */
-  NS_DURING
+    /* If the string contains bad (non-utf8) data, the lengthUTF8() function
+     * will raise an exception ... we catch it and return NO in that case
+     * since this method is not expected to raise exceptions.
+     */
+    NS_DURING
     {
-      if (NSASCIIStringEncoding == encoding)
-        {
-          BOOL	ascii;
+        if (NSASCIIStringEncoding == encoding) {
+            BOOL ascii;
 
-          lengthUTF8((const uint8_t*)nxcsptr, nxcslen, &ascii, 0);
-          NS_VALRETURN(ascii);
-        }
-      else if (NSISOLatin1StringEncoding == encoding)
-        {
-          BOOL	latin1;
+            lengthUTF8((const uint8_t *)nxcsptr, nxcslen, &ascii, 0);
+            NS_VALRETURN(ascii);
+        } else if (NSISOLatin1StringEncoding == encoding) {
+            BOOL latin1;
 
-          lengthUTF8((const uint8_t*)nxcsptr, nxcslen, 0, &latin1);
-          NS_VALRETURN(latin1);
-        }
-      else if (NSUTF8StringEncoding == encoding
-        || NSUnicodeStringEncoding == encoding)
-        {
-          lengthUTF8((const uint8_t*)nxcsptr, nxcslen, 0, 0);
-          NS_VALRETURN(YES);
-        }
-      else
-        {
-          id d = [self dataUsingEncoding: encoding allowLossyConversion: NO];
+            lengthUTF8((const uint8_t *)nxcsptr, nxcslen, 0, &latin1);
+            NS_VALRETURN(latin1);
+        } else if (NSUTF8StringEncoding == encoding || NSUnicodeStringEncoding == encoding) {
+            lengthUTF8((const uint8_t *)nxcsptr, nxcslen, 0, 0);
+            NS_VALRETURN(YES);
+        } else {
+            id d = [self dataUsingEncoding:encoding allowLossyConversion:NO];
 
-          NS_VALRETURN(d != nil ? YES : NO);
+            NS_VALRETURN(d != nil ? YES : NO);
         }
     }
-  NS_HANDLER
+    NS_HANDLER
     {
-      return NO;
+        return NO;
     }
-  NS_ENDHANDLER
+    NS_ENDHANDLER
 }
 
-- (NSData*) dataUsingEncoding: (NSStringEncoding)encoding
-	 allowLossyConversion: (BOOL)flag
+- (NSData *)dataUsingEncoding:(NSStringEncoding)encoding
+         allowLossyConversion:(BOOL)flag
 {
-  BOOL	        ascii;
-  BOOL	        latin1;
-  unsigned	length;
+    BOOL ascii;
+    BOOL latin1;
+    unsigned length;
 
-  /* Check what is actually in this string ... if it's corrupt an exception
-   * is raised.
-   */
-  length = lengthUTF8((const uint8_t*)nxcsptr, nxcslen, &ascii, &latin1);
+    /* Check what is actually in this string ... if it's corrupt an exception
+     * is raised.
+     */
+    length = lengthUTF8((const uint8_t *)nxcsptr, nxcslen, &ascii, &latin1);
 
-  if (NSUTF8StringEncoding == encoding)
-    {
-      /* We want utf-8, so we can just return an object pointing to the
-       * constant string data since e just checked that it's UTF8 in
-       * lengthUTF8().
-       */
-      return [NSDataClass dataWithBytesNoCopy: (void*)nxcsptr
-				       length: nxcslen
-				 freeWhenDone: NO];
+    if (NSUTF8StringEncoding == encoding) {
+        /* We want utf-8, so we can just return an object pointing to the
+         * constant string data since e just checked that it's UTF8 in
+         * lengthUTF8().
+         */
+        return [NSDataClass dataWithBytesNoCopy:(void *)nxcsptr
+                                         length:nxcslen
+                                   freeWhenDone:NO];
     }
 
-  if (YES == ascii && GSPrivateIsByteEncoding(encoding))
-    {
-      /* The constant string data is just ascii, so we can return a
-       * pointer to it directly for any encoding which has ascii as
-       * a subset.
-       */
-      return [NSDataClass dataWithBytesNoCopy: (void*)nxcsptr
-                                       length: nxcslen
-                                 freeWhenDone: NO];
+    if (YES == ascii && GSPrivateIsByteEncoding(encoding)) {
+        /* The constant string data is just ascii, so we can return a
+         * pointer to it directly for any encoding which has ascii as
+         * a subset.
+         */
+        return [NSDataClass dataWithBytesNoCopy:(void *)nxcsptr
+                                         length:nxcslen
+                                   freeWhenDone:NO];
     }
 
-  if (YES == latin1 && NSISOLatin1StringEncoding == encoding)
-    {
-      unsigned	i = 0;
-      unichar	n = 0;
-      uint8_t	*b;
-      uint8_t	*p;
+    if (YES == latin1 && NSISOLatin1StringEncoding == encoding) {
+        unsigned i = 0;
+        unichar n = 0;
+        uint8_t *b;
+        uint8_t *p;
 
-      /* If all the characters are latin1 we can copy them efficiently.
-       */
-      p = b = NSAllocateCollectable(length, 0);
-      while (i < nxcslen)
-        {
-          *p++ = (uint8_t)nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+        /* If all the characters are latin1 we can copy them efficiently.
+         */
+        p = b = NSAllocateCollectable(length, 0);
+        while (i < nxcslen) {
+            *p++ = (uint8_t)nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
         }
-      return [NSDataClass dataWithBytesNoCopy: (void*)b
-                                       length: length
-                                 freeWhenDone: YES];
+        return [NSDataClass dataWithBytesNoCopy:(void *)b
+                                         length:length
+                                   freeWhenDone:YES];
     }
 
-  return [super dataUsingEncoding: encoding allowLossyConversion: flag];
+    return [super dataUsingEncoding:encoding allowLossyConversion:flag];
 }
 
 #endif
 
-- (void) dealloc
+- (void)dealloc
 {
-  GSNOSUPERDEALLOC;
+    GSNOSUPERDEALLOC;
 }
 
-- (void) getCharacters: (unichar*)buffer
-		 range: (NSRange)aRange
+- (void)getCharacters:(unichar *)buffer
+                range:(NSRange)aRange
 {
 #ifdef GNUSTEP_NEW_STRING_ABI
-  GS_RANGE_CHECK(aRange, nxcslen);
-  switch (CONSTANT_STRING_ENCODING())
-  {
-      case 0: // ASCII
-	for (int i=0 ; i<aRange.length ; i++)
-	  {
-	    buffer[i] = (unichar)nxcsptr[aRange.location + i];
-	  }
-	return;
-      case 1: // UTF-8
-	NSAssert(0, @"UTF-8 constant strings not yet supported");
-      case 2: // UTF-16
-	memcpy(buffer, nxcsptr + (aRange.location * sizeof(unichar)), aRange.length * sizeof(unichar));
-	return;
-      case 3:
-	NSAssert(0, @"UTF-32 constant strings not yet supported");
-  }
-  GS_UNREACHABLE();
+    GS_RANGE_CHECK(aRange, nxcslen);
+    switch (CONSTANT_STRING_ENCODING()) {
+        case 0: // ASCII
+            for (int i = 0; i < aRange.length; i++) {
+                buffer[i] = (unichar)nxcsptr[aRange.location + i];
+            }
+            return;
+        case 1: // UTF-8
+            NSAssert(0, @"UTF-8 constant strings not yet supported");
+        case 2: // UTF-16
+            memcpy(buffer, nxcsptr + (aRange.location * sizeof(unichar)), aRange.length * sizeof(unichar));
+            return;
+        case 3:
+            NSAssert(0, @"UTF-32 constant strings not yet supported");
+    }
+    GS_UNREACHABLE();
 #else
-  unichar	n = 0;
-  unsigned	i = 0;
-  NSUInteger	max = NSMaxRange(aRange);
-  NSUInteger	index = 0;
+    unichar n = 0;
+    unsigned i = 0;
+    NSUInteger max = NSMaxRange(aRange);
+    NSUInteger index = 0;
 
-  if (NSNotFound == aRange.location)
-    [NSException raise: NSRangeException format:
-      @"in %s, range { %"PRIuPTR", %"PRIuPTR" } extends beyond string",
-      GSNameFromSelector(_cmd), aRange.location, aRange.length];
+    if (NSNotFound == aRange.location)
+        [NSException raise:NSRangeException
+                    format:
+                        @"in %s, range { %" PRIuPTR ", %" PRIuPTR " } extends beyond string",
+                        GSNameFromSelector(_cmd), aRange.location, aRange.length];
 
-  while (index < aRange.location && (i < nxcslen || n > 0))
-    {
-      nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-      index++;
+    while (index < aRange.location && (i < nxcslen || n > 0)) {
+        nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+        index++;
     }
-  if (index == aRange.location)
-    {
-      while (index < max && (i < nxcslen || n > 0))
-	{
-	  *buffer++ = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-	  index++;
-	}
+    if (index == aRange.location) {
+        while (index < max && (i < nxcslen || n > 0)) {
+            *buffer++ = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+            index++;
+        }
     }
-  if (index != max)
-    {
-      [NSException raise: NSRangeException format:
-	@"in %s, range { %"PRIuPTR", %"PRIuPTR" } extends beyond string",
-        GSNameFromSelector(_cmd), aRange.location, aRange.length];
+    if (index != max) {
+        [NSException raise:NSRangeException
+                    format:
+                        @"in %s, range { %" PRIuPTR ", %" PRIuPTR " } extends beyond string",
+                        GSNameFromSelector(_cmd), aRange.location, aRange.length];
     }
 #endif
 }
@@ -5805,382 +5092,347 @@ literalIsEqual(NXConstantString *self, id anObject)
 // This method was deprecated on Mac OS X 10.5, so if we provide an improved
 // version here then we should do it using the newer version.
 #ifndef GNUSTEP_NEW_STRING_ABI
-- (BOOL) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	   encoding: (NSStringEncoding)encoding
+- (BOOL)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+          encoding:(NSStringEncoding)encoding
 {
-  const uint8_t *ptr = (const uint8_t*)nxcsptr;
-  int           length = nxcslen;
-  int           index;
+    const uint8_t *ptr = (const uint8_t *)nxcsptr;
+    int length = nxcslen;
+    int index;
 
-  if (0 == maxLength || 0 == buffer)
-    {
-      return NO;	// Can't fit in here
+    if (0 == maxLength || 0 == buffer) {
+        return NO; // Can't fit in here
     }
-  if (NSUTF8StringEncoding == encoding)
-    {
-      BOOL	result = (length < maxLength) ? YES : NO;
+    if (NSUTF8StringEncoding == encoding) {
+        BOOL result = (length < maxLength) ? YES : NO;
 
-      /* We are already using UTF-8 so we can just copy directly.
-       */
-      if (maxLength <= length)
-        {
-          length = maxLength - 1;
+        /* We are already using UTF-8 so we can just copy directly.
+         */
+        if (maxLength <= length) {
+            length = maxLength - 1;
         }
-      for (index = 0; index < length; index++)
-        {
-          buffer[index] = (char)ptr[index];
+        for (index = 0; index < length; index++) {
+            buffer[index] = (char)ptr[index];
         }
-      /* Step back before any multibyte sequence
-       */
-      while (index > 0 && (ptr[index - 1] & 0x80))
-	{
-          index--;
+        /* Step back before any multibyte sequence
+         */
+        while (index > 0 && (ptr[index - 1] & 0x80)) {
+            index--;
         }
-      buffer[index] = '\0';
-      return result;
-    }
-  else if (isByteEncoding(encoding))
-    {
-      BOOL	result = (length < maxLength) ? YES : NO;
+        buffer[index] = '\0';
+        return result;
+    } else if (isByteEncoding(encoding)) {
+        BOOL result = (length < maxLength) ? YES : NO;
 
-      /* We want a single-byte encoding (ie ascii is a subset),
-       * so as long as this constant string is ascii, we can just
-       * copy directly.
-       */
-      if (maxLength <= length)
-        {
-          length = maxLength - 1;
+        /* We want a single-byte encoding (ie ascii is a subset),
+         * so as long as this constant string is ascii, we can just
+         * copy directly.
+         */
+        if (maxLength <= length) {
+            length = maxLength - 1;
         }
-      for (index = 0; index < length; index++)
-        {
-          buffer[index] = (char)ptr[index];
-          if (ptr[index] & 0x80)
-            {
-              break;    // Not ascii 
+        for (index = 0; index < length; index++) {
+            buffer[index] = (char)ptr[index];
+            if (ptr[index] & 0x80) {
+                break; // Not ascii
             }
         }
-      if (index == length)
-	{
-          buffer[index] = '\0';
-          return result;
+        if (index == length) {
+            buffer[index] = '\0';
+            return result;
         }
-      // Fall through to use superclass method.
+        // Fall through to use superclass method.
     }
-  return [super getCString: buffer maxLength: maxLength encoding: encoding];
+    return [super getCString:buffer maxLength:maxLength encoding:encoding];
 }
 #endif
 
 /* Must match the implementation in NSString
  * To avoid allocating memory, we build the hash incrementally.
  */
-- (NSUInteger) hash
+- (NSUInteger)hash
 {
 #ifdef GNUSTEP_NEW_STRING_ABI
-  if (CONSTANT_STRING_HAS_HASH())
+    if (CONSTANT_STRING_HAS_HASH())
+        return hash;
+    hash = [super hash];
+    CONSTANT_STRING_SET_HAS_HASH();
     return hash;
-  hash = [super hash];
-  CONSTANT_STRING_SET_HAS_HASH();
-  return hash;
 #else
-  if (nxcslen > 0)
-    {
-      uint32_t  s0 = 0;
-      uint32_t  s1 = 0;
-      unichar   chunk[64];
-      uint32_t	ret;
-      unichar	n = 0;
-      unsigned	i = 0;
-      int       l = 0;
-      uint32_t  t = 0;
+    if (nxcslen > 0) {
+        uint32_t s0 = 0;
+        uint32_t s1 = 0;
+        unichar chunk[64];
+        uint32_t ret;
+        unichar n = 0;
+        unsigned i = 0;
+        int l = 0;
+        uint32_t t = 0;
 
-      while (i < nxcslen)
-	{
-	  chunk[l++] = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-	  if (64 == l)
-            {
-              GSPrivateIncrementalHash(&s0, &s1, chunk, l * sizeof(unichar));
-              t += l;
-              l = 0;
+        while (i < nxcslen) {
+            chunk[l++] = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+            if (64 == l) {
+                GSPrivateIncrementalHash(&s0, &s1, chunk, l * sizeof(unichar));
+                t += l;
+                l = 0;
             }
-	}
-      if (0 != n)
-	{
-	  chunk[l++] = n;	// Add final character
-	}
-      if (l > 0)
-        {
-          GSPrivateIncrementalHash(&s0, &s1, chunk, l * sizeof(unichar));
-          t += l;
         }
-      ret = GSPrivateFinishHash(s0, s1, t * sizeof(unichar));
-      ret &= 0x0fffffff;
-      if (ret == 0)
-	{
-	  ret = 0x0fffffff;
-	}
-      return ret;
-    }
-  else
-    {
-      return 0x0ffffffe;	/* Hash for an empty string.	*/
+        if (0 != n) {
+            chunk[l++] = n; // Add final character
+        }
+        if (l > 0) {
+            GSPrivateIncrementalHash(&s0, &s1, chunk, l * sizeof(unichar));
+            t += l;
+        }
+        ret = GSPrivateFinishHash(s0, s1, t * sizeof(unichar));
+        ret &= 0x0fffffff;
+        if (ret == 0) {
+            ret = 0x0fffffff;
+        }
+        return ret;
+    } else {
+        return 0x0ffffffe; /* Hash for an empty string.	*/
     }
 #endif
 }
 
-- (id) initWithBytes: (const void*)bytes
-	      length: (NSUInteger)length
-	    encoding: (NSStringEncoding)encoding
+- (id)initWithBytes:(const void *)bytes
+             length:(NSUInteger)length
+           encoding:(NSStringEncoding)encoding
 {
-  [NSException raise: NSGenericException
-	      format: @"Attempt to init a constant string"];
-  return nil;
+    [NSException raise:NSGenericException
+                format:@"Attempt to init a constant string"];
+    return nil;
 }
 
-- (id) initWithBytesNoCopy: (void*)bytes
-		    length: (NSUInteger)length
-		  encoding: (NSStringEncoding)encoding
-	      freeWhenDone: (BOOL)flag
+- (id)initWithBytesNoCopy:(void *)bytes
+                   length:(NSUInteger)length
+                 encoding:(NSStringEncoding)encoding
+             freeWhenDone:(BOOL)flag
 {
-  [NSException raise: NSGenericException
-	      format: @"Attempt to init a constant string"];
-  return nil;
+    [NSException raise:NSGenericException
+                format:@"Attempt to init a constant string"];
+    return nil;
 }
 
 #ifdef GNUSTEP_NEW_STRING_ABI
-- (NSUInteger) length
+- (NSUInteger)length
 {
-  // In the new encoding, nxcslen is always the length of the string in UTF-16
-  // codepoints
-  return nxcslen;
+    // In the new encoding, nxcslen is always the length of the string in UTF-16
+    // codepoints
+    return nxcslen;
 }
 
 #else
 
-- (BOOL) isEqual: (id)anObject
+- (BOOL)isEqual:(id)anObject
 {
-  return literalIsEqual(self, anObject);
+    return literalIsEqual(self, anObject);
 }
 
-- (BOOL) isEqualToString: (NSString*)other
+- (BOOL)isEqualToString:(NSString *)other
 {
-  return literalIsEqual(self, other);
+    return literalIsEqual(self, other);
 }
 
-- (int) intValue
+- (int)intValue
 {
-  return strtol((const char*)nxcsptr, 0, 10);
+    return strtol((const char *)nxcsptr, 0, 10);
 }
 
-- (NSInteger) integerValue
+- (NSInteger)integerValue
 {
 #if GS_SIZEOF_VOIDP == GS_SIZEOF_LONG
-  return strtol((const char*)nxcsptr, 0, 10);
+    return strtol((const char *)nxcsptr, 0, 10);
 #else
-  return strtoll((const char*)nxcsptr, 0, 10);
+    return strtoll((const char *)nxcsptr, 0, 10);
 #endif
 }
 
-- (NSUInteger) length
+- (NSUInteger)length
 {
-  return lengthUTF8((const uint8_t*)nxcsptr, nxcslen, 0, 0);
+    return lengthUTF8((const uint8_t *)nxcsptr, nxcslen, 0, 0);
 }
 
-- (long long) longLongValue
+- (long long)longLongValue
 {
-  return strtoll((const char*)nxcsptr, 0, 10);
+    return strtoll((const char *)nxcsptr, 0, 10);
 }
 
-- (NSRange) rangeOfCharacterFromSet: (NSCharacterSet*)aSet
-			    options: (NSUInteger)mask
-			      range: (NSRange)aRange
+- (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+                           options:(NSUInteger)mask
+                             range:(NSRange)aRange
 {
-  NSUInteger	index;
-  NSUInteger	start;
-  NSUInteger	stop;
-  NSRange	range;
-  BOOL		ascii;
+    NSUInteger index;
+    NSUInteger start;
+    NSUInteger stop;
+    NSRange range;
+    BOOL ascii;
 
-  index = lengthUTF8((const uint8_t*)nxcsptr, nxcslen, &ascii, 0);
-  GS_RANGE_CHECK(aRange, index);
+    index = lengthUTF8((const uint8_t *)nxcsptr, nxcslen, &ascii, 0);
+    GS_RANGE_CHECK(aRange, index);
 
-  start = aRange.location;
-  stop = NSMaxRange(aRange);
+    start = aRange.location;
+    stop = NSMaxRange(aRange);
 
-  range.location = NSNotFound;
-  range.length = 0;
+    range.location = NSNotFound;
+    range.length = 0;
 
-  if (stop  > start)
-    {
-      BOOL	(*mImp)(id, SEL, unichar);
-      unichar	n = 0;
-      unsigned	i = 0;
+    if (stop > start) {
+        BOOL (*mImp)
+        (id, SEL, unichar);
+        unichar n = 0;
+        unsigned i = 0;
 
-      mImp = (BOOL(*)(id,SEL,unichar))
-	[aSet methodForSelector: @selector(characterIsMember:)];
+        mImp = (BOOL(*)(id, SEL, unichar))
+            [aSet methodForSelector:@selector(characterIsMember:)];
 
-      for (index = 0; index < start; index++)
-	{
-	  nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-	}
-      if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-	{
-	  unichar	buf[stop - start];
-	  NSUInteger	pos = 0;
-	  
-	  for (pos = 0; pos + start < stop; pos++)
-	    {
-	      buf[pos] = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-	    }
-	  index = stop;
-	  while (index-- > start)
-	    {
-	      if ((*mImp)(aSet, @selector(characterIsMember:), buf[--pos]))
-		{
-		  range = NSMakeRange(index, 1);
-		  break;
-		}
-	    }
-	}
-      else
-	{
-	  while (index < stop)
-	    {
-	      unichar letter;
+        for (index = 0; index < start; index++) {
+            nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+        }
+        if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+            unichar buf[stop - start];
+            NSUInteger pos = 0;
 
-	      letter = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-	      if ((*mImp)(aSet, @selector(characterIsMember:), letter))
-		{
-		  range = NSMakeRange(index, 1);
-		  break;
-		}
-	      index++;
-	    }
-	}
+            for (pos = 0; pos + start < stop; pos++) {
+                buf[pos] = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+            }
+            index = stop;
+            while (index-- > start) {
+                if ((*mImp)(aSet, @selector(characterIsMember:), buf[--pos])) {
+                    range = NSMakeRange(index, 1);
+                    break;
+                }
+            }
+        } else {
+            while (index < stop) {
+                unichar letter;
+
+                letter = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+                if ((*mImp)(aSet, @selector(characterIsMember:), letter)) {
+                    range = NSMakeRange(index, 1);
+                    break;
+                }
+                index++;
+            }
+        }
     }
 
-  return range;
+    return range;
 }
 
-- (NSRange) rangeOfComposedCharacterSequenceAtIndex: (NSUInteger)anIndex
+- (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
 {
-  NSUInteger	start = 0;
-  NSUInteger	pos = 0;
-  unichar	n = 0;
-  unsigned	i = 0;
-  unichar	u;
+    NSUInteger start = 0;
+    NSUInteger pos = 0;
+    unichar n = 0;
+    unsigned i = 0;
+    unichar u;
 
-  /* A composed character sequence consists of a single base character
-   * followed by zero or more non-base characters.
-   */
-  while (i < nxcslen || n > 0)
-    {
-      u = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-      if (!uni_isnonsp(u))
-	{
-	  /* This may be the base character at the start of the sequence.
-	   */
-	  start = pos;
-	}
-      if (pos++ == anIndex)
-	{
-	  /* Look ahead to see if the character at the specified index is
-	   * followed by one or more non-base characters. If it is, we
-	   * make the range longer before returning it.
-	   */
-	  while (i < nxcslen || n > 0)
-	    {
-	      u = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
-	      if (!uni_isnonsp(u))
-		{
-		  break;
-		}
-	      pos++;
-	    }
-	  return NSMakeRange(start, pos - start);
-	}
+    /* A composed character sequence consists of a single base character
+     * followed by zero or more non-base characters.
+     */
+    while (i < nxcslen || n > 0) {
+        u = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+        if (!uni_isnonsp(u)) {
+            /* This may be the base character at the start of the sequence.
+             */
+            start = pos;
+        }
+        if (pos++ == anIndex) {
+            /* Look ahead to see if the character at the specified index is
+             * followed by one or more non-base characters. If it is, we
+             * make the range longer before returning it.
+             */
+            while (i < nxcslen || n > 0) {
+                u = nextUTF8((const uint8_t *)nxcsptr, nxcslen, &i, &n);
+                if (!uni_isnonsp(u)) {
+                    break;
+                }
+                pos++;
+            }
+            return NSMakeRange(start, pos - start);
+        }
     }
 
-  [NSException raise: NSInvalidArgumentException
-    format: @"-rangeOfComposedCharacterSequenceAtIndex: index out of range"];
-  return NSMakeRange(NSNotFound, 0);
+    [NSException raise:NSInvalidArgumentException
+                format:@"-rangeOfComposedCharacterSequenceAtIndex: index out of range"];
+    return NSMakeRange(NSNotFound, 0);
 }
 #endif // GNUSTEP_NEW_STRING_ABI
 
-- (id) retain
+- (id)retain
 {
-  return self;
+    return self;
 }
 
-- (oneway void) release
+- (oneway void)release
 {
-  return;
+    return;
 }
 
-- (id) autorelease
+- (id)autorelease
 {
-  return self;
+    return self;
 }
 
-- (id) copyWithZone: (NSZone*)z
+- (id)copyWithZone:(NSZone *)z
 {
-  return self;
+    return self;
 }
 
-- (NSZone*) zone
+- (NSZone *)zone
 {
-  return NSDefaultMallocZone();
+    return NSDefaultMallocZone();
 }
 
-- (NSStringEncoding) fastestEncoding
+- (NSStringEncoding)fastestEncoding
 {
 #ifdef GNUSTEP_NEW_STRING_ABI
-  switch (CONSTANT_STRING_ENCODING())
-  {
-      case 0: // ASCII
-	return NSASCIIStringEncoding;
-      case 1: // UTF-8
-	  return NSUTF8StringEncoding;
-      case 2: // UTF-16
-	  return NSUTF16StringEncoding;
-      case 3: // UTF-32
-	  return NSUTF32StringEncoding;
-  }
-  GS_UNREACHABLE();
+    switch (CONSTANT_STRING_ENCODING()) {
+        case 0: // ASCII
+            return NSASCIIStringEncoding;
+        case 1: // UTF-8
+            return NSUTF8StringEncoding;
+        case 2: // UTF-16
+            return NSUTF16StringEncoding;
+        case 3: // UTF-32
+            return NSUTF32StringEncoding;
+    }
+    GS_UNREACHABLE();
 #else
-  return NSUTF8StringEncoding;
+    return NSUTF8StringEncoding;
 #endif
 }
 
-- (NSStringEncoding) smallestEncoding
+- (NSStringEncoding)smallestEncoding
 {
 #ifdef GNUSTEP_NEW_STRING_ABI
-  // UTF-16 might not be the smallest encoding for UTF-16 strings, but for now
-  // we'll pretend that it is.
-  switch (CONSTANT_STRING_ENCODING())
-  {
-      case 0: // ASCII
-	return NSASCIIStringEncoding;
-      case 1: // UTF-8
-	  return NSUTF8StringEncoding;
-      case 2: // UTF-16
-      case 3: // UTF-32
-	  return NSUTF16StringEncoding;
-  }
-  GS_UNREACHABLE();
+    // UTF-16 might not be the smallest encoding for UTF-16 strings, but for now
+    // we'll pretend that it is.
+    switch (CONSTANT_STRING_ENCODING()) {
+        case 0: // ASCII
+            return NSASCIIStringEncoding;
+        case 1: // UTF-8
+            return NSUTF8StringEncoding;
+        case 2: // UTF-16
+        case 3: // UTF-32
+            return NSUTF16StringEncoding;
+    }
+    GS_UNREACHABLE();
 #else
-  return NSUTF8StringEncoding;
+    return NSUTF8StringEncoding;
 #endif
 }
 
-- (NSUInteger) sizeOfContentExcluding: (NSHashTable*)exclude
+- (NSUInteger)sizeOfContentExcluding:(NSHashTable *)exclude
 {
-  return 0;	// Constant string uses no heap
+    return 0; // Constant string uses no heap
 }
 
-- (NSUInteger) sizeOfInstance
+- (NSUInteger)sizeOfInstance
 {
-  return 0;	// Constant string uses no heap
+    return 0; // Constant string uses no heap
 }
 
 @end
@@ -6189,82 +5441,64 @@ literalIsEqual(NXConstantString *self, id anObject)
 /**
  * Append characters to a string.
  */
-void
-GSPrivateStrAppendUnichars(GSStr s, const unichar *u, unsigned l)
+void GSPrivateStrAppendUnichars(GSStr s, const unichar *u, unsigned l)
 {
-  /*
-   * Make the string wide if necessary.
-   */
-  if (s->_flags.wide == 0)
-    {
-      BOOL	widen = NO;
+    /*
+     * Make the string wide if necessary.
+     */
+    if (s->_flags.wide == 0) {
+        BOOL widen = NO;
 
-      if (internalEncoding == NSISOLatin1StringEncoding)
-	{
-	  unsigned	i;
+        if (internalEncoding == NSISOLatin1StringEncoding) {
+            unsigned i;
 
-	  for (i = 0; i < l; i++)
-	    {
-	      if (u[i] > 255)
-		{
-		  widen = YES;
-		  break;
-		}
-	    }
-	}
-      else
-	{
-	  unsigned	i;
+            for (i = 0; i < l; i++) {
+                if (u[i] > 255) {
+                    widen = YES;
+                    break;
+                }
+            }
+        } else {
+            unsigned i;
 
-	  for (i = 0; i < l; i++)
-	    {
-	      if (u[i] > 127)
-		{
-		  widen = YES;
-		  break;
-		}
-	    }
-	}
-      if (widen == YES)
-	{
-	  GSStrWiden(s);
-	}
+            for (i = 0; i < l; i++) {
+                if (u[i] > 127) {
+                    widen = YES;
+                    break;
+                }
+            }
+        }
+        if (widen == YES) {
+            GSStrWiden(s);
+        }
     }
 
-  /*
-   * Make room for the characters we are appending.
-   */
-  if (s->_count + l + 1 >= s->_capacity)
-    {
-      GSStrMakeSpace(s, l);
+    /*
+     * Make room for the characters we are appending.
+     */
+    if (s->_count + l + 1 >= s->_capacity) {
+        GSStrMakeSpace(s, l);
     }
 
-  /*
-   * Copy the characters into place.
-   */
-  if (s->_flags.wide == 1)
-    {
-      memcpy(s->_contents.u + s->_count, u, l * sizeof(unichar));
-      s->_count += l;
-    }
-  else
-    {
-      unsigned 	i;
+    /*
+     * Copy the characters into place.
+     */
+    if (s->_flags.wide == 1) {
+        memcpy(s->_contents.u + s->_count, u, l * sizeof(unichar));
+        s->_count += l;
+    } else {
+        unsigned i;
 
-      for (i = 0; i < l; i++)
-	{
-	  s->_contents.c[s->_count++] = u[i];
-	}
+        for (i = 0; i < l; i++) {
+            s->_contents.c[s->_count++] = u[i];
+        }
     }
 }
 
 
-void
-GSPrivateStrExternalize(GSStr s)
+void GSPrivateStrExternalize(GSStr s)
 {
-  if (s->_flags.wide == 0 && internalEncoding != externalEncoding)
-    {
-      GSStrWiden(s);
+    if (s->_flags.wide == 0 && internalEncoding != externalEncoding) {
+        GSStrWiden(s);
     }
 }
-

--- a/Source/NSDate.m
+++ b/Source/NSDate.m
@@ -1006,6 +1006,7 @@ otherTime(NSDate* other)
   NSCalendarDate *d = [calendarClass alloc];
 
   d = [d initWithTimeIntervalSinceReferenceDate: otherTime(self)];
+  [d setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
   s = [d description];
   RELEASE(d);
   return s;
@@ -1045,6 +1046,7 @@ otherTime(NSDate* other)
   NSCalendarDate *d = [calendarClass alloc];
 
   d = [d initWithTimeIntervalSinceReferenceDate: otherTime(self)];
+  [d setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
   s = [d descriptionWithLocale: locale];
   RELEASE(d);
   return s;

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -3476,10 +3476,27 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
 // of a null terminator.
 inline static int HACK_GetCharacterWidth(NSStringEncoding encoding)
 {
+    // return quickly on common encodings
+    switch (encoding) {
+        case NSASCIIStringEncoding:
+        case NSUTF8StringEncoding:
+        case NSISOLatin1StringEncoding:
+            return 1;
+        case NSUnicodeStringEncoding:
+            return 2;
+        default:
+            break;
+    }
+
+    // otherwise, do the hacky thing
     const static NSString *testString = @"a";
+
     NSData *data = [testString dataUsingEncoding:encoding];
     assert(data != nil);
-    return [data length];
+
+    NSUInteger width =  [data length];
+
+    return width;
 }
 
 /**

--- a/Source/NSString.m
+++ b/Source/NSString.m
@@ -82,43 +82,43 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#if	defined(HAVE_SYS_FCNTL_H)
-#  include	<sys/fcntl.h>
-#elif	defined(HAVE_FCNTL_H)
-#  include	<fcntl.h>
+#if defined(HAVE_SYS_FCNTL_H)
+#include <sys/fcntl.h>
+#elif defined(HAVE_FCNTL_H)
+#include <fcntl.h>
 #endif
 
 #include <stdio.h>
 #include <wchar.h>
 
 #ifdef HAVE_MALLOC_H
-#  ifndef __OpenBSD__
-#    include <malloc.h>
-#  endif
+#ifndef __OpenBSD__
+#include <malloc.h>
+#endif
 #endif
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #endif
-#if	defined(HAVE_UNICODE_UCOL_H)
-# include <unicode/ucol.h>
+#if defined(HAVE_UNICODE_UCOL_H)
+#include <unicode/ucol.h>
 #endif
-#if	defined(HAVE_UNICODE_UNORM2_H)
-# include <unicode/unorm2.h>
+#if defined(HAVE_UNICODE_UNORM2_H)
+#include <unicode/unorm2.h>
 #endif
-#if	defined(HAVE_UNICODE_USTRING_H)
-# include <unicode/ustring.h>
+#if defined(HAVE_UNICODE_USTRING_H)
+#include <unicode/ustring.h>
 #endif
-#if	defined(HAVE_UNICODE_USEARCH_H)
-# include <unicode/usearch.h>
+#if defined(HAVE_UNICODE_USEARCH_H)
+#include <unicode/usearch.h>
 #endif
-#if	defined(HAVE_UNICODE_UBRK_H)
-# include <unicode/ubrk.h>
+#if defined(HAVE_UNICODE_UBRK_H)
+#include <unicode/ubrk.h>
 #endif
-#if	defined(HAVE_UNICODE_UTYPES_H)
-# include <unicode/utypes.h>
+#if defined(HAVE_UNICODE_UTYPES_H)
+#include <unicode/utypes.h>
 #endif
-#if	defined(HAVE_ICU_H)
-# include <icu.h>
+#if defined(HAVE_ICU_H)
+#include <icu.h>
 #endif
 
 /* Create local inline versions of key functions for case-insensitive operations
@@ -127,89 +127,83 @@
 static inline unichar
 uni_toupper(unichar ch)
 {
-  unichar result = gs_toupper_map[ch / 256][ch % 256];
-  return result ? result : ch;
+    unichar result = gs_toupper_map[ch / 256][ch % 256];
+    return result ? result : ch;
 }
 static inline unichar
 uni_tolower(unichar ch)
 {
-  unichar result = gs_tolower_map[ch / 256][ch % 256];
-  return result ? result : ch;
+    unichar result = gs_tolower_map[ch / 256][ch % 256];
+    return result ? result : ch;
 }
 
 #import "GNUstepBase/Unicode.h"
 
-@interface	NSScanner (Double)
-+ (BOOL) _scanDouble: (double*)value from: (NSString*)str;
+@interface NSScanner (Double)
++ (BOOL)_scanDouble:(double *)value from:(NSString *)str;
 @end
 
-@class	GSString;
-@class	GSMutableString;
-@class	GSPlaceholderString;
-@interface GSPlaceholderString : NSString	// Help the compiler
+@class GSString;
+@class GSMutableString;
+@class GSPlaceholderString;
+@interface GSPlaceholderString : NSString // Help the compiler
 @end
-@class	GSMutableArray;
-@class	GSMutableDictionary;
+@class GSMutableArray;
+@class GSMutableDictionary;
 
 /*
  * Cache classes and method implementations for speed.
  */
-static Class	NSDataClass;
-static Class	NSStringClass;
-static Class	NSMutableStringClass;
+static Class NSDataClass;
+static Class NSStringClass;
+static Class NSMutableStringClass;
 
-static Class	GSStringClass;
-static Class	GSMutableStringClass;
-static Class	GSPlaceholderStringClass;
+static Class GSStringClass;
+static Class GSMutableStringClass;
+static Class GSPlaceholderStringClass;
 
-static GSPlaceholderString	*defaultPlaceholderString;
-static NSMapTable		*placeholderMap;
-static gs_mutex_t		placeholderLock = GS_MUTEX_INIT_STATIC;
+static GSPlaceholderString *defaultPlaceholderString;
+static NSMapTable *placeholderMap;
+static gs_mutex_t placeholderLock = GS_MUTEX_INIT_STATIC;
 
 
-static SEL	                cMemberSel = 0;
-static NSCharacterSet	        *nonBase = nil;
-static BOOL                     (*nonBaseImp)(id, SEL, unichar) = 0;
+static SEL cMemberSel = 0;
+static NSCharacterSet *nonBase = nil;
+static BOOL (*nonBaseImp)(id, SEL, unichar) = 0;
 
 /* Macro to return the receiver if it is already immutable, but an
  * autoreleased copy otherwise.  Used where we have to return an
- * immutable string, but we don't want to change the parameter from 
+ * immutable string, but we don't want to change the parameter from
  * a mutable string to an immutable one.
  */
-#define	IMMUTABLE(S)	AUTORELEASE([(S) copyWithZone: NSDefaultMallocZone()])
+#define IMMUTABLE(S) AUTORELEASE([(S) copyWithZone:NSDefaultMallocZone()])
 
-static inline BOOL  isWhiteSpace(unichar c)
+static inline BOOL isWhiteSpace(unichar c)
 {
-  /* We can not use whitespaceAndNewlineCharacterSet here as this would lead
-   * to a recursion, as this also reads in a property list.
-   *
-   * Copied whitespace and newline index set from  NSCharacterSetData.h
-   */
-  static const NSRange whitespace[] = {{9,5},{32,1},{133,1},{160,1},{5760,1},{8192,12},{8232,2},{8239,1},{8287,1},{12288,1}};
-  unsigned	upper = sizeof(whitespace)/sizeof(*whitespace);
-  unsigned	lower = 0;
-  unsigned	pos;
-  NSRange	r;
+    /* We can not use whitespaceAndNewlineCharacterSet here as this would lead
+     * to a recursion, as this also reads in a property list.
+     *
+     * Copied whitespace and newline index set from  NSCharacterSetData.h
+     */
+    static const NSRange whitespace[] = {{9, 5}, {32, 1}, {133, 1}, {160, 1}, {5760, 1}, {8192, 12}, {8232, 2}, {8239, 1}, {8287, 1}, {12288, 1}};
+    unsigned upper = sizeof(whitespace) / sizeof(*whitespace);
+    unsigned lower = 0;
+    unsigned pos;
+    NSRange r;
 
-  /* Binary search for a range containing the character to be checked
-   */
-  for (pos = upper/2; upper != lower; pos = (upper+lower)/2)
-    {
-      r = whitespace[pos];
-      if (c < r.location)
-        {
-          upper = pos;
-        }
-      else if (c >= NSMaxRange(r))
-        {
-          lower = pos + 1;
-        }
-      else
-        {
-          break;
+    /* Binary search for a range containing the character to be checked
+     */
+    for (pos = upper / 2; upper != lower; pos = (upper + lower) / 2) {
+        r = whitespace[pos];
+        if (c < r.location) {
+            upper = pos;
+        } else if (c >= NSMaxRange(r)) {
+            lower = pos + 1;
+        } else {
+            break;
         }
     }
-  return (c >= r.location && c < NSMaxRange(r)) ? YES : NO;
+    return (c >= r.location && c < NSMaxRange(r)) ? YES : NO;
 }
 
 #define GS_IS_WHITESPACE(X) isWhiteSpace(X)
@@ -224,32 +218,32 @@ static inline BOOL  isWhiteSpace(unichar c)
 inline BOOL
 uni_isnonsp(unichar u)
 {
-  /* Treating upper surrogates as non-spacing is a convenient solution
-   * to a number of issues with UTF-16
-   */
-  if ((u >= 0xdc00) && (u <= 0xdfff))
-    return YES;
+    /* Treating upper surrogates as non-spacing is a convenient solution
+     * to a number of issues with UTF-16
+     */
+    if ((u >= 0xdc00) && (u <= 0xdfff))
+        return YES;
 
-  return (*nonBaseImp)(nonBase, cMemberSel, u);
+    return (*nonBaseImp)(nonBase, cMemberSel, u);
 }
 
 /*
  *	Include sequence handling code with instructions to generate search
  *	and compare functions for NSString objects.
  */
-#define	GSEQ_STRCOMP	strCompNsNs
-#define	GSEQ_STRRANGE	strRangeNsNs
-#define	GSEQ_O	GSEQ_NS
-#define	GSEQ_S	GSEQ_NS
+#define GSEQ_STRCOMP strCompNsNs
+#define GSEQ_STRRANGE strRangeNsNs
+#define GSEQ_O GSEQ_NS
+#define GSEQ_S GSEQ_NS
 #include "GSeq.h"
 
 /*
  * The path handling mode.
  */
 static enum {
-  PH_DO_THE_RIGHT_THING,
-  PH_UNIX,
-  PH_WINDOWS
+    PH_DO_THE_RIGHT_THING,
+    PH_UNIX,
+    PH_WINDOWS
 } pathHandling = PH_DO_THE_RIGHT_THING;
 
 /**
@@ -263,40 +257,36 @@ static enum {
  * Any other none-null string sets do-the-right-thing mode.<br />
  * The function returns a C String describing the old mode.
  */
-GS_DECLARE const char*
+GS_DECLARE const char *
 GSPathHandling(const char *mode)
 {
-  int	old = pathHandling;
+    int old = pathHandling;
 
-  if (mode != 0)
-    {
-      if (strcasecmp(mode, "windows") == 0)
-	{
-	  pathHandling = PH_WINDOWS;
-	}
-      else if (strcasecmp(mode, "unix") == 0)
-	{
-	  pathHandling = PH_UNIX;
-	}
-      else
-	{
-	  pathHandling = PH_DO_THE_RIGHT_THING;
-	}
+    if (mode != 0) {
+        if (strcasecmp(mode, "windows") == 0) {
+            pathHandling = PH_WINDOWS;
+        } else if (strcasecmp(mode, "unix") == 0) {
+            pathHandling = PH_UNIX;
+        } else {
+            pathHandling = PH_DO_THE_RIGHT_THING;
+        }
     }
-  switch (old)
-    {
-      case PH_WINDOWS:		return "windows";
-      case PH_UNIX:		return "unix";
-      default:			return "right";
+    switch (old) {
+        case PH_WINDOWS:
+            return "windows";
+        case PH_UNIX:
+            return "unix";
+        default:
+            return "right";
     }
 }
 
-#define	GSPathHandlingRight()	\
-  ((pathHandling == PH_DO_THE_RIGHT_THING) ? YES : NO)
-#define	GSPathHandlingUnix()	\
-  ((pathHandling == PH_UNIX) ? YES : NO)
-#define	GSPathHandlingWindows()	\
-  ((pathHandling == PH_WINDOWS) ? YES : NO)
+#define GSPathHandlingRight() \
+    ((pathHandling == PH_DO_THE_RIGHT_THING) ? YES : NO)
+#define GSPathHandlingUnix() \
+    ((pathHandling == PH_UNIX) ? YES : NO)
+#define GSPathHandlingWindows() \
+    ((pathHandling == PH_WINDOWS) ? YES : NO)
 
 /*
  * The pathSeps character set is used for parsing paths ... it *must*
@@ -306,79 +296,62 @@ GSPathHandling(const char *mode)
  * We can't have a 'pathSeps' variable initialized in the +initialize
  * method because that would cause recursion.
  */
-static NSCharacterSet*
+static NSCharacterSet *
 pathSeps(void)
 {
-  static NSCharacterSet	*wPathSeps = nil;
-  static NSCharacterSet	*uPathSeps = nil;
-  static NSCharacterSet	*rPathSeps = nil;
-  if (GSPathHandlingRight())
-    {
-      if (rPathSeps == nil)
-	{
-	  GS_MUTEX_LOCK(placeholderLock);
-	  if (rPathSeps == nil)
-	    {
-	      rPathSeps
-		= [NSCharacterSet characterSetWithCharactersInString: @"/\\"];
-              rPathSeps = [NSObject leakAt: &rPathSeps];
-	    }
-	  GS_MUTEX_UNLOCK(placeholderLock);
-	}
-      return rPathSeps;
+    static NSCharacterSet *wPathSeps = nil;
+    static NSCharacterSet *uPathSeps = nil;
+    static NSCharacterSet *rPathSeps = nil;
+    if (GSPathHandlingRight()) {
+        if (rPathSeps == nil) {
+            GS_MUTEX_LOCK(placeholderLock);
+            if (rPathSeps == nil) {
+                rPathSeps = [NSCharacterSet characterSetWithCharactersInString:@"/\\"];
+                rPathSeps = [NSObject leakAt:&rPathSeps];
+            }
+            GS_MUTEX_UNLOCK(placeholderLock);
+        }
+        return rPathSeps;
     }
-  if (GSPathHandlingUnix())
-    {
-      if (uPathSeps == nil)
-	{
-	  GS_MUTEX_LOCK(placeholderLock);
-	  if (uPathSeps == nil)
-	    {
-	      uPathSeps
-		= [NSCharacterSet characterSetWithCharactersInString: @"/"];
-              uPathSeps = [NSObject leakAt: &uPathSeps];
-	    }
-	  GS_MUTEX_UNLOCK(placeholderLock);
-	}
-      return uPathSeps;
+    if (GSPathHandlingUnix()) {
+        if (uPathSeps == nil) {
+            GS_MUTEX_LOCK(placeholderLock);
+            if (uPathSeps == nil) {
+                uPathSeps = [NSCharacterSet characterSetWithCharactersInString:@"/"];
+                uPathSeps = [NSObject leakAt:&uPathSeps];
+            }
+            GS_MUTEX_UNLOCK(placeholderLock);
+        }
+        return uPathSeps;
     }
-  if (GSPathHandlingWindows())
-    {
-      if (wPathSeps == nil)
-	{
-	  GS_MUTEX_LOCK(placeholderLock);
-	  if (wPathSeps == nil)
-	    {
-	      wPathSeps
-		= [NSCharacterSet characterSetWithCharactersInString: @"\\"];
-              wPathSeps = [NSObject leakAt: &wPathSeps];
-	    }
-	  GS_MUTEX_UNLOCK(placeholderLock);
-	}
-      return wPathSeps;
+    if (GSPathHandlingWindows()) {
+        if (wPathSeps == nil) {
+            GS_MUTEX_LOCK(placeholderLock);
+            if (wPathSeps == nil) {
+                wPathSeps = [NSCharacterSet characterSetWithCharactersInString:@"\\"];
+                wPathSeps = [NSObject leakAt:&wPathSeps];
+            }
+            GS_MUTEX_UNLOCK(placeholderLock);
+        }
+        return wPathSeps;
     }
-  pathHandling = PH_DO_THE_RIGHT_THING;
-  return pathSeps();
+    pathHandling = PH_DO_THE_RIGHT_THING;
+    return pathSeps();
 }
 
 inline static BOOL
 pathSepMember(unichar c)
 {
-  if (c == (unichar)'/')
-    {
-      if (GSPathHandlingWindows() == NO)
-	{
-	  return YES;
-	}
+    if (c == (unichar)'/') {
+        if (GSPathHandlingWindows() == NO) {
+            return YES;
+        }
+    } else if (c == (unichar)'\\') {
+        if (GSPathHandlingUnix() == NO) {
+            return YES;
+        }
     }
-  else if (c == (unichar)'\\')
-    {
-      if (GSPathHandlingUnix() == NO)
-	{
-	  return YES;
-	}
-    }
-  return NO;
+    return NO;
 }
 
 /* For cross-platform portability we always use slash as the separator
@@ -391,11 +364,10 @@ pathSepMember(unichar c)
 inline static unichar
 pathSepChar()
 {
-  if (GSPathHandlingWindows() == NO)
-    {
-      return '/';
+    if (GSPathHandlingWindows() == NO) {
+        return '/';
     }
-  return '\\';
+    return '\\';
 }
 
 /*
@@ -403,14 +375,13 @@ pathSepChar()
  * when building paths ... unless specific windows path handling is
  * required.
  */
-inline static NSString*
+inline static NSString *
 pathSepString()
 {
-  if (GSPathHandlingWindows() == NO)
-    {
-      return @"/";
+    if (GSPathHandlingWindows() == NO) {
+        return @"/";
     }
-  return @"\\";
+    return @"\\";
 }
 
 /*
@@ -446,89 +417,69 @@ pathSepString()
  */
 static unsigned rootOf(NSString *s, unsigned l)
 {
-  unsigned	root = 0;
+    unsigned root = 0;
 
-  if (l > 0)
-    {
-      unichar	c = [s characterAtIndex: 0];
+    if (l > 0) {
+        unichar c = [s characterAtIndex:0];
 
-      if (c == '~')
-	{
-	  NSRange	range = NSMakeRange(1, l-1);
+        if (c == '~') {
+            NSRange range = NSMakeRange(1, l - 1);
 
-	  range = [s rangeOfCharacterFromSet: pathSeps()
-				     options: NSLiteralSearch
-				       range: range];
-	  if (range.length == 0)
-	    {
-	      root = l;			// ~ or ~name
-	    }
-	  else
-	    {
-	      root = NSMaxRange(range);	// ~/... or ~name/...
-	    }
-	}
-      else
-	{
-	  if (pathSepMember(c))
-	    {
-	      root++;
-	    }
-	  if (GSPathHandlingUnix() == NO)
-	    {
-	      if (root == 0 && l > 1
-		&& ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
-		&& [s characterAtIndex: 1] == ':')
-		{
-		  // Got a drive relative path ... see if it's absolute.
-		  root = 2;
-		  if (l > 2 && pathSepMember([s characterAtIndex: 2]))
-		    {
-		      root++;
-		    }
-		}
-	      else if (root == 1
-		&& l > 4 && pathSepMember([s characterAtIndex: 1]))
-		{
-		  NSRange	range = NSMakeRange(2, l-2);
+            range = [s rangeOfCharacterFromSet:pathSeps()
+                                       options:NSLiteralSearch
+                                         range:range];
+            if (range.length == 0) {
+                root = l; // ~ or ~name
+            } else {
+                root = NSMaxRange(range); // ~/... or ~name/...
+            }
+        } else {
+            if (pathSepMember(c)) {
+                root++;
+            }
+            if (GSPathHandlingUnix() == NO) {
+                if (root == 0 && l > 1 && ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) && [s characterAtIndex:1] == ':') {
+                    // Got a drive relative path ... see if it's absolute.
+                    root = 2;
+                    if (l > 2 && pathSepMember([s characterAtIndex:2])) {
+                        root++;
+                    }
+                } else if (root == 1 && l > 4 && pathSepMember([s characterAtIndex:1])) {
+                    NSRange range = NSMakeRange(2, l - 2);
 
-		  range = [s rangeOfCharacterFromSet: pathSeps()
-					     options: NSLiteralSearch
-					       range: range];
-		  if (range.length > 0 && range.location > 2)
-		    {
-		      unsigned pos = NSMaxRange(range);
+                    range = [s rangeOfCharacterFromSet:pathSeps()
+                                               options:NSLiteralSearch
+                                                 range:range];
+                    if (range.length > 0 && range.location > 2) {
+                        unsigned pos = NSMaxRange(range);
 
-		      // Found end of UNC host perhaps ... look for share
-		      if (pos < l)
-			{
-			  range = NSMakeRange(pos, l - pos);
-			  range = [s rangeOfCharacterFromSet: pathSeps()
-						     options: NSLiteralSearch
-						       range: range];
-			  if (range.length > 0)
-			    {
-			      /*
-			       * Found another slash ...  but if it comes
-			       * immediately after the last one this can't
-			       * be a UNC path as it's '//host//' rather
-			       * than '//host/share'
-			       */
-			      if (range.location > pos)
-				{
-				  /* OK ... we have the '//host/share/'
-				   * format, so this is a valid UNC path.
-				   */
-				  root = NSMaxRange(range);
-				}
-			    }
-			}
-		    }
-		}
-	    }
-	}
+                        // Found end of UNC host perhaps ... look for share
+                        if (pos < l) {
+                            range = NSMakeRange(pos, l - pos);
+                            range = [s rangeOfCharacterFromSet:pathSeps()
+                                                       options:NSLiteralSearch
+                                                         range:range];
+                            if (range.length > 0) {
+                                /*
+                                 * Found another slash ...  but if it comes
+                                 * immediately after the last one this can't
+                                 * be a UNC path as it's '//host//' rather
+                                 * than '//host/share'
+                                 */
+                                if (range.location > pos) {
+                                    /* OK ... we have the '//host/share/'
+                                     * format, so this is a valid UNC path.
+                                     */
+                                    root = NSMaxRange(range);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
-  return root;
+    return root;
 }
 
 
@@ -537,7 +488,7 @@ static unsigned rootOf(NSString *s, unsigned l)
 //  methods to generate objects of unspecified subclasses.
 
 static NSStringEncoding _DefaultStringEncoding;
-static BOOL		_ByteEncodingOk;
+static BOOL _ByteEncodingOk;
 static const unichar byteOrderMark = 0xFEFF;
 static const unichar byteOrderMarkSwapped = 0xFFFE;
 
@@ -552,111 +503,103 @@ static const unichar byteOrderMarkSwapped = 0xFFFE;
    Apparently GNU libc 2.xx needs this to be 0 also, along with Linux
    libc versions 5.2.xx and higher (including libc6, which is just GNU
    libc). -chung */
-#if defined(_LINUX_C_LIB_VERSION_MINOR)	\
-  && _LINUX_C_LIB_VERSION_MAJOR <= 5	\
-  && _LINUX_C_LIB_VERSION_MINOR < 2
-#define PRINTF_ATSIGN_VA_LIST	1
+#if defined(_LINUX_C_LIB_VERSION_MINOR) && _LINUX_C_LIB_VERSION_MAJOR <= 5 && _LINUX_C_LIB_VERSION_MINOR < 2
+#define PRINTF_ATSIGN_VA_LIST 1
 #else
-#define PRINTF_ATSIGN_VA_LIST	0
+#define PRINTF_ATSIGN_VA_LIST 0
 #endif
 
-#if ! PRINTF_ATSIGN_VA_LIST
+#if !PRINTF_ATSIGN_VA_LIST
 static int
-arginfo_func (const struct printf_info *info, size_t n, int *argtypes
-#if     defined(HAVE_REGISTER_PRINTF_SPECIFIER)
-, int *size
+arginfo_func(const struct printf_info *info, size_t n, int *argtypes
+#if defined(HAVE_REGISTER_PRINTF_SPECIFIER)
+             ,
+             int *size
 #endif
 )
 {
-  *argtypes = PA_POINTER;
-  return 1;
+    *argtypes = PA_POINTER;
+    return 1;
 }
 #endif /* !PRINTF_ATSIGN_VA_LIST */
 
 static int
-handle_printf_atsign (FILE *stream,
-		      const struct printf_info *info,
+handle_printf_atsign(FILE *stream,
+                     const struct printf_info *info,
 #if PRINTF_ATSIGN_VA_LIST
-		      va_list *ap_pointer)
-#elif defined(_LINUX_C_LIB_VERSION_MAJOR)       \
-     && _LINUX_C_LIB_VERSION_MAJOR < 6
-                      const void **const args)
+                     va_list *ap_pointer)
+#elif defined(_LINUX_C_LIB_VERSION_MAJOR) && _LINUX_C_LIB_VERSION_MAJOR < 6
+                     const void **const args)
 #else /* GNU libc needs the following. */
-                      const void *const *args)
+                     const void *const *args)
 #endif
 {
-#if ! PRINTF_ATSIGN_VA_LIST
-  const void *ptr = *args;
+#if !PRINTF_ATSIGN_VA_LIST
+    const void *ptr = *args;
 #endif
-  id string_object;
-  int len;
+    id string_object;
+    int len;
 
-  /* xxx This implementation may not pay pay attention to as much
-     of printf_info as it should. */
+    /* xxx This implementation may not pay pay attention to as much
+       of printf_info as it should. */
 
 #if PRINTF_ATSIGN_VA_LIST
-  string_object = va_arg (*ap_pointer, id);
+    string_object = va_arg(*ap_pointer, id);
 #else
-  string_object = *((id*) ptr);
+    string_object = *((id *)ptr);
 #endif
-  string_object = [string_object description];
+    string_object = [string_object description];
 
 #if HAVE_WIDE_PRINTF_FUNCTION
-  if (info->wide)
-    {
-      if (sizeof(wchar_t) == 4)
-        {
-	  unsigned	length = [string_object length];
-	  wchar_t	buf[length + 1];
-	  unsigned	i;
+    if (info->wide) {
+        if (sizeof(wchar_t) == 4) {
+            unsigned length = [string_object length];
+            wchar_t buf[length + 1];
+            unsigned i;
 
-	  for (i = 0; i < length; i++)
-	    {
-	      buf[i] = [string_object characterAtIndex: i];
-	    }
-	  buf[i] = 0;
-          len = fwprintf(stream, L"%*ls",
-	    (info->left ? - info->width : info->width), buf);
+            for (i = 0; i < length; i++) {
+                buf[i] = [string_object characterAtIndex:i];
+            }
+            buf[i] = 0;
+            len = fwprintf(stream, L"%*ls",
+                           (info->left ? -info->width : info->width), buf);
+        } else {
+            len = fwprintf(stream, L"%*ls",
+                           (info->left ? -info->width : info->width),
+                           [string_object cStringUsingEncoding:NSUnicodeStringEncoding]);
         }
-      else
-        {
-          len = fwprintf(stream, L"%*ls",
-	    (info->left ? - info->width : info->width),
-	    [string_object cStringUsingEncoding: NSUnicodeStringEncoding]);
-	}
-    }
-  else
-#endif	/* HAVE_WIDE_PRINTF_FUNCTION */
+    } else
+#endif /* HAVE_WIDE_PRINTF_FUNCTION */
     {
-      len = fprintf(stream, "%*s",
-	(info->left ? - info->width : info->width),
-	[string_object lossyCString]);
+        len = fprintf(stream, "%*s",
+                      (info->left ? -info->width : info->width),
+                      [string_object lossyCString]);
     }
-  return len;
+    return len;
 }
 #endif /* HAVE_REGISTER_PRINTF_FUNCTION */
 
 static void
-register_printf_atsign ()
+register_printf_atsign()
 {
-#if     defined(HAVE_REGISTER_PRINTF_SPECIFIER)
-      if (register_printf_specifier ('@', handle_printf_atsign,
+#if defined(HAVE_REGISTER_PRINTF_SPECIFIER)
+    if (register_printf_specifier('@', handle_printf_atsign,
 #if PRINTF_ATSIGN_VA_LIST
-				    0))
+                                  0))
 #else
-	                            arginfo_func))
+                                  arginfo_func))
 #endif
-	[NSException raise: NSGenericException
-		     format: @"register printf handling of %%@ failed"];
-#elif   defined(HAVE_REGISTER_PRINTF_FUNCTION)
-      if (register_printf_function ('@', handle_printf_atsign,
+        [NSException raise:NSGenericException
+                    format:@"register printf handling of %%@ failed"];
+#elif defined(HAVE_REGISTER_PRINTF_FUNCTION)
+    if (register_printf_function('@', handle_printf_atsign,
 #if PRINTF_ATSIGN_VA_LIST
-				    0))
+                                 0))
 #else
-	                            arginfo_func))
+                                 arginfo_func))
 #endif
-	[NSException raise: NSGenericException
-		     format: @"register printf handling of %%@ failed"];
+        [NSException raise:NSGenericException
+                    format:@"register printf handling of %%@ failed"];
 #endif
 }
 
@@ -670,272 +613,236 @@ register_printf_atsign ()
 static UCollator *
 GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
 {
-  UErrorCode status = U_ZERO_ERROR;
-  const char *localeCString;
-  UCollator *coll;
-  
-  if (mask & NSLiteralSearch)
-    {
-      return NULL;
+    UErrorCode status = U_ZERO_ERROR;
+    const char *localeCString;
+    UCollator *coll;
+
+    if (mask & NSLiteralSearch) {
+        return NULL;
     }
 
-  if (NO == [locale isKindOfClass: [NSLocale class]])
-    {
-      if (nil == locale)
-        {
-          /* See comments below about the posix locale.
-           * It's bad for case insensitive search, but needed for numeric
-           */
-          if (mask & NSNumericSearch)
-            {
-              locale = [NSLocale systemLocale];
+    if (NO == [locale isKindOfClass:[NSLocale class]]) {
+        if (nil == locale) {
+            /* See comments below about the posix locale.
+             * It's bad for case insensitive search, but needed for numeric
+             */
+            if (mask & NSNumericSearch) {
+                locale = [NSLocale systemLocale];
+            } else {
+                /* A nil locale should trigger POSIX collation (i.e. 'A'-'Z' sort
+                 * before 'a'), and support for this was added in ICU 4.6 under the
+                 * locale name en_US_POSIX, but it doesn't fit our requirements
+                 * (e.g. 'e' and 'E' don't compare as equal with case insensitive
+                 * comparison.) - so return NULL to indicate that the GNUstep
+                 * comparison code should be used.
+                 */
+                return NULL;
             }
-          else
-            {
-              /* A nil locale should trigger POSIX collation (i.e. 'A'-'Z' sort
-               * before 'a'), and support for this was added in ICU 4.6 under the
-               * locale name en_US_POSIX, but it doesn't fit our requirements
-               * (e.g. 'e' and 'E' don't compare as equal with case insensitive
-               * comparison.) - so return NULL to indicate that the GNUstep
-               * comparison code should be used.
-               */
-              return NULL;
-            }
-        }
-      else
-        {
-          locale = [NSLocale currentLocale];
+        } else {
+            locale = [NSLocale currentLocale];
         }
     }
 
-  localeCString = [[locale localeIdentifier] UTF8String];
+    localeCString = [[locale localeIdentifier] UTF8String];
 
-  if (localeCString != NULL && strcmp("", localeCString) == 0)
-    {
-      localeCString = NULL;
+    if (localeCString != NULL && strcmp("", localeCString) == 0) {
+        localeCString = NULL;
     }
 
-  coll = ucol_open(localeCString, &status);
+    coll = ucol_open(localeCString, &status);
 
-  if (U_SUCCESS(status))
-    {
-      if (mask & (NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch))
-	{
-	  ucol_setStrength(coll, UCOL_PRIMARY);
-	}
-      else if (mask & NSCaseInsensitiveSearch)
-	{
-	  ucol_setStrength(coll, UCOL_SECONDARY);
-	}
-      else if (mask & NSDiacriticInsensitiveSearch)
-	{
-	  ucol_setStrength(coll, UCOL_PRIMARY);
-	  ucol_setAttribute(coll, UCOL_CASE_LEVEL, UCOL_ON, &status);
-	}
-      
-      if (mask & NSNumericSearch)
-	{
-	  ucol_setAttribute(coll, UCOL_NUMERIC_COLLATION, UCOL_ON, &status);
-	}
-	  
-      if (U_SUCCESS(status))
-	{
-	  return coll;
-	}
+    if (U_SUCCESS(status)) {
+        if (mask & (NSCaseInsensitiveSearch | NSDiacriticInsensitiveSearch)) {
+            ucol_setStrength(coll, UCOL_PRIMARY);
+        } else if (mask & NSCaseInsensitiveSearch) {
+            ucol_setStrength(coll, UCOL_SECONDARY);
+        } else if (mask & NSDiacriticInsensitiveSearch) {
+            ucol_setStrength(coll, UCOL_PRIMARY);
+            ucol_setAttribute(coll, UCOL_CASE_LEVEL, UCOL_ON, &status);
+        }
+
+        if (mask & NSNumericSearch) {
+            ucol_setAttribute(coll, UCOL_NUMERIC_COLLATION, UCOL_ON, &status);
+        }
+
+        if (U_SUCCESS(status)) {
+            return coll;
+        }
     }
 
-  ucol_close(coll);
-  return NULL;
+    ucol_close(coll);
+    return NULL;
 }
 
 #if defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H)
-- (NSString *) _normalizedICUStringOfType: (const char*)normalization
-                                     mode: (UNormalization2Mode)mode
+- (NSString *)_normalizedICUStringOfType:(const char *)normalization
+                                    mode:(UNormalization2Mode)mode
 {
-  UErrorCode            err;
-  const UNormalizer2    *normalizer;
-  int32_t               length;
-  int32_t               newLength;
-  NSString              *newString;
+    UErrorCode err;
+    const UNormalizer2 *normalizer;
+    int32_t length;
+    int32_t newLength;
+    NSString *newString;
 
-  length = (uint32_t)[self length];
-  if (0 == length)
-    {
-      return @"";       // Simple case ... empty string
+    length = (uint32_t)[self length];
+    if (0 == length) {
+        return @""; // Simple case ... empty string
     }
 
-  err = 0;
-  normalizer = unorm2_getInstance(NULL, normalization, mode, &err);
-  if (U_FAILURE(err))
-    {
-      [NSException raise: NSCharacterConversionException
-                  format: @"libicu unorm2_getInstance() failed"];
+    err = 0;
+    normalizer = unorm2_getInstance(NULL, normalization, mode, &err);
+    if (U_FAILURE(err)) {
+        [NSException raise:NSCharacterConversionException
+                    format:@"libicu unorm2_getInstance() failed"];
     }
 
-  if (length < 200)
-    {
-      unichar   src[length];
-      unichar   dst[length*3];
+    if (length < 200) {
+        unichar src[length];
+        unichar dst[length * 3];
 
-      /* For a short string, it's very efficient to just use on-stack
-       * buffers for the libicu work, and then let the standard string
-       * initialiser convert that to an inline string.
-       */
-      [self getCharacters: (unichar *)src range: NSMakeRange(0, length)];
-      err = 0;
-      newLength = unorm2_normalize(normalizer, (UChar*)src, length,
-        (UChar*)dst, length*3, &err);
-      if (U_FAILURE(err))
-        {
-          [NSException raise: NSCharacterConversionException
-                      format: @"precompose/decompose failed"];
+        /* For a short string, it's very efficient to just use on-stack
+         * buffers for the libicu work, and then let the standard string
+         * initialiser convert that to an inline string.
+         */
+        [self getCharacters:(unichar *)src range:NSMakeRange(0, length)];
+        err = 0;
+        newLength = unorm2_normalize(normalizer, (UChar *)src, length,
+                                     (UChar *)dst, length * 3, &err);
+        if (U_FAILURE(err)) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"precompose/decompose failed"];
         }
-      newString = [[NSString alloc] initWithCharacters: dst length: newLength];
-    }
-  else
-    {
-      unichar   *src;
-      unichar   *dst;
+        newString = [[NSString alloc] initWithCharacters:dst length:newLength];
+    } else {
+        unichar *src;
+        unichar *dst;
 
-      /* For longer strings, we copy the source into a buffer on the heap
-       * for the libicu operation, determine the length needed for the
-       * output buffer, then do the actual conversion to build the string.
-       */
-      src = (unichar*)malloc(length * sizeof(unichar));
-      [self getCharacters: (unichar*)src range: NSMakeRange(0, length)];
-      err = 0;
-      newLength = unorm2_normalize(normalizer, (UChar*)src, length,
-        0, 0, &err);
-      if (U_BUFFER_OVERFLOW_ERROR != err)
-        {
-          free(src);
-          [NSException raise: NSCharacterConversionException
-                      format: @"precompose/decompose length check failed"];
+        /* For longer strings, we copy the source into a buffer on the heap
+         * for the libicu operation, determine the length needed for the
+         * output buffer, then do the actual conversion to build the string.
+         */
+        src = (unichar *)malloc(length * sizeof(unichar));
+        [self getCharacters:(unichar *)src range:NSMakeRange(0, length)];
+        err = 0;
+        newLength = unorm2_normalize(normalizer, (UChar *)src, length,
+                                     0, 0, &err);
+        if (U_BUFFER_OVERFLOW_ERROR != err) {
+            free(src);
+            [NSException raise:NSCharacterConversionException
+                        format:@"precompose/decompose length check failed"];
         }
-      dst = NSZoneMalloc(NSDefaultMallocZone(), newLength * sizeof(unichar));
-      err = 0;
-      unorm2_normalize(normalizer, (UChar*)src, length,
-        (UChar*)dst, newLength, &err);
-      free(src);
-      if (U_FAILURE(err))
-        {
-          NSZoneFree(NSDefaultMallocZone(), dst);
-          [NSException raise: NSCharacterConversionException
-                      format: @"precompose/decompose failed"];
+        dst = NSZoneMalloc(NSDefaultMallocZone(), newLength * sizeof(unichar));
+        err = 0;
+        unorm2_normalize(normalizer, (UChar *)src, length,
+                         (UChar *)dst, newLength, &err);
+        free(src);
+        if (U_FAILURE(err)) {
+            NSZoneFree(NSDefaultMallocZone(), dst);
+            [NSException raise:NSCharacterConversionException
+                        format:@"precompose/decompose failed"];
         }
-      newString = [[NSString alloc] initWithCharactersNoCopy: dst
-                                                      length: newLength
-                                                freeWhenDone: YES];
+        newString = [[NSString alloc] initWithCharactersNoCopy:dst
+                                                        length:newLength
+                                                  freeWhenDone:YES];
     }
 
-  return AUTORELEASE(newString);
+    return AUTORELEASE(newString);
 }
 #endif
 #endif
 
-+ (void) atExit
++ (void)atExit
 {
-  DESTROY(placeholderMap);
+    DESTROY(placeholderMap);
 }
 
-+ (void) initialize
++ (void)initialize
 {
-  /*
-   * Flag required as we call this method explicitly from GSBuildStrings()
-   * to ensure that NSString is initialised properly.
-   */
-  static BOOL	beenHere = NO;
+    /*
+     * Flag required as we call this method explicitly from GSBuildStrings()
+     * to ensure that NSString is initialised properly.
+     */
+    static BOOL beenHere = NO;
 
-  if (self == [NSString class] && beenHere == NO)
-    {
-      beenHere = YES;
-      cMemberSel = @selector(characterIsMember:);
-      caiSel = @selector(characterAtIndex:);
-      gcrSel = @selector(getCharacters:range:);
-      ranSel = @selector(rangeOfComposedCharacterSequenceAtIndex:);
+    if (self == [NSString class] && beenHere == NO) {
+        beenHere = YES;
+        cMemberSel = @selector(characterIsMember:);
+        caiSel = @selector(characterAtIndex:);
+        gcrSel = @selector(getCharacters:range:);
+        ranSel = @selector(rangeOfComposedCharacterSequenceAtIndex:);
 
-      nonBase = [NSCharacterSet nonBaseCharacterSet];
-      nonBase = [NSObject leakAt: &nonBase];
-      nonBaseImp
-        = (BOOL(*)(id,SEL,unichar))[nonBase methodForSelector: cMemberSel];
+        nonBase = [NSCharacterSet nonBaseCharacterSet];
+        nonBase = [NSObject leakAt:&nonBase];
+        nonBaseImp = (BOOL(*)(id, SEL, unichar))[nonBase methodForSelector:cMemberSel];
 
-      _DefaultStringEncoding = GSPrivateDefaultCStringEncoding();
-      _ByteEncodingOk = GSPrivateIsByteEncoding(_DefaultStringEncoding);
+        _DefaultStringEncoding = GSPrivateDefaultCStringEncoding();
+        _ByteEncodingOk = GSPrivateIsByteEncoding(_DefaultStringEncoding);
 
-      NSStringClass = self;
-      [self setVersion: 1];
-      NSMutableStringClass = [NSMutableString class];
-      NSDataClass = [NSData class];
-      GSPlaceholderStringClass = [GSPlaceholderString class];
-      GSStringClass = [GSString class];
-      GSMutableStringClass = [GSMutableString class];
+        NSStringClass = self;
+        [self setVersion:1];
+        NSMutableStringClass = [NSMutableString class];
+        NSDataClass = [NSData class];
+        GSPlaceholderStringClass = [GSPlaceholderString class];
+        GSStringClass = [GSString class];
+        GSMutableStringClass = [GSMutableString class];
 
-      /*
-       * Set up infrastructure for placeholder strings.
-       */
-      defaultPlaceholderString = (GSPlaceholderString*)
-	[GSPlaceholderStringClass allocWithZone: NSDefaultMallocZone()];
-      placeholderMap = NSCreateMapTable(NSNonOwnedPointerMapKeyCallBacks,
-	NSNonRetainedObjectMapValueCallBacks, 0);
-      register_printf_atsign();
-      [self registerAtExit];
+        /*
+         * Set up infrastructure for placeholder strings.
+         */
+        defaultPlaceholderString = (GSPlaceholderString *)
+            [GSPlaceholderStringClass allocWithZone:NSDefaultMallocZone()];
+        placeholderMap = NSCreateMapTable(NSNonOwnedPointerMapKeyCallBacks,
+                                          NSNonRetainedObjectMapValueCallBacks, 0);
+        register_printf_atsign();
+        [self registerAtExit];
     }
 }
 
-+ (id) allocWithZone: (NSZone*)z
++ (id)allocWithZone:(NSZone *)z
 {
-  if (self == NSStringClass)
-    {
-      /*
-       * For a constant string, we return a placeholder object that can
-       * be converted to a real object when its initialisation method
-       * is called.
-       */
-      if (z == NSDefaultMallocZone() || z == 0)
-	{
-	  /*
-	   * As a special case, we can return a placeholder for a string
-	   * in the default zone extremely efficiently.
-	   */
-	  return defaultPlaceholderString;
-	}
-      else
-	{
-	  id	obj;
+    if (self == NSStringClass) {
+        /*
+         * For a constant string, we return a placeholder object that can
+         * be converted to a real object when its initialisation method
+         * is called.
+         */
+        if (z == NSDefaultMallocZone() || z == 0) {
+            /*
+             * As a special case, we can return a placeholder for a string
+             * in the default zone extremely efficiently.
+             */
+            return defaultPlaceholderString;
+        } else {
+            id obj;
 
-	  /*
-	   * For anything other than the default zone, we need to
-	   * locate the correct placeholder in the (lock protected)
-	   * table of placeholders.
-	   */
-	  GS_MUTEX_LOCK(placeholderLock);
-	  obj = (id)NSMapGet(placeholderMap, (void*)z);
-	  if (obj == nil)
-	    {
-	      /*
-	       * There is no placeholder object for this zone, so we
-	       * create a new one and use that.
-	       */
-	      obj = (id)[GSPlaceholderStringClass allocWithZone: z];
-	      NSMapInsert(placeholderMap, (void*)z, (void*)obj);
-	    }
-	  GS_MUTEX_UNLOCK(placeholderLock);
-	  return obj;
-	}
-    }
-  else if ([self isKindOfClass: GSStringClass] == YES)
-    {
-      [NSException raise: NSInternalInconsistencyException
-		  format: @"Called +allocWithZone: on private string class"];
-      return nil;	/* NOT REACHED */
-    }
-  else
-    {
-      /*
-       * For user provided strings, we simply allocate an object of
-       * the given class.
-       */
-      return NSAllocateObject (self, 0, z);
+            /*
+             * For anything other than the default zone, we need to
+             * locate the correct placeholder in the (lock protected)
+             * table of placeholders.
+             */
+            GS_MUTEX_LOCK(placeholderLock);
+            obj = (id)NSMapGet(placeholderMap, (void *)z);
+            if (obj == nil) {
+                /*
+                 * There is no placeholder object for this zone, so we
+                 * create a new one and use that.
+                 */
+                obj = (id)[GSPlaceholderStringClass allocWithZone:z];
+                NSMapInsert(placeholderMap, (void *)z, (void *)obj);
+            }
+            GS_MUTEX_UNLOCK(placeholderLock);
+            return obj;
+        }
+    } else if ([self isKindOfClass:GSStringClass] == YES) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Called +allocWithZone: on private string class"];
+        return nil; /* NOT REACHED */
+    } else {
+        /*
+         * For user provided strings, we simply allocate an object of
+         * the given class.
+         */
+        return NSAllocateObject(self, 0, z);
     }
 }
 
@@ -948,45 +855,45 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * (and will automatically be changed by GNUstep to avoid conflicts
  * with the default implementation in the Objective-C runtime library).
  */
-+ (Class) constantStringClass
++ (Class)constantStringClass
 {
-  return [@"" class];
+    return [@"" class];
 }
 
 /**
  * Create an empty string.
  */
-+ (id) string
++ (id)string
 {
-  return AUTORELEASE([[self allocWithZone: NSDefaultMallocZone()] init]);
+    return AUTORELEASE([[self allocWithZone:NSDefaultMallocZone()] init]);
 }
 
 /**
  * Create a copy of aString.
  */
-+ (id) stringWithString: (NSString*)aString
++ (id)stringWithString:(NSString *)aString
 {
-  NSString	*obj;
+    NSString *obj;
 
-  if (NULL == aString)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[NSString+stringWithString:]: NULL string"];
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithString: aString];
-  return AUTORELEASE(obj);
+    if (NULL == aString)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString+stringWithString:]: NULL string"];
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithString:aString];
+    return AUTORELEASE(obj);
 }
 
 /**
  * Create a string of unicode characters.
  */
-+ (id) stringWithCharacters: (const unichar*)chars
-		     length: (NSUInteger)length
++ (id)stringWithCharacters:(const unichar *)chars
+                    length:(NSUInteger)length
 {
-  NSString	*obj;
+    NSString *obj;
 
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithCharacters: chars length: length];
-  return AUTORELEASE(obj);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithCharacters:chars length:length];
+    return AUTORELEASE(obj);
 }
 
 /**
@@ -994,16 +901,16 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * null-terminated and encoded in the default C string encoding.  (Characters
  * will be converted to unicode representation internally.)
  */
-+ (id) stringWithCString: (const char*)byteString
++ (id)stringWithCString:(const char *)byteString
 {
-  NSString	*obj;
+    NSString *obj;
 
-  if (NULL == byteString)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[NSString+stringWithCString:]: NULL cString"];
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithCString: byteString];
-  return AUTORELEASE(obj);
+    if (NULL == byteString)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString+stringWithCString:]: NULL cString"];
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithCString:byteString];
+    return AUTORELEASE(obj);
 }
 
 /**
@@ -1011,17 +918,17 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * null-terminated and encoded in the specified C string encoding.
  * Characters may be converted to unicode representation internally.
  */
-+ (id) stringWithCString: (const char*)byteString
-		encoding: (NSStringEncoding)encoding
++ (id)stringWithCString:(const char *)byteString
+               encoding:(NSStringEncoding)encoding
 {
-  NSString	*obj;
+    NSString *obj;
 
-  if (NULL == byteString)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[NSString+stringWithCString:encoding:]: NULL cString"];
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithCString: byteString encoding: encoding];
-  return AUTORELEASE(obj);
+    if (NULL == byteString)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString+stringWithCString:encoding:]: NULL cString"];
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithCString:byteString encoding:encoding];
+    return AUTORELEASE(obj);
 }
 
 /**
@@ -1029,37 +936,34 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * null bytes and should be encoded in the default C string encoding.
  * (Characters will be converted to unicode representation internally.)
  */
-+ (id) stringWithCString: (const char*)byteString
-		  length: (NSUInteger)length
++ (id)stringWithCString:(const char *)byteString
+                 length:(NSUInteger)length
 {
-  NSString	*obj;
+    NSString *obj;
 
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithCString: byteString length: length];
-  return AUTORELEASE(obj);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithCString:byteString length:length];
+    return AUTORELEASE(obj);
 }
 
 /**
  * Create a string based on the given UTF-8 string, null-terminated.<br />
  * Raises NSInvalidArgumentException if given NULL pointer.
  */
-+ (id) stringWithUTF8String: (const char *)bytes
++ (id)stringWithUTF8String:(const char *)bytes
 {
-  NSString	*obj;
+    NSString *obj;
 
-  if (NULL == bytes)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[NSString+stringWithUTF8String:]: NULL cString"];
-  if (self == NSStringClass)
-    {
-      obj = defaultPlaceholderString;
+    if (NULL == bytes)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString+stringWithUTF8String:]: NULL cString"];
+    if (self == NSStringClass) {
+        obj = defaultPlaceholderString;
+    } else {
+        obj = [self allocWithZone:NSDefaultMallocZone()];
     }
-  else
-    {
-      obj = [self allocWithZone: NSDefaultMallocZone()];
-    }
-  obj = [obj initWithUTF8String: bytes];
-  return AUTORELEASE(obj);
+    obj = [obj initWithUTF8String:bytes];
+    return AUTORELEASE(obj);
 }
 
 /**
@@ -1067,43 +971,43 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * containing direct unicode if it begins with the unicode byte order mark,
  * else converts to unicode using default C string encoding.
  */
-+ (id) stringWithContentsOfFile: (NSString *)path
++ (id)stringWithContentsOfFile:(NSString *)path
 {
-  NSString	*obj;
+    NSString *obj;
 
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithContentsOfFile: path];
-  return AUTORELEASE(obj);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithContentsOfFile:path];
+    return AUTORELEASE(obj);
 }
 
 /**
  * Load contents of file at path into a new string using the
  * -initWithContentsOfFile:usedEncoding:error: method.
  */
-+ (id) stringWithContentsOfFile: (NSString *)path
-                   usedEncoding: (NSStringEncoding*)enc
-                          error: (NSError**)error
++ (id)stringWithContentsOfFile:(NSString *)path
+                  usedEncoding:(NSStringEncoding *)enc
+                         error:(NSError **)error
 {
-  NSString	*obj;
+    NSString *obj;
 
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithContentsOfFile: path usedEncoding: enc error: error];
-  return AUTORELEASE(obj);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithContentsOfFile:path usedEncoding:enc error:error];
+    return AUTORELEASE(obj);
 }
 
 /**
  * Load contents of file at path into a new string using the
  * -initWithContentsOfFile:encoding:error: method.
  */
-+ (id) stringWithContentsOfFile: (NSString*)path
-                       encoding: (NSStringEncoding)enc
-                          error: (NSError**)error
++ (id)stringWithContentsOfFile:(NSString *)path
+                      encoding:(NSStringEncoding)enc
+                         error:(NSError **)error
 {
-   NSString	*obj;
+    NSString *obj;
 
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithContentsOfFile: path encoding: enc error: error];
-  return AUTORELEASE(obj);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithContentsOfFile:path encoding:enc error:error];
+    return AUTORELEASE(obj);
 }
 
 /**
@@ -1111,35 +1015,35 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * containing direct unicode if it begins with the unicode byte order mark,
  * else converts to unicode using default C string encoding.
  */
-+ (id) stringWithContentsOfURL: (NSURL *)url
++ (id)stringWithContentsOfURL:(NSURL *)url
 {
-  NSString	*obj;
+    NSString *obj;
 
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithContentsOfURL: url];
-  return AUTORELEASE(obj);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithContentsOfURL:url];
+    return AUTORELEASE(obj);
 }
 
-+ (id) stringWithContentsOfURL: (NSURL*)url
-                  usedEncoding: (NSStringEncoding*)enc
-                         error: (NSError**)error
++ (id)stringWithContentsOfURL:(NSURL *)url
+                 usedEncoding:(NSStringEncoding *)enc
+                        error:(NSError **)error
 {
-  NSString	*obj;
+    NSString *obj;
 
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithContentsOfURL: url usedEncoding: enc error: error];
-  return AUTORELEASE(obj);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithContentsOfURL:url usedEncoding:enc error:error];
+    return AUTORELEASE(obj);
 }
 
-+ (id) stringWithContentsOfURL: (NSURL*)url
-                      encoding: (NSStringEncoding)enc
-                         error: (NSError**)error
++ (id)stringWithContentsOfURL:(NSURL *)url
+                     encoding:(NSStringEncoding)enc
+                        error:(NSError **)error
 {
-  NSString	*obj;
+    NSString *obj;
 
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithContentsOfURL: url encoding: enc error: error];
-  return AUTORELEASE(obj);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithContentsOfURL:url encoding:enc error:error];
+    return AUTORELEASE(obj);
 }
 
 /**
@@ -1147,19 +1051,19 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * be a constant format string, like '<code>@"float val = %f"</code>', remaining
  * arguments should be the variables to print the values of, comma-separated.
  */
-+ (id) stringWithFormat: (NSString*)format,...
++ (id)stringWithFormat:(NSString *)format, ...
 {
-  va_list ap;
-  NSString	*obj;
+    va_list ap;
+    NSString *obj;
 
-  if (NULL == format)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[NSString+stringWithFormat:]: NULL format"];
-  va_start(ap, format);
-  obj = [self allocWithZone: NSDefaultMallocZone()];
-  obj = [obj initWithFormat: format arguments: ap];
-  va_end(ap);
-  return AUTORELEASE(obj);
+    if (NULL == format)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString+stringWithFormat:]: NULL format"];
+    va_start(ap, format);
+    obj = [self allocWithZone:NSDefaultMallocZone()];
+    obj = [obj initWithFormat:format arguments:ap];
+    va_end(ap);
+    return AUTORELEASE(obj);
 }
 
 
@@ -1192,10 +1096,10 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * subclassing NSString will need to be updated.
  * </p>
  */
-- (id) init
+- (id)init
 {
-  self = [super init];
-  return self;
+    self = [super init];
+    return self;
 }
 
 /**
@@ -1206,27 +1110,24 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * If the data can not be interpreted using the encoding, the receiver
  * is released and nil is returned.
  */
-- (id) initWithBytes: (const void*)bytes
-	      length: (NSUInteger)length
-	    encoding: (NSStringEncoding)encoding
+- (id)initWithBytes:(const void *)bytes
+             length:(NSUInteger)length
+           encoding:(NSStringEncoding)encoding
 {
-  if (length == 0)
-    {
-      return [self initWithBytesNoCopy: (void *)0
-				length: 0
-			      encoding: encoding
-			  freeWhenDone: NO];
-    }
-  else
-    {
-      void	*buf;
+    if (length == 0) {
+        return [self initWithBytesNoCopy:(void *)0
+                                  length:0
+                                encoding:encoding
+                            freeWhenDone:NO];
+    } else {
+        void *buf;
 
-      buf = NSZoneMalloc([self zone], length);
-      memcpy(buf, bytes, length);
-      return [self initWithBytesNoCopy: buf
-				length: length
-			      encoding: encoding
-			  freeWhenDone: YES];
+        buf = NSZoneMalloc([self zone], length);
+        memcpy(buf, bytes, length);
+        return [self initWithBytesNoCopy:buf
+                                  length:length
+                                encoding:encoding
+                            freeWhenDone:YES];
     }
 }
 
@@ -1248,13 +1149,13 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * In the GNUstep implementation, your subclasses may override
  * this initialiser in order to have all other functionality.</p>
  */
-- (id) initWithBytesNoCopy: (void*)bytes
-		    length: (NSUInteger)length
-		  encoding: (NSStringEncoding)encoding
-	      freeWhenDone: (BOOL)flag
+- (id)initWithBytesNoCopy:(void *)bytes
+                   length:(NSUInteger)length
+                 encoding:(NSStringEncoding)encoding
+             freeWhenDone:(BOOL)flag
 {
-  self = [self init];
-  return self;
+    self = [self init];
+    return self;
 }
 
 /**
@@ -1263,26 +1164,26 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  *  this instance is deallocated.</p>
  * See -initWithBytesNoCopy:length:encoding:freeWhenDone: for more details.
  */
-- (id) initWithCharactersNoCopy: (unichar*)chars
-			 length: (NSUInteger)length
-		   freeWhenDone: (BOOL)flag
+- (id)initWithCharactersNoCopy:(unichar *)chars
+                        length:(NSUInteger)length
+                  freeWhenDone:(BOOL)flag
 {
-  return [self initWithBytesNoCopy: chars
-			    length: length * sizeof(unichar)
-			  encoding: NSUnicodeStringEncoding
-		      freeWhenDone: flag];
+    return [self initWithBytesNoCopy:chars
+                              length:length * sizeof(unichar)
+                            encoding:NSUnicodeStringEncoding
+                        freeWhenDone:flag];
 }
 
 /**
  * <p>Initialize with given unicode chars up to length, regardless of presence
  *  of null bytes.  Copies the string and frees copy when deallocated.</p>
  */
-- (id) initWithCharacters: (const unichar*)chars
-		   length: (NSUInteger)length
+- (id)initWithCharacters:(const unichar *)chars
+                  length:(NSUInteger)length
 {
-  return [self initWithBytes: chars
-		      length: length * sizeof(unichar)
-		    encoding: NSUnicodeStringEncoding];
+    return [self initWithBytes:chars
+                        length:length * sizeof(unichar)
+                      encoding:NSUnicodeStringEncoding];
 }
 
 /**
@@ -1292,14 +1193,14 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  *  when this instance is deallocated.</p>
  * See -initWithBytesNoCopy:length:encoding:freeWhenDone: for more details.
  */
-- (id) initWithCStringNoCopy: (char*)byteString
-		      length: (NSUInteger)length
-		freeWhenDone: (BOOL)flag
+- (id)initWithCStringNoCopy:(char *)byteString
+                     length:(NSUInteger)length
+               freeWhenDone:(BOOL)flag
 {
-  return [self initWithBytesNoCopy: byteString
-			    length: length
-			  encoding: _DefaultStringEncoding
-		      freeWhenDone: flag];
+    return [self initWithBytesNoCopy:byteString
+                              length:length
+                            encoding:_DefaultStringEncoding
+                        freeWhenDone:flag];
 }
 
 /**
@@ -1307,15 +1208,15 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * Characters converted to unicode based on the specified C encoding.
  * Copies the string.</p>
  */
-- (id) initWithCString: (const char*)byteString
-	      encoding: (NSStringEncoding)encoding
+- (id)initWithCString:(const char *)byteString
+             encoding:(NSStringEncoding)encoding
 {
-  if (NULL == byteString)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[NSString-initWithCString:encoding:]: NULL cString"];
-  return [self initWithBytes: byteString
-		      length: strlen(byteString)
-		    encoding: encoding];
+    if (NULL == byteString)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString-initWithCString:encoding:]: NULL cString"];
+    return [self initWithBytes:byteString
+                        length:strlen(byteString)
+                      encoding:encoding];
 }
 
 /**
@@ -1323,11 +1224,11 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  *  presence of null bytes.  Characters converted to unicode based on the
  *  default C encoding.  Copies the string.</p>
  */
-- (id) initWithCString: (const char*)byteString  length: (NSUInteger)length
+- (id)initWithCString:(const char *)byteString length:(NSUInteger)length
 {
-  return [self initWithBytes: byteString
-		      length: length
-		    encoding: _DefaultStringEncoding];
+    return [self initWithBytes:byteString
+                        length:length
+                      encoding:_DefaultStringEncoding];
 }
 
 /**
@@ -1335,176 +1236,166 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * null-terminated.  Characters are converted to unicode based on the default
  * C encoding.  Copies the string.</p>
  */
-- (id) initWithCString: (const char*)byteString
+- (id)initWithCString:(const char *)byteString
 {
-  if (NULL == byteString)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[NSString-initWithCString:]: NULL cString"];
-  return [self initWithBytes: byteString
-		      length: strlen(byteString)
-		    encoding: _DefaultStringEncoding];
+    if (NULL == byteString)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString-initWithCString:]: NULL cString"];
+    return [self initWithBytes:byteString
+                        length:strlen(byteString)
+                      encoding:_DefaultStringEncoding];
 }
 
 /**
  * Initialize to be a copy of the given string.
  */
-- (id) initWithString: (NSString*)string
+- (id)initWithString:(NSString *)string
 {
-  unsigned	length = [string length];
+    unsigned length = [string length];
 
-  if (NULL == string)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[NSString-initWithString:]: NULL string"];
-  if (length > 0)
-    {
-      unichar	*s = NSZoneMalloc([self zone], sizeof(unichar)*length);
+    if (NULL == string)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString-initWithString:]: NULL string"];
+    if (length > 0) {
+        unichar *s = NSZoneMalloc([self zone], sizeof(unichar) * length);
 
-      [string getCharacters: s range: ((NSRange){0, length})];
-      self = [self initWithCharactersNoCopy: s
-				     length: length
-			       freeWhenDone: YES];
+        [string getCharacters:s range:((NSRange){0, length})];
+        self = [self initWithCharactersNoCopy:s
+                                       length:length
+                                 freeWhenDone:YES];
+    } else {
+        self = [self initWithCharactersNoCopy:(unichar *)0
+                                       length:0
+                                 freeWhenDone:NO];
     }
-  else
-    {
-      self = [self initWithCharactersNoCopy: (unichar*)0
-				     length: 0
-			       freeWhenDone: NO];
-    }
-  return self;
+    return self;
 }
 
 /**
  * Initialize based on given null-terminated UTF-8 string bytes.
  */
-- (id) initWithUTF8String: (const char *)bytes
+- (id)initWithUTF8String:(const char *)bytes
 {
-  if (NULL == bytes)
-    [NSException raise: NSInvalidArgumentException
-		format: @"[NSString-initWithUTF8String:]: NULL cString"];
-  return [self initWithBytes: bytes
-		      length: strlen(bytes)
-		    encoding: NSUTF8StringEncoding];
+    if (NULL == bytes)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString-initWithUTF8String:]: NULL cString"];
+    return [self initWithBytes:bytes
+                        length:strlen(bytes)
+                      encoding:NSUTF8StringEncoding];
 }
 
 /**
  * Invokes -initWithFormat:locale:arguments: with a nil locale.
  */
-- (id) initWithFormat: (NSString*)format,...
+- (id)initWithFormat:(NSString *)format, ...
 {
-  va_list ap;
-  va_start(ap, format);
-  self = [self initWithFormat: format locale: nil arguments: ap];
-  va_end(ap);
-  return self;
+    va_list ap;
+    va_start(ap, format);
+    self = [self initWithFormat:format locale:nil arguments:ap];
+    va_end(ap);
+    return self;
 }
 
 /**
  * Invokes -initWithFormat:locale:arguments:
  */
-- (id) initWithFormat: (NSString*)format
-               locale: (NSDictionary*)locale, ...
+- (id)initWithFormat:(NSString *)format
+              locale:(NSDictionary *)locale, ...
 {
-  va_list ap;
-  va_start(ap, locale);
-  self = [self initWithFormat: format locale: locale arguments: ap];
-  va_end(ap);
-  return self;
+    va_list ap;
+    va_start(ap, locale);
+    self = [self initWithFormat:format locale:locale arguments:ap];
+    va_end(ap);
+    return self;
 }
 
 /**
  * Invokes -initWithFormat:locale:arguments: with a nil locale.
  */
-- (id) initWithFormat: (NSString*)format
-            arguments: (va_list)argList
+- (id)initWithFormat:(NSString *)format
+           arguments:(va_list)argList
 {
-  return [self initWithFormat: format locale: nil arguments: argList];
+    return [self initWithFormat:format locale:nil arguments:argList];
 }
 
 /**
  * Initialises the string using the specified format and locale
  * to format the following arguments.
  */
-- (id) initWithFormat: (NSString*)format
-               locale: (NSDictionary*)locale
-            arguments: (va_list)argList
+- (id)initWithFormat:(NSString *)format
+              locale:(NSDictionary *)locale
+           arguments:(va_list)argList
 {
-  unsigned char	buf[2048];
-  GSStr		f;
-  unichar	fbuf[1024];
-  unichar	*fmt = fbuf;
-  size_t	len;
+    unsigned char buf[2048];
+    GSStr f;
+    unichar fbuf[1024];
+    unichar *fmt = fbuf;
+    size_t len;
 
-  if (NULL == format)
-    [NSException raise: NSInvalidArgumentException
-      format: @"[NSString-initWithFormat:locale:arguments:]: NULL format"];
+    if (NULL == format)
+        [NSException raise:NSInvalidArgumentException
+                    format:@"[NSString-initWithFormat:locale:arguments:]: NULL format"];
 
-  if ([format isKindOfClass:[GSLocalizedString class]])
-    {
-      // Get the appropriate format according to the pluralization rules.
-      format = [(GSLocalizedString *) format getPluralizedFormat:argList];
+    if ([format isKindOfClass:[GSLocalizedString class]]) {
+        // Get the appropriate format according to the pluralization rules.
+        format = [(GSLocalizedString *)format getPluralizedFormat:argList];
     }
 
-  /*
-   * First we provide an array of unichar characters containing the
-   * format string.  For performance reasons we try to use an on-stack
-   * buffer if the format string is small enough ... it almost always
-   * will be.
-   */
-  len = [format length];
-  if (len >= 1024)
-    {
-      fmt = NSZoneMalloc(NSDefaultMallocZone(), (len+1)*sizeof(unichar));
+    /*
+     * First we provide an array of unichar characters containing the
+     * format string.  For performance reasons we try to use an on-stack
+     * buffer if the format string is small enough ... it almost always
+     * will be.
+     */
+    len = [format length];
+    if (len >= 1024) {
+        fmt = NSZoneMalloc(NSDefaultMallocZone(), (len + 1) * sizeof(unichar));
     }
-  [format getCharacters: fmt range: ((NSRange){0, len})];
-  fmt[len] = '\0';
+    [format getCharacters:fmt range:((NSRange){0, len})];
+    fmt[len] = '\0';
 
-  /*
-   * Now set up 'f' as a GSMutableString object whose initial buffer is
-   * allocated on the stack.  The GSPrivateFormat function can write into it.
-   */
-  f = (GSStr)alloca(class_getInstanceSize(GSMutableStringClass));
-  object_setClass(f, GSMutableStringClass);
-  f->_zone = NSDefaultMallocZone();
-  f->_contents.c = buf;
-  f->_capacity = sizeof(buf);
-  f->_count = 0;
-  f->_flags.wide = 0;
-  f->_flags.owned = 0;
-  f->_flags.unused = 0;
-  f->_flags.hash = 0;
-  GSPrivateFormat(f, fmt, argList, locale);
-  GSPrivateStrExternalize(f);
-  if (fmt != fbuf)
-    {
-      NSZoneFree(NSDefaultMallocZone(), fmt);
+    /*
+     * Now set up 'f' as a GSMutableString object whose initial buffer is
+     * allocated on the stack.  The GSPrivateFormat function can write into it.
+     */
+    f = (GSStr)alloca(class_getInstanceSize(GSMutableStringClass));
+    object_setClass(f, GSMutableStringClass);
+    f->_zone = NSDefaultMallocZone();
+    f->_contents.c = buf;
+    f->_capacity = sizeof(buf);
+    f->_count = 0;
+    f->_flags.wide = 0;
+    f->_flags.owned = 0;
+    f->_flags.unused = 0;
+    f->_flags.hash = 0;
+    GSPrivateFormat(f, fmt, argList, locale);
+    GSPrivateStrExternalize(f);
+    if (fmt != fbuf) {
+        NSZoneFree(NSDefaultMallocZone(), fmt);
     }
 
-  /*
-   * Don't use noCopy because f->_contents.u may be memory on the stack,
-   * and even if it wasn't f->_capacity may be greater than f->_count so
-   * we could be wasting quite a bit of space.  Better to accept a
-   * performance hit due to copying data (and allocating/deallocating
-   * the temporary buffer) for large strings.  For most strings, the
-   * on-stack memory will have been used, so we will get better performance.
-   */
-  if (f->_flags.wide == 1)
-    {
-      self = [self initWithCharacters: f->_contents.u length: f->_count];
-    }
-  else
-    {
-      self = [self initWithCString: (char*)f->_contents.c length: f->_count];
+    /*
+     * Don't use noCopy because f->_contents.u may be memory on the stack,
+     * and even if it wasn't f->_capacity may be greater than f->_count so
+     * we could be wasting quite a bit of space.  Better to accept a
+     * performance hit due to copying data (and allocating/deallocating
+     * the temporary buffer) for large strings.  For most strings, the
+     * on-stack memory will have been used, so we will get better performance.
+     */
+    if (f->_flags.wide == 1) {
+        self = [self initWithCharacters:f->_contents.u length:f->_count];
+    } else {
+        self = [self initWithCString:(char *)f->_contents.c length:f->_count];
     }
 
-  /*
-   * If the string had to grow beyond the initial buffer size, we must
-   * release any allocated memory.
-   */
-  if (f->_flags.owned == 1)
-    {
-      NSZoneFree(f->_zone, f->_contents.c);
+    /*
+     * If the string had to grow beyond the initial buffer size, we must
+     * release any allocated memory.
+     */
+    if (f->_flags.owned == 1) {
+        NSZoneFree(f->_zone, f->_contents.c);
     }
-  return self;
+    return self;
 }
 
 /**
@@ -1515,12 +1406,12 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * If the data can not be interpreted using the encoding, the receiver
  * is released and nil is returned.
  */
-- (id) initWithData: (NSData*)data
-	   encoding: (NSStringEncoding)encoding
+- (id)initWithData:(NSData *)data
+          encoding:(NSStringEncoding)encoding
 {
-  return [self initWithBytes: [data bytes]
-		      length: [data length]
-		    encoding: encoding];
+    return [self initWithBytes:[data bytes]
+                        length:[data length]
+                      encoding:encoding];
 }
 
 /**
@@ -1541,54 +1432,43 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * and converted to a string.
  * </p>
  */
-- (id) initWithContentsOfFile: (NSString*)path
+- (id)initWithContentsOfFile:(NSString *)path
 {
-  NSStringEncoding	enc = _DefaultStringEncoding;
-  NSData		*d;
-  unsigned int		len;
-  const unsigned char	*data_bytes;
+    NSStringEncoding enc = _DefaultStringEncoding;
+    NSData *d;
+    unsigned int len;
+    const unsigned char *data_bytes;
 
-  d = [[NSDataClass alloc] initWithContentsOfFile: path];
-  if (d == nil)
-    {
-      DESTROY(self);
-      return nil;
+    d = [[NSDataClass alloc] initWithContentsOfFile:path];
+    if (d == nil) {
+        DESTROY(self);
+        return nil;
     }
-  len = [d length];
-  if (len == 0)
-    {
-      RELEASE(d);
-      return [self initWithBytesNoCopy: (char *)""
-				length: 0
-			      encoding: NSASCIIStringEncoding
-			  freeWhenDone: NO];
+    len = [d length];
+    if (len == 0) {
+        RELEASE(d);
+        return [self initWithBytesNoCopy:(char *)""
+                                  length:0
+                                encoding:NSASCIIStringEncoding
+                            freeWhenDone:NO];
     }
-  data_bytes = [d bytes];
-  if ((data_bytes != NULL) && (len >= 2))
-    {
-      const unichar *data_ucs2chars = (const unichar *)(void*) data_bytes;
-      if ((data_ucs2chars[0] == byteOrderMark)
-	|| (data_ucs2chars[0] == byteOrderMarkSwapped))
-	{
-	  /* somebody set up us the BOM! */
-	  enc = NSUnicodeStringEncoding;
-	}
-      else if (len >= 3
-	&& data_bytes[0] == 0xEF
-	&& data_bytes[1] == 0xBB
-	&& data_bytes[2] == 0xBF)
-	{
-	  enc = NSUTF8StringEncoding;
-	}
+    data_bytes = [d bytes];
+    if ((data_bytes != NULL) && (len >= 2)) {
+        const unichar *data_ucs2chars = (const unichar *)(void *)data_bytes;
+        if ((data_ucs2chars[0] == byteOrderMark) || (data_ucs2chars[0] == byteOrderMarkSwapped)) {
+            /* somebody set up us the BOM! */
+            enc = NSUnicodeStringEncoding;
+        } else if (len >= 3 && data_bytes[0] == 0xEF && data_bytes[1] == 0xBB && data_bytes[2] == 0xBF) {
+            enc = NSUTF8StringEncoding;
+        }
     }
-  self = [self initWithData: d encoding: enc];
-  RELEASE(d);
-  if (self == nil)
-    {
-      NSWarnMLog(@"Contents of file '%@' are not string data using %@",
-        path, [NSString localizedNameOfStringEncoding: enc]);
+    self = [self initWithData:d encoding:enc];
+    RELEASE(d);
+    if (self == nil) {
+        NSWarnMLog(@"Contents of file '%@' are not string data using %@",
+                   path, [NSString localizedNameOfStringEncoding:enc]);
     }
-  return self;
+    return self;
 }
 
 /**
@@ -1609,102 +1489,85 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * and converted to a string.
  * </p>
  */
-- (id) initWithContentsOfFile: (NSString*)path
-                 usedEncoding: (NSStringEncoding*)enc
-                        error: (NSError**)error
+- (id)initWithContentsOfFile:(NSString *)path
+                usedEncoding:(NSStringEncoding *)enc
+                       error:(NSError **)error
 {
-  NSData		*d;
-  unsigned int		len;
-  const unsigned char	*data_bytes;
+    NSData *d;
+    unsigned int len;
+    const unsigned char *data_bytes;
 
-  d = [[NSDataClass alloc] initWithContentsOfFile: path];
-  if (nil == d)
-    {
-      DESTROY(self);
-      if (error != 0)
-        {
-          *error = [NSError errorWithDomain: NSCocoaErrorDomain
-                                       code: NSFileReadUnknownError
-                                   userInfo: nil];
+    d = [[NSDataClass alloc] initWithContentsOfFile:path];
+    if (nil == d) {
+        DESTROY(self);
+        if (error != 0) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                         code:NSFileReadUnknownError
+                                     userInfo:nil];
         }
-      return nil;
+        return nil;
     }
-  *enc = _DefaultStringEncoding;
-  len = [d length];
-  if (len == 0)
-    {
-      RELEASE(d);
-      return [self initWithBytesNoCopy: (char *)""
-				length: 0
-			      encoding: NSASCIIStringEncoding
-			  freeWhenDone: NO];
+    *enc = _DefaultStringEncoding;
+    len = [d length];
+    if (len == 0) {
+        RELEASE(d);
+        return [self initWithBytesNoCopy:(char *)""
+                                  length:0
+                                encoding:NSASCIIStringEncoding
+                            freeWhenDone:NO];
     }
-  data_bytes = [d bytes];
-  if ((data_bytes != NULL) && (len >= 2))
-    {
-      const unichar *data_ucs2chars = (const unichar *)(void*) data_bytes;
-      if ((data_ucs2chars[0] == byteOrderMark)
-	|| (data_ucs2chars[0] == byteOrderMarkSwapped))
-	{
-	  /* somebody set up us the BOM! */
-	  *enc = NSUnicodeStringEncoding;
-	}
-      else if (len >= 3
-	&& data_bytes[0] == 0xEF
-	&& data_bytes[1] == 0xBB
-	&& data_bytes[2] == 0xBF)
-	{
-	  *enc = NSUTF8StringEncoding;
-	}
-    }
-  self = [self initWithData: d encoding: *enc];
-  RELEASE(d);
-  if (nil == self)
-    {
-      if (error != 0)
-        {
-          *error = [NSError errorWithDomain: NSCocoaErrorDomain
-                                       code: NSFileReadCorruptFileError
-                                   userInfo: nil];
+    data_bytes = [d bytes];
+    if ((data_bytes != NULL) && (len >= 2)) {
+        const unichar *data_ucs2chars = (const unichar *)(void *)data_bytes;
+        if ((data_ucs2chars[0] == byteOrderMark) || (data_ucs2chars[0] == byteOrderMarkSwapped)) {
+            /* somebody set up us the BOM! */
+            *enc = NSUnicodeStringEncoding;
+        } else if (len >= 3 && data_bytes[0] == 0xEF && data_bytes[1] == 0xBB && data_bytes[2] == 0xBF) {
+            *enc = NSUTF8StringEncoding;
         }
     }
-  return self;
+    self = [self initWithData:d encoding:*enc];
+    RELEASE(d);
+    if (nil == self) {
+        if (error != 0) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                         code:NSFileReadCorruptFileError
+                                     userInfo:nil];
+        }
+    }
+    return self;
 }
 
-- (id) initWithContentsOfFile: (NSString*)path
-                     encoding: (NSStringEncoding)enc
-                        error: (NSError**)error
+- (id)initWithContentsOfFile:(NSString *)path
+                    encoding:(NSStringEncoding)enc
+                       error:(NSError **)error
 {
-  NSData		*d;
-  unsigned int		len;
+    NSData *d;
+    unsigned int len;
 
-  d = [[NSDataClass alloc] initWithContentsOfFile: path];
-  if (d == nil)
-    {
-      DESTROY(self);
-      return nil;
+    d = [[NSDataClass alloc] initWithContentsOfFile:path];
+    if (d == nil) {
+        DESTROY(self);
+        return nil;
     }
-  len = [d length];
-  if (len == 0)
-    {
-      RELEASE(d);
-      return [self initWithBytesNoCopy: (char *)""
-				length: 0
-			      encoding: NSASCIIStringEncoding
-			  freeWhenDone: NO];
+    len = [d length];
+    if (len == 0) {
+        RELEASE(d);
+        return [self initWithBytesNoCopy:(char *)""
+                                  length:0
+                                encoding:NSASCIIStringEncoding
+                            freeWhenDone:NO];
     }
-  self = [self initWithData: d encoding: enc];
-  RELEASE(d);
-  if (self == nil)
-    {
-      if (error != 0)
-        {
-          *error = [NSError errorWithDomain: NSCocoaErrorDomain
-                                       code: NSFileReadCorruptFileError
-                                   userInfo: nil];
+    self = [self initWithData:d encoding:enc];
+    RELEASE(d);
+    if (self == nil) {
+        if (error != 0) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                         code:NSFileReadCorruptFileError
+                                     userInfo:nil];
         }
     }
-  return self;
+    return self;
 }
 
 /**
@@ -1725,151 +1588,124 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * read and converted to a string.
  * </p>
  */
-- (id) initWithContentsOfURL: (NSURL*)url
+- (id)initWithContentsOfURL:(NSURL *)url
 {
-  NSStringEncoding	enc = _DefaultStringEncoding;
-  NSData		*d = [NSDataClass dataWithContentsOfURL: url];
-  unsigned int		len = [d length];
-  const unsigned char	*data_bytes;
+    NSStringEncoding enc = _DefaultStringEncoding;
+    NSData *d = [NSDataClass dataWithContentsOfURL:url];
+    unsigned int len = [d length];
+    const unsigned char *data_bytes;
 
-  if (d == nil)
-    {
-      NSWarnMLog(@"Contents of URL '%@' are not readable", url);
-      DESTROY(self);
-      return nil;
+    if (d == nil) {
+        NSWarnMLog(@"Contents of URL '%@' are not readable", url);
+        DESTROY(self);
+        return nil;
     }
-  if (len == 0)
-    {
-      DESTROY(self);
-      return [self initWithBytesNoCopy: (char *)""
-				length: 0
-			      encoding: NSASCIIStringEncoding
-			  freeWhenDone: NO];
+    if (len == 0) {
+        DESTROY(self);
+        return [self initWithBytesNoCopy:(char *)""
+                                  length:0
+                                encoding:NSASCIIStringEncoding
+                            freeWhenDone:NO];
     }
-  data_bytes = [d bytes];
-  if ((data_bytes != NULL) && (len >= 2))
-    {
-      const unichar *data_ucs2chars = (const unichar *)(void*) data_bytes;
-      if ((data_ucs2chars[0] == byteOrderMark)
-	|| (data_ucs2chars[0] == byteOrderMarkSwapped))
-	{
-	  enc = NSUnicodeStringEncoding;
-	}
-      else if (len >= 3
-	&& data_bytes[0] == 0xEF
-	&& data_bytes[1] == 0xBB
-	&& data_bytes[2] == 0xBF)
-	{
-	  enc = NSUTF8StringEncoding;
-	}
-    }
-  self = [self initWithData: d encoding: enc];
-  if (self == nil)
-    {
-      NSWarnMLog(@"Contents of URL '%@' are not string data using %@",
-        url, [NSString localizedNameOfStringEncoding: enc]);
-    }
-  return self;
-}
-
-- (id) initWithContentsOfURL: (NSURL*)url
-                usedEncoding: (NSStringEncoding*)enc
-                       error: (NSError**)error
-{
-  NSData		*d;
-  unsigned int		len;
-  const unsigned char	*data_bytes;
-
-  d = [NSDataClass dataWithContentsOfURL: url];
-  if (d == nil)
-    {
-      DESTROY(self);
-      return nil;
-    }
-  *enc = _DefaultStringEncoding;
-  len = [d length];
-  if (len == 0)
-    {
-      DESTROY(self);
-      return [self initWithBytesNoCopy: (char *)""
-				length: 0
-			      encoding: NSASCIIStringEncoding
-			  freeWhenDone: NO];
-    }
-  data_bytes = [d bytes];
-  if ((data_bytes != NULL) && (len >= 2))
-    {
-      const unichar *data_ucs2chars = (const unichar *)(void*) data_bytes;
-      if ((data_ucs2chars[0] == byteOrderMark)
-	|| (data_ucs2chars[0] == byteOrderMarkSwapped))
-	{
-	  /* somebody set up us the BOM! */
-	  *enc = NSUnicodeStringEncoding;
-	}
-      else if (len >= 3
-	&& data_bytes[0] == 0xEF
-	&& data_bytes[1] == 0xBB
-	&& data_bytes[2] == 0xBF)
-	{
-	  *enc = NSUTF8StringEncoding;
-	}
-    }
-  self = [self initWithData: d encoding: *enc];
-  if (self == nil)
-    {
-      if (error != 0)
-        {
-          *error = [NSError errorWithDomain: NSCocoaErrorDomain
-                                       code: NSFileReadCorruptFileError
-                                   userInfo: nil];
+    data_bytes = [d bytes];
+    if ((data_bytes != NULL) && (len >= 2)) {
+        const unichar *data_ucs2chars = (const unichar *)(void *)data_bytes;
+        if ((data_ucs2chars[0] == byteOrderMark) || (data_ucs2chars[0] == byteOrderMarkSwapped)) {
+            enc = NSUnicodeStringEncoding;
+        } else if (len >= 3 && data_bytes[0] == 0xEF && data_bytes[1] == 0xBB && data_bytes[2] == 0xBF) {
+            enc = NSUTF8StringEncoding;
         }
     }
-  return self;
+    self = [self initWithData:d encoding:enc];
+    if (self == nil) {
+        NSWarnMLog(@"Contents of URL '%@' are not string data using %@",
+                   url, [NSString localizedNameOfStringEncoding:enc]);
+    }
+    return self;
 }
 
-- (id) initWithContentsOfURL: (NSURL*)url
-                    encoding: (NSStringEncoding)enc
-                       error: (NSError**)error
+- (id)initWithContentsOfURL:(NSURL *)url
+               usedEncoding:(NSStringEncoding *)enc
+                      error:(NSError **)error
 {
-  NSData		*d;
-  unsigned int		len;
+    NSData *d;
+    unsigned int len;
+    const unsigned char *data_bytes;
 
-  d = [NSDataClass dataWithContentsOfURL: url];
-  if (d == nil)
-    {
-      DESTROY(self);
-      return nil;
+    d = [NSDataClass dataWithContentsOfURL:url];
+    if (d == nil) {
+        DESTROY(self);
+        return nil;
     }
-  len = [d length];
-  if (len == 0)
-    {
-      DESTROY(self);
-      return [self initWithBytesNoCopy: (char *)""
-				length: 0
-			      encoding: NSASCIIStringEncoding
-			  freeWhenDone: NO];
+    *enc = _DefaultStringEncoding;
+    len = [d length];
+    if (len == 0) {
+        DESTROY(self);
+        return [self initWithBytesNoCopy:(char *)""
+                                  length:0
+                                encoding:NSASCIIStringEncoding
+                            freeWhenDone:NO];
     }
-  self = [self initWithData: d encoding: enc];
-  if (self == nil)
-    {
-      if (error != 0)
-        {
-          *error = [NSError errorWithDomain: NSCocoaErrorDomain
-                                       code: NSFileReadCorruptFileError
-                                   userInfo: nil];
+    data_bytes = [d bytes];
+    if ((data_bytes != NULL) && (len >= 2)) {
+        const unichar *data_ucs2chars = (const unichar *)(void *)data_bytes;
+        if ((data_ucs2chars[0] == byteOrderMark) || (data_ucs2chars[0] == byteOrderMarkSwapped)) {
+            /* somebody set up us the BOM! */
+            *enc = NSUnicodeStringEncoding;
+        } else if (len >= 3 && data_bytes[0] == 0xEF && data_bytes[1] == 0xBB && data_bytes[2] == 0xBF) {
+            *enc = NSUTF8StringEncoding;
         }
     }
-  return self;
+    self = [self initWithData:d encoding:*enc];
+    if (self == nil) {
+        if (error != 0) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                         code:NSFileReadCorruptFileError
+                                     userInfo:nil];
+        }
+    }
+    return self;
+}
+
+- (id)initWithContentsOfURL:(NSURL *)url
+                   encoding:(NSStringEncoding)enc
+                      error:(NSError **)error
+{
+    NSData *d;
+    unsigned int len;
+
+    d = [NSDataClass dataWithContentsOfURL:url];
+    if (d == nil) {
+        DESTROY(self);
+        return nil;
+    }
+    len = [d length];
+    if (len == 0) {
+        DESTROY(self);
+        return [self initWithBytesNoCopy:(char *)""
+                                  length:0
+                                encoding:NSASCIIStringEncoding
+                            freeWhenDone:NO];
+    }
+    self = [self initWithData:d encoding:enc];
+    if (self == nil) {
+        if (error != 0) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                         code:NSFileReadCorruptFileError
+                                     userInfo:nil];
+        }
+    }
+    return self;
 }
 
 /**
  * Returns the number of Unicode characters in this string, including the
  * individual characters of composed character sequences,
  */
-- (NSUInteger) length
+- (NSUInteger)length
 {
-  [self subclassResponsibility: _cmd];
-  return 0;
+    [self subclassResponsibility:_cmd];
+    return 0;
 }
 
 // Accessing Characters
@@ -1878,40 +1714,40 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * Returns unicode character at index.  <code>unichar</code> is an unsigned
  * short.  Thus, a 16-bit character is returned.
  */
-- (unichar) characterAtIndex: (NSUInteger)index
+- (unichar)characterAtIndex:(NSUInteger)index
 {
-  [self subclassResponsibility: _cmd];
-  return (unichar)0;
+    [self subclassResponsibility:_cmd];
+    return (unichar)0;
 }
 
-- (NSString *) decomposedStringWithCompatibilityMapping
+- (NSString *)decomposedStringWithCompatibilityMapping
 {
 #if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
-  return [self _normalizedICUStringOfType: "nfkc" mode: UNORM2_DECOMPOSE];
+    return [self _normalizedICUStringOfType:"nfkc" mode:UNORM2_DECOMPOSE];
 #else
-  return [self notImplemented: _cmd];
+    return [self notImplemented:_cmd];
 #endif
 }
 
-- (NSString *) decomposedStringWithCanonicalMapping
+- (NSString *)decomposedStringWithCanonicalMapping
 {
 #if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
-  return [self _normalizedICUStringOfType: "nfc" mode: UNORM2_DECOMPOSE];
+    return [self _normalizedICUStringOfType:"nfc" mode:UNORM2_DECOMPOSE];
 #else
-  return [self notImplemented: _cmd];
+    return [self notImplemented:_cmd];
 #endif
 }
- 
+
 /**
  * Returns this string as an array of 16-bit <code>unichar</code> (unsigned
  * short) values.  buffer must be preallocated and should be capable of
  * holding -length shorts.
  */
 // Inefficient.  Should be overridden
-- (void) getCharacters: (unichar*)buffer
+- (void)getCharacters:(unichar *)buffer
 {
-  [self getCharacters: buffer range: ((NSRange){0, [self length]})];
-  return;
+    [self getCharacters:buffer range:((NSRange){0, [self length]})];
+    return;
 }
 
 /**
@@ -1920,128 +1756,110 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * of holding a sufficient number of shorts.
  */
 // Inefficient.  Should be overridden
-- (void) getCharacters: (unichar*)buffer
-		 range: (NSRange)aRange
+- (void)getCharacters:(unichar *)buffer
+                range:(NSRange)aRange
 {
-  unsigned	l = [self length];
-  unsigned	i;
-  unichar	(*caiImp)(NSString*, SEL, NSUInteger);
+    unsigned l = [self length];
+    unsigned i;
+    unichar (*caiImp)(NSString *, SEL, NSUInteger);
 
-  GS_RANGE_CHECK(aRange, l);
+    GS_RANGE_CHECK(aRange, l);
 
-  caiImp = (unichar (*)(NSString*,SEL,NSUInteger))
-    [self methodForSelector: caiSel];
+    caiImp = (unichar(*)(NSString *, SEL, NSUInteger))
+        [self methodForSelector:caiSel];
 
-  for (i = 0; i < aRange.length; i++)
-    {
-      buffer[i] = (*caiImp)(self, caiSel, aRange.location + i);
+    for (i = 0; i < aRange.length; i++) {
+        buffer[i] = (*caiImp)(self, caiSel, aRange.location + i);
     }
 }
 
-- (NSString *) stringByAddingPercentEncodingWithAllowedCharacters:
-  (NSCharacterSet *)aSet
+- (NSString *)stringByAddingPercentEncodingWithAllowedCharacters:
+    (NSCharacterSet *)aSet
 {
-  NSData	*data = [self dataUsingEncoding: NSUTF8StringEncoding];
-  NSString	*s = nil;
+    NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *s = nil;
 
-  if (data != nil)
-    {
-      unsigned char	*src = (unsigned char*)[data bytes];
-      unsigned int	slen = [data length];
-      unsigned char	*dst;
-      unsigned int	spos = 0;
-      unsigned int	dpos = 0;
+    if (data != nil) {
+        unsigned char *src = (unsigned char *)[data bytes];
+        unsigned int slen = [data length];
+        unsigned char *dst;
+        unsigned int spos = 0;
+        unsigned int dpos = 0;
 
-      dst = (unsigned char*)NSZoneMalloc(NSDefaultMallocZone(), slen * 3);
-      while (spos < slen)
-	{
-	  unichar	c = src[spos++];
-	  unsigned int	hi;
-	  unsigned int	lo;
+        dst = (unsigned char *)NSZoneMalloc(NSDefaultMallocZone(), slen * 3);
+        while (spos < slen) {
+            unichar c = src[spos++];
+            unsigned int hi;
+            unsigned int lo;
 
-	  /* If the character is in the allowed set *and* is in the
-	   * 7-bit ASCII range, it can be added unchanged.
-	   */
-	  if (c < 128 && [aSet characterIsMember: c])
-	    {
-	      dst[dpos++] = c;
-	    }
-	  else // if not, then encode it...
-	    {
-	      dst[dpos++] = '%';
-	      hi = (c & 0xf0) >> 4;
-	      dst[dpos++] = (hi > 9) ? 'A' + hi - 10 : '0' + hi;
-	      lo = (c & 0x0f);
-	      dst[dpos++] = (lo > 9) ? 'A' + lo - 10 : '0' + lo;
-	    }
-	}
-      s = [[NSString alloc] initWithBytes: dst
-				   length: dpos
-				 encoding: NSASCIIStringEncoding];
-      NSZoneFree(NSDefaultMallocZone(), dst);
-      IF_NO_ARC([s autorelease];)
+            /* If the character is in the allowed set *and* is in the
+             * 7-bit ASCII range, it can be added unchanged.
+             */
+            if (c < 128 && [aSet characterIsMember:c]) {
+                dst[dpos++] = c;
+            } else // if not, then encode it...
+            {
+                dst[dpos++] = '%';
+                hi = (c & 0xf0) >> 4;
+                dst[dpos++] = (hi > 9) ? 'A' + hi - 10 : '0' + hi;
+                lo = (c & 0x0f);
+                dst[dpos++] = (lo > 9) ? 'A' + lo - 10 : '0' + lo;
+            }
+        }
+        s = [[NSString alloc] initWithBytes:dst
+                                     length:dpos
+                                   encoding:NSASCIIStringEncoding];
+        NSZoneFree(NSDefaultMallocZone(), dst);
+        IF_NO_ARC([s autorelease];)
     }
-  return s;
+    return s;
 }
 
-- (NSString *) stringByRemovingPercentEncoding
+- (NSString *)stringByRemovingPercentEncoding
 {
-  NSData	*data = [self dataUsingEncoding: NSUTF8StringEncoding];
-  const uint8_t	*s = [data bytes];
-  NSUInteger	length = [data length]; 
-  NSUInteger	lastPercent = length - 3;
-  char		*o = (char *)NSZoneMalloc(NSDefaultMallocZone(), length + 1);
-  char		*next = o;
-  NSUInteger	index;
-  NSString	*result;
+    NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding];
+    const uint8_t *s = [data bytes];
+    NSUInteger length = [data length];
+    NSUInteger lastPercent = length - 3;
+    char *o = (char *)NSZoneMalloc(NSDefaultMallocZone(), length + 1);
+    char *next = o;
+    NSUInteger index;
+    NSString *result;
 
-  for (index = 0; index < length; index++)
-    {
-      char	c = s[index];
+    for (index = 0; index < length; index++) {
+        char c = s[index];
 
-      if ('%' == c && index <= lastPercent)
-	{
-	  uint8_t	hi = s[index+1];
-	  uint8_t	lo = s[index+2];
+        if ('%' == c && index <= lastPercent) {
+            uint8_t hi = s[index + 1];
+            uint8_t lo = s[index + 2];
 
-	  if (isxdigit(hi) && isxdigit(lo))
-	    {
-	      index += 2;
-              if (hi <= '9')
-                {
-                  c = hi - '0';
+            if (isxdigit(hi) && isxdigit(lo)) {
+                index += 2;
+                if (hi <= '9') {
+                    c = hi - '0';
+                } else if (hi <= 'F') {
+                    c = hi - 'A' + 10;
+                } else {
+                    c = hi - 'a' + 10;
                 }
-              else if (hi <= 'F')
-                {
-                  c = hi - 'A' + 10;
+                c <<= 4;
+                if (lo <= '9') {
+                    c += lo - '0';
+                } else if (lo <= 'F') {
+                    c += lo - 'A' + 10;
+                } else {
+                    c += lo - 'a' + 10;
                 }
-              else
-                {
-                  c = hi - 'a' + 10;
-                }
-	      c <<= 4;
-              if (lo <= '9')
-                {
-                  c += lo - '0';
-                }
-              else if (lo <= 'F')
-                {
-                  c += lo - 'A' + 10;
-                }
-              else
-                {
-                  c += lo - 'a' + 10;
-                }
-	    }
-	}
-      *next++ = c;
+            }
+        }
+        *next++ = c;
     }
-  *next = '\0';
+    *next = '\0';
 
-  result = [NSString stringWithUTF8String: o];
-  NSZoneFree(NSDefaultMallocZone(), o);
-  
-  return result; 
+    result = [NSString stringWithUTF8String:o];
+    NSZoneFree(NSDefaultMallocZone(), o);
+
+    return result;
 }
 
 /**
@@ -2063,82 +1881,77 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * add a string as a form field value (or name) you must add percent
  * escapes for those characters yourself.
  */
-- (NSString*) stringByAddingPercentEscapesUsingEncoding: (NSStringEncoding)e
+- (NSString *)stringByAddingPercentEscapesUsingEncoding:(NSStringEncoding)e
 {
-  NSData	*data = [self dataUsingEncoding: e];
-  NSString	*s = nil;
+    NSData *data = [self dataUsingEncoding:e];
+    NSString *s = nil;
 
-  if (data != nil)
-    {
-      unsigned char	*src = (unsigned char*)[data bytes];
-      unsigned int	slen = [data length];
-      unsigned char	*dst;
-      unsigned int	spos = 0;
-      unsigned int	dpos = 0;
+    if (data != nil) {
+        unsigned char *src = (unsigned char *)[data bytes];
+        unsigned int slen = [data length];
+        unsigned char *dst;
+        unsigned int spos = 0;
+        unsigned int dpos = 0;
 
-      dst = (unsigned char*)NSZoneMalloc(NSDefaultMallocZone(), slen * 3);
-      while (spos < slen)
-	{
-	  unsigned char	c = src[spos++];
-	  unsigned int	hi;
-	  unsigned int	lo;
+        dst = (unsigned char *)NSZoneMalloc(NSDefaultMallocZone(), slen * 3);
+        while (spos < slen) {
+            unsigned char c = src[spos++];
+            unsigned int hi;
+            unsigned int lo;
 
-	  if (c <= 32 || c > 126 || c == 34 || c == 35 || c == 37
-	    || c == 60 || c == 62 || c == 91 || c == 92 || c == 93
-	    || c == 94 || c == 96 || c == 123 || c == 124 || c == 125)
-	    {
-	      dst[dpos++] = '%';
-	      hi = (c & 0xf0) >> 4;
-	      dst[dpos++] = (hi > 9) ? 'A' + hi - 10 : '0' + hi;
-	      lo = (c & 0x0f);
-	      dst[dpos++] = (lo > 9) ? 'A' + lo - 10 : '0' + lo;
-	    }
-	  else
-	    {
-	      dst[dpos++] = c;
-	    }
-	}
-      s = [[NSString alloc] initWithBytes: dst
-				   length: dpos
-				 encoding: NSASCIIStringEncoding];
-      NSZoneFree(NSDefaultMallocZone(), dst);
-      IF_NO_ARC([s autorelease];)
+            if (c <= 32 || c > 126 || c == 34 || c == 35 || c == 37 || c == 60 || c == 62 || c == 91 || c == 92 || c == 93 || c == 94 || c == 96 || c == 123 || c == 124 || c == 125) {
+                dst[dpos++] = '%';
+                hi = (c & 0xf0) >> 4;
+                dst[dpos++] = (hi > 9) ? 'A' + hi - 10 : '0' + hi;
+                lo = (c & 0x0f);
+                dst[dpos++] = (lo > 9) ? 'A' + lo - 10 : '0' + lo;
+            } else {
+                dst[dpos++] = c;
+            }
+        }
+        s = [[NSString alloc] initWithBytes:dst
+                                     length:dpos
+                                   encoding:NSASCIIStringEncoding];
+        NSZoneFree(NSDefaultMallocZone(), dst);
+        IF_NO_ARC([s autorelease];)
     }
-  return s;
+    return s;
 }
 
 /**
  * Constructs a new string consisting of this instance followed by the string
  * specified by format.
  */
-- (NSString*) stringByAppendingFormat: (NSString*)format,...
+- (NSString *)stringByAppendingFormat:(NSString *)format, ...
 {
-  va_list	ap;
-  id		ret;
+    va_list ap;
+    id ret;
 
-  va_start(ap, format);
-  ret = [self stringByAppendingString:
-    [NSString stringWithFormat: format arguments: ap]];
-  va_end(ap);
-  return ret;
+    va_start(ap, format);
+    ret = [self stringByAppendingString:
+                    [NSString stringWithFormat:format
+                                     arguments:ap]];
+    va_end(ap);
+    return ret;
 }
 
 /**
  * Constructs a new string consisting of this instance followed by the aString.
  */
-- (NSString*) stringByAppendingString: (NSString*)aString
+- (NSString *)stringByAppendingString:(NSString *)aString
 {
-  unsigned	len = [self length];
-  unsigned	otherLength = [aString length];
-  NSZone	*z = [self zone];
-  unichar	*s = NSZoneMalloc(z, (len+otherLength)*sizeof(unichar));
-  NSString	*tmp;
+    unsigned len = [self length];
+    unsigned otherLength = [aString length];
+    NSZone *z = [self zone];
+    unichar *s = NSZoneMalloc(z, (len + otherLength) * sizeof(unichar));
+    NSString *tmp;
 
-  [self getCharacters: s range: ((NSRange){0, len})];
-  [aString getCharacters: s + len range: ((NSRange){0, otherLength})];
-  tmp = [[NSStringClass allocWithZone: z] initWithCharactersNoCopy: s
-    length: len + otherLength freeWhenDone: YES];
-  return AUTORELEASE(tmp);
+    [self getCharacters:s range:((NSRange){0, len})];
+    [aString getCharacters:s + len range:((NSRange){0, otherLength})];
+    tmp = [[NSStringClass allocWithZone:z] initWithCharactersNoCopy:s
+                                                             length:len + otherLength
+                                                       freeWhenDone:YES];
+    return AUTORELEASE(tmp);
 }
 
 // Dividing Strings into Substrings
@@ -2150,42 +1963,41 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * returned.  If string begins or ends with separator, empty strings will
  * be returned for those positions.</p>
  */
-- (NSArray *) componentsSeparatedByCharactersInSet: (NSCharacterSet *)separator
+- (NSArray *)componentsSeparatedByCharactersInSet:(NSCharacterSet *)separator
 {
-  NSRange	search;
-  NSRange	complete;
-  NSRange	found;
-  NSMutableArray *array;
-  IF_NO_ARC(NSAutoreleasePool *pool; NSUInteger count;)
+    NSRange search;
+    NSRange complete;
+    NSRange found;
+    NSMutableArray *array;
+    IF_NO_ARC(NSAutoreleasePool * pool; NSUInteger count;)
 
-  if (separator == nil)
-    [NSException raise: NSInvalidArgumentException format: @"separator is nil"];
+    if (separator == nil)
+        [NSException raise:NSInvalidArgumentException format:@"separator is nil"];
 
-  array = [NSMutableArray array];
-  IF_NO_ARC(pool = [NSAutoreleasePool new]; count = 0;)
-  search = NSMakeRange (0, [self length]);
-  complete = search;
-  found = [self rangeOfCharacterFromSet: separator];
-  while (found.length != 0)
-    {
-      NSRange current;
+    array = [NSMutableArray array];
+    IF_NO_ARC(pool = [NSAutoreleasePool new]; count = 0;)
+    search = NSMakeRange(0, [self length]);
+    complete = search;
+    found = [self rangeOfCharacterFromSet:separator];
+    while (found.length != 0) {
+        NSRange current;
 
-      current = NSMakeRange (search.location,
-	found.location - search.location);
-      [array addObject: [self substringWithRange: current]];
+        current = NSMakeRange(search.location,
+                              found.location - search.location);
+        [array addObject:[self substringWithRange:current]];
 
-      search = NSMakeRange (found.location + found.length,
-	complete.length - found.location - found.length);
-      found = [self rangeOfCharacterFromSet: separator
-                                    options: 0
-                                      range: search];
-      IF_NO_ARC(if (0 == count % 200) [pool emptyPool];)
+        search = NSMakeRange(found.location + found.length,
+                             complete.length - found.location - found.length);
+        found = [self rangeOfCharacterFromSet:separator
+                                      options:0
+                                        range:search];
+        IF_NO_ARC(if (0 == count % 200)[pool emptyPool];)
     }
-  // Add the last search string range
-  [array addObject: [self substringWithRange: search]];
-  IF_NO_ARC([pool release];)
-  // FIXME: Need to make mutable array into non-mutable array?
-  return array;
+    // Add the last search string range
+    [array addObject:[self substringWithRange:search]];
+    IF_NO_ARC([pool release];)
+    // FIXME: Need to make mutable array into non-mutable array?
+    return array;
 }
 
 /**
@@ -2196,80 +2008,79 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * be returned for those positions.</p>
  * <p>Note, use an [NSScanner] if you need more sophisticated parsing.</p>
  */
-- (NSArray*) componentsSeparatedByString: (NSString*)separator
+- (NSArray *)componentsSeparatedByString:(NSString *)separator
 {
-  NSRange	search;
-  NSRange	complete;
-  NSRange	found;
-  NSMutableArray *array = [NSMutableArray array];
+    NSRange search;
+    NSRange complete;
+    NSRange found;
+    NSMutableArray *array = [NSMutableArray array];
 
-  search = NSMakeRange (0, [self length]);
-  complete = search;
-  found = [self rangeOfString: separator
-                      options: 0
-                        range: search
-                       locale: nil];
-  while (found.length != 0)
-    {
-      NSRange current;
+    search = NSMakeRange(0, [self length]);
+    complete = search;
+    found = [self rangeOfString:separator
+                        options:0
+                          range:search
+                         locale:nil];
+    while (found.length != 0) {
+        NSRange current;
 
-      current = NSMakeRange (search.location,
-	found.location - search.location);
-      [array addObject: [self substringWithRange: current]];
+        current = NSMakeRange(search.location,
+                              found.location - search.location);
+        [array addObject:[self substringWithRange:current]];
 
-      search = NSMakeRange (found.location + found.length,
-	complete.length - found.location - found.length);
-      found = [self rangeOfString: separator
-			  options: 0
-			    range: search
-                           locale: nil];
+        search = NSMakeRange(found.location + found.length,
+                             complete.length - found.location - found.length);
+        found = [self rangeOfString:separator
+                            options:0
+                              range:search
+                             locale:nil];
     }
-  // Add the last search string range
-  [array addObject: [self substringWithRange: search]];
+    // Add the last search string range
+    [array addObject:[self substringWithRange:search]];
 
-  // FIXME: Need to make mutable array into non-mutable array?
-  return array;
+    // FIXME: Need to make mutable array into non-mutable array?
+    return array;
 }
 
-- (NSString*) stringByReplacingOccurrencesOfString: (NSString*)replace
-                                        withString: (NSString*)by
-                                           options: (NSStringCompareOptions)opts
-                                             range: (NSRange)searchRange
+- (NSString *)stringByReplacingOccurrencesOfString:(NSString *)replace
+                                        withString:(NSString *)by
+                                           options:(NSStringCompareOptions)opts
+                                             range:(NSRange)searchRange
 {
-  id copy;
+    id copy;
 
-  copy = [[[GSMutableStringClass allocWithZone: NSDefaultMallocZone()]
-    initWithString: self] autorelease];
-  [copy replaceOccurrencesOfString: replace
-                        withString: by
-                           options: opts
-                             range: searchRange];
-  return GS_IMMUTABLE(copy);
+    copy = [[[GSMutableStringClass allocWithZone:NSDefaultMallocZone()]
+        initWithString:self] autorelease];
+    [copy replaceOccurrencesOfString:replace
+                          withString:by
+                             options:opts
+                               range:searchRange];
+    return GS_IMMUTABLE(copy);
 }
 
-- (NSString*) stringByReplacingOccurrencesOfString: (NSString*)replace
-                                        withString: (NSString*)by
+- (NSString *)stringByReplacingOccurrencesOfString:(NSString *)replace
+                                        withString:(NSString *)by
 {
-  return [self 
-      stringByReplacingOccurrencesOfString: replace
-                                withString: by
-                                   options: 0
-                                     range: NSMakeRange(0, [self length])];
+    return [self
+        stringByReplacingOccurrencesOfString:replace
+                                  withString:by
+                                     options:0
+                                       range:NSMakeRange(0, [self length])];
 }
 
 /**
- * Returns a new string where the substring in the given range is replaced by 
- * the passed string. 
+ * Returns a new string where the substring in the given range is replaced by
+ * the passed string.
  */
-- (NSString*) stringByReplacingCharactersInRange: (NSRange)aRange 
-                                      withString: (NSString*)by
+- (NSString *)stringByReplacingCharactersInRange:(NSRange)aRange
+                                      withString:(NSString *)by
 {
-  id	copy;
+    id copy;
 
-  copy = [[[GSMutableStringClass allocWithZone: NSDefaultMallocZone()]
-    initWithString: self] autorelease];
-  [copy replaceCharactersInRange: aRange withString: by];
-  return GS_IMMUTABLE(copy);
+    copy = [[[GSMutableStringClass allocWithZone:NSDefaultMallocZone()]
+        initWithString:self] autorelease];
+    [copy replaceCharactersInRange:aRange withString:by];
+    return GS_IMMUTABLE(copy);
 }
 
 /**
@@ -2281,9 +2092,9 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * If the supplied index is greater than or equal to the length of the
  * receiver an exception is raised.
  */
-- (NSString*) substringFromIndex: (NSUInteger)index
+- (NSString *)substringFromIndex:(NSUInteger)index
 {
-  return [self substringWithRange: ((NSRange){index, [self length]-index})];
+    return [self substringWithRange:((NSRange){index, [self length] - index})];
 }
 
 /**
@@ -2294,17 +2105,17 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * If the supplied index is greater than the length of the receiver
  * an exception is raised.
  */
-- (NSString*) substringToIndex: (NSUInteger)index
+- (NSString *)substringToIndex:(NSUInteger)index
 {
-  return [self substringWithRange: ((NSRange){0,index})];
+    return [self substringWithRange:((NSRange){0, index})];
 }
 
 /**
  * An obsolete name for -substringWithRange: ... deprecated.
  */
-- (NSString*) substringFromRange: (NSRange)aRange
+- (NSString *)substringFromRange:(NSRange)aRange
 {
-  return [self substringWithRange: aRange];
+    return [self substringWithRange:aRange];
 }
 
 /**
@@ -2314,21 +2125,23 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * present in the receiver, an exception is raised.<br />
  * If aRange has a length of zero, an empty string is returned.
  */
-- (NSString*) substringWithRange: (NSRange)aRange
+- (NSString *)substringWithRange:(NSRange)aRange
 {
-  unichar	*buf;
-  id		ret;
-  unsigned	len = [self length];
+    unichar *buf;
+    id ret;
+    unsigned len = [self length];
 
-  GS_RANGE_CHECK(aRange, len);
+    GS_RANGE_CHECK(aRange, len);
 
-  if (aRange.length == 0)
-    return @"";
-  buf = NSZoneMalloc([self zone], sizeof(unichar)*aRange.length);
-  [self getCharacters: buf range: aRange];
-  ret = [[NSStringClass allocWithZone: NSDefaultMallocZone()]
-    initWithCharactersNoCopy: buf length: aRange.length freeWhenDone: YES];
-  return AUTORELEASE(ret);
+    if (aRange.length == 0)
+        return @"";
+    buf = NSZoneMalloc([self zone], sizeof(unichar) * aRange.length);
+    [self getCharacters:buf range:aRange];
+    ret = [[NSStringClass allocWithZone:NSDefaultMallocZone()]
+        initWithCharactersNoCopy:buf
+                          length:aRange.length
+                    freeWhenDone:YES];
+    return AUTORELEASE(ret);
 }
 
 // Finding Ranges of Characters and Substrings
@@ -2339,13 +2152,13 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * the range returned will contain the whole sequence, else just the character
  * itself.
  */
-- (NSRange) rangeOfCharacterFromSet: (NSCharacterSet*)aSet
+- (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
 {
-  NSRange all = NSMakeRange(0, [self length]);
+    NSRange all = NSMakeRange(0, [self length]);
 
-  return [self rangeOfCharacterFromSet: aSet
-			       options: 0
-				 range: all];
+    return [self rangeOfCharacterFromSet:aSet
+                                 options:0
+                                   range:all];
 }
 
 /**
@@ -2357,14 +2170,14 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * characters equal), or <code>NSBackwardsSearch</code> (search from end of
  * string).
  */
-- (NSRange) rangeOfCharacterFromSet: (NSCharacterSet*)aSet
-			    options: (NSUInteger)mask
+- (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+                           options:(NSUInteger)mask
 {
-  NSRange all = NSMakeRange(0, [self length]);
+    NSRange all = NSMakeRange(0, [self length]);
 
-  return [self rangeOfCharacterFromSet: aSet
-			       options: mask
-				 range: all];
+    return [self rangeOfCharacterFromSet:aSet
+                                 options:mask
+                                   range:all];
 }
 
 /**
@@ -2376,77 +2189,77 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * characters equal), or <code>NSBackwardsSearch</code> (search from end of
  * string).  Search only carried out within aRange.
  */
-- (NSRange) rangeOfCharacterFromSet: (NSCharacterSet*)aSet
-			    options: (NSUInteger)mask
-			      range: (NSRange)aRange
+- (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
+                           options:(NSUInteger)mask
+                             range:(NSRange)aRange
 {
-  unsigned int	i;
-  unsigned int	start;
-  unsigned int	stop;
-  int		step;
-  NSRange	range;
-  unichar	(*cImp)(id, SEL, NSUInteger);
-  BOOL		(*mImp)(id, SEL, unichar);
+    unsigned int i;
+    unsigned int start;
+    unsigned int stop;
+    int step;
+    NSRange range;
+    unichar (*cImp)(id, SEL, NSUInteger);
+    BOOL (*mImp)
+    (id, SEL, unichar);
 
-  i = [self length];
-  GS_RANGE_CHECK(aRange, i);
+    i = [self length];
+    GS_RANGE_CHECK(aRange, i);
 
-  if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-    {
-      start = NSMaxRange(aRange)-1; stop = aRange.location-1; step = -1;
+    if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+        start = NSMaxRange(aRange) - 1;
+        stop = aRange.location - 1;
+        step = -1;
+    } else {
+        start = aRange.location;
+        stop = NSMaxRange(aRange);
+        step = 1;
     }
-  else
-    {
-      start = aRange.location; stop = NSMaxRange(aRange); step = 1;
-    }
-  range.location = NSNotFound;
-  range.length = 0;
+    range.location = NSNotFound;
+    range.length = 0;
 
-  cImp = (unichar(*)(id,SEL,NSUInteger))
-    [self methodForSelector: caiSel];
-  mImp = (BOOL(*)(id,SEL,unichar))
-    [aSet methodForSelector: cMemberSel];
+    cImp = (unichar(*)(id, SEL, NSUInteger))
+        [self methodForSelector:caiSel];
+    mImp = (BOOL(*)(id, SEL, unichar))
+        [aSet methodForSelector:cMemberSel];
 
-  for (i = start; i != stop; i += step)
-    {
-      unichar letter = (unichar)(*cImp)(self, caiSel, i);
+    for (i = start; i != stop; i += step) {
+        unichar letter = (unichar)(*cImp)(self, caiSel, i);
 
-      if ((*mImp)(aSet, cMemberSel, letter))
-	{
-	  range = NSMakeRange(i, 1);
-	  break;
-	}
+        if ((*mImp)(aSet, cMemberSel, letter)) {
+            range = NSMakeRange(i, 1);
+            break;
+        }
     }
 
-  return range;
+    return range;
 }
 
 /**
  * Invokes -rangeOfString:options: with no options.
  */
-- (NSRange) rangeOfString: (NSString*)string
+- (NSRange)rangeOfString:(NSString *)string
 {
-  NSRange	all = NSMakeRange(0, [self length]);
+    NSRange all = NSMakeRange(0, [self length]);
 
-  return [self rangeOfString: string
-		     options: 0
-		       range: all
-                      locale: nil];
+    return [self rangeOfString:string
+                       options:0
+                         range:all
+                        locale:nil];
 }
 
 /**
  * Invokes -rangeOfString:options:range: with the range set
  * set to the range of the whole of the receiver.
  */
-- (NSRange) rangeOfString: (NSString*)string
-		  options: (NSUInteger)mask
+- (NSRange)rangeOfString:(NSString *)string
+                 options:(NSUInteger)mask
 {
-  NSRange	all = NSMakeRange(0, [self length]);
+    NSRange all = NSMakeRange(0, [self length]);
 
-  return [self rangeOfString: string
-		     options: mask
-		       range: all
-                      locale: nil];
+    return [self rangeOfString:string
+                       options:mask
+                         range:all
+                        locale:nil];
 }
 
 /**
@@ -2473,484 +2286,368 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * beginning (or end, if <code>NSBackwardsSearch</code> is also given) of the
  * string.  Options should be OR'd together using <code>'|'</code>.
  */
-- (NSRange) rangeOfString: (NSString *)aString
-		  options: (NSUInteger)mask
-		    range: (NSRange)aRange
+- (NSRange)rangeOfString:(NSString *)aString
+                 options:(NSUInteger)mask
+                   range:(NSRange)aRange
 {
-  return [self rangeOfString: aString
-                     options: mask
-                       range: aRange
-		      locale: nil];
+    return [self rangeOfString:aString
+                       options:mask
+                         range:aRange
+                        locale:nil];
 }
 
-- (NSRange) rangeOfString: (NSString *)aString
-                  options: (NSStringCompareOptions)mask
-                    range: (NSRange)searchRange
-                   locale: (NSLocale *)locale
+- (NSRange)rangeOfString:(NSString *)aString
+                 options:(NSStringCompareOptions)mask
+                   range:(NSRange)searchRange
+                  locale:(NSLocale *)locale
 {
-  NSUInteger    length = [self length];
-  NSUInteger    countOther;
+    NSUInteger length = [self length];
+    NSUInteger countOther;
 
-  GS_RANGE_CHECK(searchRange, length);
-  if (aString == nil)
-    [NSException raise: NSInvalidArgumentException format: @"range of nil"];
+    GS_RANGE_CHECK(searchRange, length);
+    if (aString == nil)
+        [NSException raise:NSInvalidArgumentException format:@"range of nil"];
 
-  if ((mask & NSRegularExpressionSearch) == NSRegularExpressionSearch)
-    {
-      NSRange			r = {NSNotFound, 0};
-      NSError			*e = nil;
-      NSUInteger		options = 0;
-      NSRegularExpression	*regex = [NSRegularExpression alloc];
+    if ((mask & NSRegularExpressionSearch) == NSRegularExpressionSearch) {
+        NSRange r = {NSNotFound, 0};
+        NSError *e = nil;
+        NSUInteger options = 0;
+        NSRegularExpression *regex = [NSRegularExpression alloc];
 
-      if ((mask & NSCaseInsensitiveSearch) == NSCaseInsensitiveSearch)
-	{
-	  options |= NSRegularExpressionCaseInsensitive;
-	}
-      regex = [regex initWithPattern: aString options: options error: &e];
-      if (nil == e)
-	{
-	  options = ((mask & NSAnchoredSearch) == NSAnchoredSearch)
-	    ? NSMatchingAnchored : 0;
-	  r = [regex rangeOfFirstMatchInString: self
-				       options: options
-					 range: searchRange];
-	}
-      [regex release];
-      return r;
-    }
-
-  countOther = [aString length];
-
-  /* A zero length string is always found at the start of the given range.
-   */
-  if (0 == countOther)
-    {
-      if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-        {
-          searchRange.location += searchRange.length;
+        if ((mask & NSCaseInsensitiveSearch) == NSCaseInsensitiveSearch) {
+            options |= NSRegularExpressionCaseInsensitive;
         }
-      searchRange.length = 0;
-      return searchRange;
+        regex = [regex initWithPattern:aString options:options error:&e];
+        if (nil == e) {
+            options = ((mask & NSAnchoredSearch) == NSAnchoredSearch) ? NSMatchingAnchored : 0;
+            r = [regex rangeOfFirstMatchInString:self
+                                         options:options
+                                           range:searchRange];
+        }
+        [regex release];
+        return r;
     }
 
-  /* If the string to search for is a single codepoint which is not
-   * decomposable to a sequence, then it can only match the identical
-   * codepoint, so we can perform the much cheaper literal search.
-   */
-  if (1 == countOther)
-    {
-      unichar   u = [aString characterAtIndex: 0];
+    countOther = [aString length];
 
-      if ((mask & NSLiteralSearch) == NSLiteralSearch || uni_is_decomp(u))
-        {
-          NSRange   result;
+    /* A zero length string is always found at the start of the given range.
+     */
+    if (0 == countOther) {
+        if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+            searchRange.location += searchRange.length;
+        }
+        searchRange.length = 0;
+        return searchRange;
+    }
 
-          if (searchRange.length < countOther)
-            {
-              /* Range to search is smaller than string to look for.
-               */
-              result = NSMakeRange(NSNotFound, 0);
-            }
-          else if ((mask & NSAnchoredSearch) == NSAnchoredSearch
-            || searchRange.length == 1)
-            {
-              /* Range to search is a single character.
-               */
-              if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-                {
-                  searchRange.location = NSMaxRange(searchRange) - 1;
+    /* If the string to search for is a single codepoint which is not
+     * decomposable to a sequence, then it can only match the identical
+     * codepoint, so we can perform the much cheaper literal search.
+     */
+    if (1 == countOther) {
+        unichar u = [aString characterAtIndex:0];
+
+        if ((mask & NSLiteralSearch) == NSLiteralSearch || uni_is_decomp(u)) {
+            NSRange result;
+
+            if (searchRange.length < countOther) {
+                /* Range to search is smaller than string to look for.
+                 */
+                result = NSMakeRange(NSNotFound, 0);
+            } else if ((mask & NSAnchoredSearch) == NSAnchoredSearch || searchRange.length == 1) {
+                /* Range to search is a single character.
+                 */
+                if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+                    searchRange.location = NSMaxRange(searchRange) - 1;
                 }
-              if ((mask & NSCaseInsensitiveSearch) == NSCaseInsensitiveSearch)
-                {
-                  u = uni_toupper(u);
-                  if (uni_toupper([self characterAtIndex: searchRange.location])
-                     == u)
-                    {
-                      result = searchRange;
+                if ((mask & NSCaseInsensitiveSearch) == NSCaseInsensitiveSearch) {
+                    u = uni_toupper(u);
+                    if (uni_toupper([self characterAtIndex:searchRange.location]) == u) {
+                        result = searchRange;
+                    } else {
+                        result = NSMakeRange(NSNotFound, 0);
                     }
-                  else
-                    {
-                      result = NSMakeRange(NSNotFound, 0);
-                    }
-                }
-              else
-                {
-                  if ([self characterAtIndex: searchRange.location] == u)
-                    {
-                      result = searchRange;
-                    }
-                  else
-                    {
-                      result = NSMakeRange(NSNotFound, 0);
+                } else {
+                    if ([self characterAtIndex:searchRange.location] == u) {
+                        result = searchRange;
+                    } else {
+                        result = NSMakeRange(NSNotFound, 0);
                     }
                 }
-            }
-          else
-            {
-              NSUInteger    pos;
-              NSUInteger    end;
+            } else {
+                NSUInteger pos;
+                NSUInteger end;
 
-              /* Range to search is bigger than string to look for.
-               */
-              GS_BEGINITEMBUF2(charsSelf, (searchRange.length*sizeof(unichar)),
-                unichar)
-              [self getCharacters: charsSelf range: searchRange];
-              end = searchRange.length;
-              if ((mask & NSCaseInsensitiveSearch) == NSCaseInsensitiveSearch)
-                {
-                  u = uni_toupper(u);
-                  if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-                    {
-                      pos = end;
-                      while (pos-- > 0)
-                        {
-                          if (uni_toupper(charsSelf[pos]) == u)
-                            {
-                              break;
+                /* Range to search is bigger than string to look for.
+                 */
+                GS_BEGINITEMBUF2(charsSelf, (searchRange.length * sizeof(unichar)),
+                                 unichar)
+                [self getCharacters:charsSelf range:searchRange];
+                end = searchRange.length;
+                if ((mask & NSCaseInsensitiveSearch) == NSCaseInsensitiveSearch) {
+                    u = uni_toupper(u);
+                    if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+                        pos = end;
+                        while (pos-- > 0) {
+                            if (uni_toupper(charsSelf[pos]) == u) {
+                                break;
                             }
                         }
-                    }
-                  else
-                    {
-                      pos = 0;
-                      while (pos < end)
-                        {
-                          if (uni_toupper(charsSelf[pos]) == u)
-                            {
-                              break;
+                    } else {
+                        pos = 0;
+                        while (pos < end) {
+                            if (uni_toupper(charsSelf[pos]) == u) {
+                                break;
                             }
-                          pos++;
-                        }                        
-                    }
-                }
-              else
-                {
-                  if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-                    {
-                      pos = end;
-                      while (pos-- > 0)
-                        {
-                          if (charsSelf[pos] == u)
-                            {
-                              break;
-                            }
+                            pos++;
                         }
                     }
-                  else
-                    {
-                      pos = 0;
-                      while (pos < end)
-                        {
-                          if (charsSelf[pos] == u)
-                            {
-                              break;
+                } else {
+                    if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+                        pos = end;
+                        while (pos-- > 0) {
+                            if (charsSelf[pos] == u) {
+                                break;
                             }
-                          pos++;
-                        }                        
+                        }
+                    } else {
+                        pos = 0;
+                        while (pos < end) {
+                            if (charsSelf[pos] == u) {
+                                break;
+                            }
+                            pos++;
+                        }
                     }
                 }
-              GS_ENDITEMBUF2()
+                GS_ENDITEMBUF2()
 
-              if (pos >= end)
-                {
-                  result = NSMakeRange(NSNotFound, 0);
-                }
-              else
-                {
-                  result = NSMakeRange(searchRange.location + pos, countOther);
+                if (pos >= end) {
+                    result = NSMakeRange(NSNotFound, 0);
+                } else {
+                    result = NSMakeRange(searchRange.location + pos, countOther);
                 }
             }
-          return result;
+            return result;
         }
     }
 
-  if ((mask & NSLiteralSearch) == NSLiteralSearch)
-    {
-      NSRange   result;
-      BOOL      insensitive;
+    if ((mask & NSLiteralSearch) == NSLiteralSearch) {
+        NSRange result;
+        BOOL insensitive;
 
-      if ((mask & NSCaseInsensitiveSearch) == NSCaseInsensitiveSearch)
-        {
-          insensitive = YES;
-        }
-      else
-        {
-          insensitive = NO;
+        if ((mask & NSCaseInsensitiveSearch) == NSCaseInsensitiveSearch) {
+            insensitive = YES;
+        } else {
+            insensitive = NO;
         }
 
-      if (searchRange.length < countOther)
-        {
-          /* Range to search is smaller than string to look for.
-           */
-          result = NSMakeRange(NSNotFound, 0);
-        }
-      else
-        {
-          GS_BEGINITEMBUF(charsOther, (countOther*sizeof(unichar)), unichar)
+        if (searchRange.length < countOther) {
+            /* Range to search is smaller than string to look for.
+             */
+            result = NSMakeRange(NSNotFound, 0);
+        } else {
+            GS_BEGINITEMBUF(charsOther, (countOther * sizeof(unichar)), unichar)
 
-          [aString getCharacters: charsOther range: NSMakeRange(0, countOther)];
-          if (YES == insensitive)
-            {
-              NSUInteger        index;
+            [aString getCharacters:charsOther range:NSMakeRange(0, countOther)];
+            if (YES == insensitive) {
+                NSUInteger index;
 
-              /* Make the substring we are searching for be uppercase.
-               */
-              for (index = 0; index < countOther; index++)
-                {
-                  charsOther[index] = uni_toupper(charsOther[index]);
+                /* Make the substring we are searching for be uppercase.
+                 */
+                for (index = 0; index < countOther; index++) {
+                    charsOther[index] = uni_toupper(charsOther[index]);
                 }
             }
-          if ((mask & NSAnchoredSearch) == NSAnchoredSearch
-            || searchRange.length == countOther)
-            {
-              /* Range to search is same size as string to look for.
-               */
-              GS_BEGINITEMBUF2(charsSelf, (countOther*sizeof(unichar)), unichar)
-              if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-                {
-                  searchRange.location = NSMaxRange(searchRange) - countOther;
-                  searchRange.length = countOther;
+            if ((mask & NSAnchoredSearch) == NSAnchoredSearch || searchRange.length == countOther) {
+                /* Range to search is same size as string to look for.
+                 */
+                GS_BEGINITEMBUF2(charsSelf, (countOther * sizeof(unichar)), unichar)
+                if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+                    searchRange.location = NSMaxRange(searchRange) - countOther;
+                    searchRange.length = countOther;
+                } else {
+                    searchRange.length = countOther;
                 }
-              else
-                {
-                  searchRange.length = countOther;
-                }
-              [self getCharacters: charsSelf range: searchRange];
-              if (YES == insensitive)
-                {
-                  NSUInteger    index;
+                [self getCharacters:charsSelf range:searchRange];
+                if (YES == insensitive) {
+                    NSUInteger index;
 
-                  for (index = 0; index < countOther; index++)
-                    {
-                      if (uni_toupper(charsSelf[index]) != charsOther[index])
-                        {
-                          break;
+                    for (index = 0; index < countOther; index++) {
+                        if (uni_toupper(charsSelf[index]) != charsOther[index]) {
+                            break;
                         }
                     }
-                  if (index < countOther)
-                    {
-                      result = NSMakeRange(NSNotFound, 0);
+                    if (index < countOther) {
+                        result = NSMakeRange(NSNotFound, 0);
+                    } else {
+                        result = searchRange;
                     }
-                  else
-                    {
-                      result = searchRange;
-                    }
-                }
-              else
-                {
-                  if (memcmp(&charsSelf[0], &charsOther[0],
-                    countOther * sizeof(unichar)) == 0)
-                    {
-                      result = searchRange;
-                    }
-                  else
-                    {
-                      result = NSMakeRange(NSNotFound, 0);
+                } else {
+                    if (memcmp(&charsSelf[0], &charsOther[0],
+                               countOther * sizeof(unichar)) == 0) {
+                        result = searchRange;
+                    } else {
+                        result = NSMakeRange(NSNotFound, 0);
                     }
                 }
-              GS_ENDITEMBUF2()
-            }
-          else
-            {
-              NSUInteger    pos;
-              NSUInteger    end;
+                GS_ENDITEMBUF2()
+            } else {
+                NSUInteger pos;
+                NSUInteger end;
 
-              end = searchRange.length - countOther + 1;
-              if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-                {
-                  pos = end;
+                end = searchRange.length - countOther + 1;
+                if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+                    pos = end;
+                } else {
+                    pos = 0;
                 }
-              else
-                {
-                  pos = 0;
-                }
-              /* Range to search is bigger than string to look for.
-               */
-              GS_BEGINITEMBUF2(charsSelf, (searchRange.length*sizeof(unichar)),
-                unichar)
-              [self getCharacters: charsSelf range: searchRange];
+                /* Range to search is bigger than string to look for.
+                 */
+                GS_BEGINITEMBUF2(charsSelf, (searchRange.length * sizeof(unichar)),
+                                 unichar)
+                [self getCharacters:charsSelf range:searchRange];
 
-              if (YES == insensitive)
-                {
-                  NSUInteger        count;
-                  NSUInteger        index;
+                if (YES == insensitive) {
+                    NSUInteger count;
+                    NSUInteger index;
 
-                  /* Make things uppercase in the string being searched
-                   * Start with all but one of the characters in a substring
-                   * and we'll uppercase one more character each time we do
-                   * a comparison.
-                   */
-                  index = pos;
-                  for (count = 1; count < countOther; count++)
-                    {
-                      charsSelf[index] = uni_toupper(charsSelf[index]);
-                      index++;
+                    /* Make things uppercase in the string being searched
+                     * Start with all but one of the characters in a substring
+                     * and we'll uppercase one more character each time we do
+                     * a comparison.
+                     */
+                    index = pos;
+                    for (count = 1; count < countOther; count++) {
+                        charsSelf[index] = uni_toupper(charsSelf[index]);
+                        index++;
                     }
                 }
 
-              if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-                {
-                  if (YES == insensitive)
-                    {
-                      while (pos-- > 0)
-                        {
-                          charsSelf[pos] = uni_toupper(charsSelf[pos]);
-                          if (memcmp(&charsSelf[pos], charsOther,
-                            countOther * sizeof(unichar)) == 0)
-                            {
-                              break;
+                if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+                    if (YES == insensitive) {
+                        while (pos-- > 0) {
+                            charsSelf[pos] = uni_toupper(charsSelf[pos]);
+                            if (memcmp(&charsSelf[pos], charsOther,
+                                       countOther * sizeof(unichar)) == 0) {
+                                break;
+                            }
+                        }
+                    } else {
+                        while (pos-- > 0) {
+                            if (memcmp(&charsSelf[pos], charsOther,
+                                       countOther * sizeof(unichar)) == 0) {
+                                break;
                             }
                         }
                     }
-                  else
-                    {
-                      while (pos-- > 0)
-                        {
-                          if (memcmp(&charsSelf[pos], charsOther,
-                            countOther * sizeof(unichar)) == 0)
-                            {
-                              break;
+                } else {
+                    if (YES == insensitive) {
+                        while (pos < end) {
+                            charsSelf[pos + countOther - 1] = uni_toupper(charsSelf[pos + countOther - 1]);
+                            if (memcmp(&charsSelf[pos], charsOther,
+                                       countOther * sizeof(unichar)) == 0) {
+                                break;
                             }
+                            pos++;
+                        }
+                    } else {
+                        while (pos < end) {
+                            if (memcmp(&charsSelf[pos], charsOther,
+                                       countOther * sizeof(unichar)) == 0) {
+                                break;
+                            }
+                            pos++;
                         }
                     }
                 }
-              else
-                {
-                  if (YES == insensitive)
-                    {
-                      while (pos < end)
-                        {
-                          charsSelf[pos + countOther - 1]
-                            = uni_toupper(charsSelf[pos + countOther - 1]);
-                          if (memcmp(&charsSelf[pos], charsOther,
-                            countOther * sizeof(unichar)) == 0)
-                            {
-                              break;
-                            }
-                          pos++;
-                        }                        
-                    }
-                  else
-                    {
-                      while (pos < end)
-                        {
-                          if (memcmp(&charsSelf[pos], charsOther,
-                            countOther * sizeof(unichar)) == 0)
-                            {
-                              break;
-                            }
-                          pos++;
-                        }                        
-                    }
-                }
 
-              if (pos >= end)
-                {
-                  result = NSMakeRange(NSNotFound, 0);
+                if (pos >= end) {
+                    result = NSMakeRange(NSNotFound, 0);
+                } else {
+                    result = NSMakeRange(searchRange.location + pos, countOther);
                 }
-              else
-                {
-                  result = NSMakeRange(searchRange.location + pos, countOther);
-                }
-              GS_ENDITEMBUF2()
+                GS_ENDITEMBUF2()
             }
-          GS_ENDITEMBUF()
+            GS_ENDITEMBUF()
         }
-      return result;
+        return result;
     }
 
 #if GS_USE_ICU == 1
     {
-      UCollator *coll = GSICUCollatorOpen(mask, locale);
+        UCollator *coll = GSICUCollatorOpen(mask, locale);
 
-      if (NULL != coll)
-	{
-	  NSRange       result = NSMakeRange(NSNotFound, 0);
-	  UErrorCode    status = U_ZERO_ERROR; 
-	  NSUInteger    countSelf = searchRange.length;
-	  UStringSearch *search = NULL;
-          GS_BEGINITEMBUF(charsSelf, (countSelf * sizeof(unichar)), unichar)
-          GS_BEGINITEMBUF2(charsOther, (countOther * sizeof(unichar)), unichar)
+        if (NULL != coll) {
+            NSRange result = NSMakeRange(NSNotFound, 0);
+            UErrorCode status = U_ZERO_ERROR;
+            NSUInteger countSelf = searchRange.length;
+            UStringSearch *search = NULL;
+            GS_BEGINITEMBUF(charsSelf, (countSelf * sizeof(unichar)), unichar)
+            GS_BEGINITEMBUF2(charsOther, (countOther * sizeof(unichar)), unichar)
 
-	  // Copy to buffer
-      
-	  [self getCharacters: charsSelf range: searchRange];
-	  [aString getCharacters: charsOther range: NSMakeRange(0, countOther)];
-	  
-	  search = usearch_openFromCollator(charsOther, countOther,
-					    charsSelf, countSelf,
-					    coll, NULL, &status);
-	  if (search != NULL && U_SUCCESS(status))
-	    {
-	      int32_t matchLocation;
-	      int32_t matchLength;
+            // Copy to buffer
 
-	      if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-		{		
-		  matchLocation = usearch_last(search, &status);
-		}
-	      else
-		{
-		  matchLocation = usearch_first(search, &status);
-		}
-	      matchLength = usearch_getMatchedLength(search);
-	      
-	      if (matchLocation != USEARCH_DONE && matchLength != 0)
-		{
-		  if ((mask & NSAnchoredSearch) == NSAnchoredSearch)
-		    {
-		      if ((mask & NSBackwardsSearch) == NSBackwardsSearch)
-			{
-			  if (matchLocation + matchLength
-                            == NSMaxRange(searchRange))
-                            {
-                              result = NSMakeRange(searchRange.location
-                                + matchLocation, matchLength);
+            [self getCharacters:charsSelf range:searchRange];
+            [aString getCharacters:charsOther range:NSMakeRange(0, countOther)];
+
+            search = usearch_openFromCollator(charsOther, countOther,
+                                              charsSelf, countSelf,
+                                              coll, NULL, &status);
+            if (search != NULL && U_SUCCESS(status)) {
+                int32_t matchLocation;
+                int32_t matchLength;
+
+                if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+                    matchLocation = usearch_last(search, &status);
+                } else {
+                    matchLocation = usearch_first(search, &status);
+                }
+                matchLength = usearch_getMatchedLength(search);
+
+                if (matchLocation != USEARCH_DONE && matchLength != 0) {
+                    if ((mask & NSAnchoredSearch) == NSAnchoredSearch) {
+                        if ((mask & NSBackwardsSearch) == NSBackwardsSearch) {
+                            if (matchLocation + matchLength == NSMaxRange(searchRange)) {
+                                result = NSMakeRange(searchRange.location + matchLocation, matchLength);
                             }
-			}
-		      else
-			{
-			  if (matchLocation == 0)
-                            {
-                              result = NSMakeRange(searchRange.location
-                                + matchLocation, matchLength);
+                        } else {
+                            if (matchLocation == 0) {
+                                result = NSMakeRange(searchRange.location + matchLocation, matchLength);
                             }
-			}
-		    }
-		  else 
-		    {
-		      result = NSMakeRange(searchRange.location
-                        + matchLocation, matchLength);
-		    }
-		}
-	    }
-          GS_ENDITEMBUF2()
-          GS_ENDITEMBUF()
-	  usearch_close(search);
-	  ucol_close(coll);
-	  return result;
-	}
+                        }
+                    } else {
+                        result = NSMakeRange(searchRange.location + matchLocation, matchLength);
+                    }
+                }
+            }
+            GS_ENDITEMBUF2()
+            GS_ENDITEMBUF()
+            usearch_close(search);
+            ucol_close(coll);
+            return result;
+        }
     }
 #endif
 
-  return strRangeNsNs(self, aString, mask, searchRange);
+    return strRangeNsNs(self, aString, mask, searchRange);
 }
 
-- (NSUInteger) indexOfString: (NSString *)substring
+- (NSUInteger)indexOfString:(NSString *)substring
 {
-  NSRange range = {0, [self length]};
+    NSRange range = {0, [self length]};
 
-  range = [self rangeOfString: substring options: 0 range: range locale: nil];
-  return range.length ? range.location : NSNotFound;
+    range = [self rangeOfString:substring options:0 range:range locale:nil];
+    return range.length ? range.location : NSNotFound;
 }
 
-- (NSUInteger) indexOfString: (NSString*)substring
-                   fromIndex: (NSUInteger)index
+- (NSUInteger)indexOfString:(NSString *)substring
+                  fromIndex:(NSUInteger)index
 {
-  NSRange range = {index, [self length] - index};
+    NSRange range = {index, [self length] - index};
 
-  range = [self rangeOfString: substring options: 0 range: range locale: nil];
-  return range.length ? range.location : NSNotFound;
+    range = [self rangeOfString:substring options:0 range:range locale:nil];
+    return range.length ? range.location : NSNotFound;
 }
 
 // Determining Composed Character Sequences
@@ -2960,53 +2657,48 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * character sequence anIndex (note indices start from 0), returns the full
  * range of this sequence.
  */
-- (NSRange) rangeOfComposedCharacterSequenceAtIndex: (NSUInteger)anIndex
+- (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
 {
-  unsigned	start;
-  unsigned	end;
-  unsigned	length = [self length];
-  unichar	ch;
-  unichar	(*caiImp)(NSString*, SEL, NSUInteger);
+    unsigned start;
+    unsigned end;
+    unsigned length = [self length];
+    unichar ch;
+    unichar (*caiImp)(NSString *, SEL, NSUInteger);
 
-  if (anIndex >= length)
-    [NSException raise: NSRangeException format:@"Invalid location."];
-  caiImp = (unichar (*)(NSString*,SEL,NSUInteger))
-    [self methodForSelector: caiSel];
+    if (anIndex >= length)
+        [NSException raise:NSRangeException format:@"Invalid location."];
+    caiImp = (unichar(*)(NSString *, SEL, NSUInteger))
+        [self methodForSelector:caiSel];
 
-  for (start = anIndex; start > 0; start--)
-    {
-      ch = (*caiImp)(self, caiSel, start);
-      if (uni_isnonsp(ch) == NO)
-        break;
+    for (start = anIndex; start > 0; start--) {
+        ch = (*caiImp)(self, caiSel, start);
+        if (uni_isnonsp(ch) == NO)
+            break;
     }
-  for (end = start+1; end < length; end++)
-    {
-      ch = (*caiImp)(self, caiSel, end);
-      if (uni_isnonsp(ch) == NO)
-        break;
+    for (end = start + 1; end < length; end++) {
+        ch = (*caiImp)(self, caiSel, end);
+        if (uni_isnonsp(ch) == NO)
+            break;
     }
 
-  return NSMakeRange(start, end-start);
+    return NSMakeRange(start, end - start);
 }
 
-- (NSRange) rangeOfComposedCharacterSequencesForRange: (NSRange)range
+- (NSRange)rangeOfComposedCharacterSequencesForRange:(NSRange)range
 {
-  NSRange	startRange;
+    NSRange startRange;
 
-  startRange = [self rangeOfComposedCharacterSequenceAtIndex: range.location];
-  if (NSMaxRange(startRange) >= NSMaxRange(range))
-    {
-      return startRange;
-    }
-  else
-    {
-      NSUInteger	index;
-      NSRange		endRange;
+    startRange = [self rangeOfComposedCharacterSequenceAtIndex:range.location];
+    if (NSMaxRange(startRange) >= NSMaxRange(range)) {
+        return startRange;
+    } else {
+        NSUInteger index;
+        NSRange endRange;
 
-      index = NSMaxRange(range) - 1;
-      endRange = [self rangeOfComposedCharacterSequenceAtIndex: index];
+        index = NSMaxRange(range) - 1;
+        endRange = [self rangeOfComposedCharacterSequenceAtIndex:index];
 
-      return NSUnionRange(startRange, endRange);
+        return NSUnionRange(startRange, endRange);
     }
 }
 
@@ -3018,9 +2710,9 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * <code>NSOrderedSame</code>, depending on whether this instance occurs
  * before or after string in lexical order, or is equal to it.</p>
  */
-- (NSComparisonResult) compare: (NSString*)aString
+- (NSComparisonResult)compare:(NSString *)aString
 {
-  return [self compare: aString options: 0];
+    return [self compare:aString options:0];
 }
 
 /**
@@ -3030,11 +2722,12 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * return inaccurate results in cases where two different composed character
  * sequences may be used to express the same character.</p>
  */
-- (NSComparisonResult) compare: (NSString*)aString
-		       options: (NSUInteger)mask
+- (NSComparisonResult)compare:(NSString *)aString
+                      options:(NSUInteger)mask
 {
-  return [self compare: aString options: mask
-		 range: ((NSRange){0, [self length]})];
+    return [self compare:aString
+                 options:mask
+                   range:((NSRange){0, [self length]})];
 }
 
 /**
@@ -3047,83 +2740,77 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * string.</p>
  */
 // xxx Should implement full POSIX.2 collate
-- (NSComparisonResult) compare: (NSString*)aString
-		       options: (NSUInteger)mask
-			 range: (NSRange)aRange
+- (NSComparisonResult)compare:(NSString *)aString
+                      options:(NSUInteger)mask
+                        range:(NSRange)aRange
 {
-  return [self compare: aString
-	       options: mask
-		 range: aRange
-		locale: nil];
+    return [self compare:aString
+                 options:mask
+                   range:aRange
+                  locale:nil];
 }
 
 /**
  *  Returns whether this string starts with aString.
  */
-- (BOOL) hasPrefix: (NSString*)aString
+- (BOOL)hasPrefix:(NSString *)aString
 {
-  NSRange	range = NSMakeRange(0, [self length]);
-  NSUInteger    mask = NSLiteralSearch | NSAnchoredSearch;
+    NSRange range = NSMakeRange(0, [self length]);
+    NSUInteger mask = NSLiteralSearch | NSAnchoredSearch;
 
-  range = [self rangeOfString: aString
-                      options: mask
-                        range: range
-                       locale: nil];
-  return (range.length > 0) ? YES : NO;
+    range = [self rangeOfString:aString
+                        options:mask
+                          range:range
+                         locale:nil];
+    return (range.length > 0) ? YES : NO;
 }
 
 /**
  *  Returns whether this string ends with aString.
  */
-- (BOOL) hasSuffix: (NSString*)aString
+- (BOOL)hasSuffix:(NSString *)aString
 {
-  NSRange	range = NSMakeRange(0, [self length]);
-  NSUInteger    mask = NSLiteralSearch | NSAnchoredSearch | NSBackwardsSearch;
+    NSRange range = NSMakeRange(0, [self length]);
+    NSUInteger mask = NSLiteralSearch | NSAnchoredSearch | NSBackwardsSearch;
 
-  range = [self rangeOfString: aString
-                      options: mask
-                        range: range
-                       locale: nil];
-  return (range.length > 0) ? YES : NO;
+    range = [self rangeOfString:aString
+                        options:mask
+                          range:range
+                         locale:nil];
+    return (range.length > 0) ? YES : NO;
 }
 
 /**
  *  Returns whether the receiver and an anObject are equals as strings.
  *  If anObject isn't an NSString, returns NO.
  */
-- (BOOL) isEqual: (id)anObject
+- (BOOL)isEqual:(id)anObject
 {
-  if (anObject == self)
-    {
-      return YES;
+    if (anObject == self) {
+        return YES;
     }
-  if (anObject != nil && [anObject isKindOfClass: NSStringClass])
-    {
-      return [self isEqualToString: anObject];
+    if (anObject != nil && [anObject isKindOfClass:NSStringClass]) {
+        return [self isEqualToString:anObject];
     }
-  return NO;
+    return NO;
 }
 
 /**
  *  Returns whether this instance is equal as a string to aString.  See also
  *  -compare: and related methods.
  */
-- (BOOL) isEqualToString: (NSString*)aString
+- (BOOL)isEqualToString:(NSString *)aString
 {
-  if (aString == self)
-    {
-      return YES;
+    if (aString == self) {
+        return YES;
     }
-  if (nil == aString || [self hash] != [aString hash])
-    {
-      return NO;
+    if (nil == aString || [self hash] != [aString hash]) {
+        return NO;
     }
-  if (strCompNsNs(self, aString, 0, (NSRange){0, [self length]})
-    == NSOrderedSame)
-    {
-      return YES;
+    if (strCompNsNs(self, aString, 0, (NSRange){0, [self length]}) == NSOrderedSame) {
+        return YES;
     }
-  return NO;
+    return NO;
 }
 
 /**
@@ -3131,43 +2818,38 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * for other purposes in a bitfield in the concrete string subclasses, so we
  * must not use the full unsigned integer.
  */
-- (NSUInteger) hash
+- (NSUInteger)hash
 {
-  uint32_t	ret = 0;
-  int   	len = (int)[self length];
+    uint32_t ret = 0;
+    int len = (int)[self length];
 
-  if (len > 0)
-    {
-      static const int buf_size = 64;
-      unichar		buf[buf_size];
-      int idx = 0;
-      uint32_t s0 = 0;
-      uint32_t s1 = 0;
+    if (len > 0) {
+        static const int buf_size = 64;
+        unichar buf[buf_size];
+        int idx = 0;
+        uint32_t s0 = 0;
+        uint32_t s1 = 0;
 
-      while (idx < len)
-	{
-	  int l = MIN(len-idx, buf_size);
-	  [self getCharacters: buf range: NSMakeRange(idx,l)];
-	  GSPrivateIncrementalHash(&s0, &s1, buf, l * sizeof(unichar));
-	  idx += l;
-	}
+        while (idx < len) {
+            int l = MIN(len - idx, buf_size);
+            [self getCharacters:buf range:NSMakeRange(idx, l)];
+            GSPrivateIncrementalHash(&s0, &s1, buf, l * sizeof(unichar));
+            idx += l;
+        }
 
-      ret = GSPrivateFinishHash(s0, s1, len * sizeof(unichar));
+        ret = GSPrivateFinishHash(s0, s1, len * sizeof(unichar));
 
-      /*
-       * The hash caching in our concrete string classes uses zero to denote
-       * an empty cache value, so we MUST NOT return a hash of zero.
-       */
-      ret &= 0x0fffffff;
-      if (ret == 0)
-	{
-	  ret = 0x0fffffff;
-	}
-      return ret;
-    }
-  else
-    {
-      return 0x0ffffffe;	/* Hash for an empty string.	*/
+        /*
+         * The hash caching in our concrete string classes uses zero to denote
+         * an empty cache value, so we MUST NOT return a hash of zero.
+         */
+        ret &= 0x0fffffff;
+        if (ret == 0) {
+            ret = 0x0fffffff;
+        }
+        return ret;
+    } else {
+        return 0x0ffffffe; /* Hash for an empty string.	*/
     }
 }
 
@@ -3181,139 +2863,115 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  *  where two different composed character sequences may be used to express
  *  the same character.
  */
-- (NSString*) commonPrefixWithString: (NSString*)aString
-			     options: (NSUInteger)mask
+- (NSString *)commonPrefixWithString:(NSString *)aString
+                             options:(NSUInteger)mask
 {
-  if (mask & NSLiteralSearch)
-    {
-      int prefix_len = 0;
-      unsigned	length = [self length];
-      unsigned	aLength = [aString length];
-      unichar *u;
-      unichar a1[length+1];
-      unichar *s1 = a1;
-      unichar a2[aLength+1];
-      unichar *s2 = a2;
+    if (mask & NSLiteralSearch) {
+        int prefix_len = 0;
+        unsigned length = [self length];
+        unsigned aLength = [aString length];
+        unichar *u;
+        unichar a1[length + 1];
+        unichar *s1 = a1;
+        unichar a2[aLength + 1];
+        unichar *s2 = a2;
 
-      [self getCharacters: s1 range: ((NSRange){0, length})];
-      s1[length] = (unichar)0;
-      [aString getCharacters: s2 range: ((NSRange){0, aLength})];
-      s2[aLength] = (unichar)0;
-      u = s1;
+        [self getCharacters:s1 range:((NSRange){0, length})];
+        s1[length] = (unichar)0;
+        [aString getCharacters:s2 range:((NSRange){0, aLength})];
+        s2[aLength] = (unichar)0;
+        u = s1;
 
-      if (mask & NSCaseInsensitiveSearch)
-	{
-	  while (*s1 && *s2 && (uni_tolower(*s1) == uni_tolower(*s2)))
-	    {
-	      s1++;
-	      s2++;
-	      prefix_len++;
-	    }
-	}
-      else
-	{
-	  while (*s1 && *s2 && (*s1 == *s2))
-	    {
-	      s1++;
-	      s2++;
-	      prefix_len++;
-	    }
-	}
-      return [NSStringClass stringWithCharacters: u length: prefix_len];
-    }
-  else
-    {
-      unichar	(*scImp)(NSString*, SEL, NSUInteger);
-      unichar	(*ocImp)(NSString*, SEL, NSUInteger);
-      void	(*sgImp)(NSString*, SEL, unichar*, NSRange) = 0;
-      void	(*ogImp)(NSString*, SEL, unichar*, NSRange) = 0;
-      NSRange	(*srImp)(NSString*, SEL, NSUInteger) = 0;
-      NSRange	(*orImp)(NSString*, SEL, NSUInteger) = 0;
-      BOOL	gotRangeImps = NO;
-      BOOL	gotFetchImps = NO;
-      NSRange	sRange;
-      NSRange	oRange;
-      unsigned	sLength = [self length];
-      unsigned	oLength = [aString length];
-      unsigned	sIndex = 0;
-      unsigned	oIndex = 0;
+        if (mask & NSCaseInsensitiveSearch) {
+            while (*s1 && *s2 && (uni_tolower(*s1) == uni_tolower(*s2))) {
+                s1++;
+                s2++;
+                prefix_len++;
+            }
+        } else {
+            while (*s1 && *s2 && (*s1 == *s2)) {
+                s1++;
+                s2++;
+                prefix_len++;
+            }
+        }
+        return [NSStringClass stringWithCharacters:u length:prefix_len];
+    } else {
+        unichar (*scImp)(NSString *, SEL, NSUInteger);
+        unichar (*ocImp)(NSString *, SEL, NSUInteger);
+        void (*sgImp)(NSString *, SEL, unichar *, NSRange) = 0;
+        void (*ogImp)(NSString *, SEL, unichar *, NSRange) = 0;
+        NSRange (*srImp)(NSString *, SEL, NSUInteger) = 0;
+        NSRange (*orImp)(NSString *, SEL, NSUInteger) = 0;
+        BOOL gotRangeImps = NO;
+        BOOL gotFetchImps = NO;
+        NSRange sRange;
+        NSRange oRange;
+        unsigned sLength = [self length];
+        unsigned oLength = [aString length];
+        unsigned sIndex = 0;
+        unsigned oIndex = 0;
 
-      if (!sLength)
-	return IMMUTABLE(self);
-      if (!oLength)
-	return IMMUTABLE(aString);
+        if (!sLength)
+            return IMMUTABLE(self);
+        if (!oLength)
+            return IMMUTABLE(aString);
 
-      scImp = (unichar (*)(NSString*,SEL,NSUInteger))
-	[self methodForSelector: caiSel];
-      ocImp = (unichar (*)(NSString*,SEL,NSUInteger))
-	[aString methodForSelector: caiSel];
+        scImp = (unichar(*)(NSString *, SEL, NSUInteger))
+            [self methodForSelector:caiSel];
+        ocImp = (unichar(*)(NSString *, SEL, NSUInteger))
+            [aString methodForSelector:caiSel];
 
-      while ((sIndex < sLength) && (oIndex < oLength))
-	{
-	  unichar	sc = (*scImp)(self, caiSel, sIndex);
-	  unichar	oc = (*ocImp)(aString, caiSel, oIndex);
+        while ((sIndex < sLength) && (oIndex < oLength)) {
+            unichar sc = (*scImp)(self, caiSel, sIndex);
+            unichar oc = (*ocImp)(aString, caiSel, oIndex);
 
-	  if (sc == oc)
-	    {
-	      sIndex++;
-	      oIndex++;
-	    }
-	  else if ((mask & NSCaseInsensitiveSearch)
-	    && (uni_tolower(sc) == uni_tolower(oc)))
-	    {
-	      sIndex++;
-	      oIndex++;
-	    }
-	  else
-	    {
-	      if (gotRangeImps == NO)
-		{
-		  gotRangeImps = YES;
-		  srImp=(NSRange (*)())[self methodForSelector: ranSel];
-		  orImp=(NSRange (*)())[aString methodForSelector: ranSel];
-		}
-	      sRange = (*srImp)(self, ranSel, sIndex);
-	      oRange = (*orImp)(aString, ranSel, oIndex);
+            if (sc == oc) {
+                sIndex++;
+                oIndex++;
+            } else if ((mask & NSCaseInsensitiveSearch) && (uni_tolower(sc) == uni_tolower(oc))) {
+                sIndex++;
+                oIndex++;
+            } else {
+                if (gotRangeImps == NO) {
+                    gotRangeImps = YES;
+                    srImp = (NSRange(*)())[self methodForSelector:ranSel];
+                    orImp = (NSRange(*)())[aString methodForSelector:ranSel];
+                }
+                sRange = (*srImp)(self, ranSel, sIndex);
+                oRange = (*orImp)(aString, ranSel, oIndex);
 
-	      if ((sRange.length < 2) || (oRange.length < 2))
-		return [self substringWithRange: NSMakeRange(0, sIndex)];
-	      else
-		{
-		  GSEQ_MAKE(sBuf, sSeq, sRange.length);
-		  GSEQ_MAKE(oBuf, oSeq, oRange.length);
+                if ((sRange.length < 2) || (oRange.length < 2))
+                    return [self substringWithRange:NSMakeRange(0, sIndex)];
+                else {
+                    GSEQ_MAKE(sBuf, sSeq, sRange.length);
+                    GSEQ_MAKE(oBuf, oSeq, oRange.length);
 
-		  if (gotFetchImps == NO)
-		    {
-		      gotFetchImps = YES;
-		      sgImp=(void (*)())[self methodForSelector: gcrSel];
-		      ogImp=(void (*)())[aString methodForSelector: gcrSel];
-		    }
-		  (*sgImp)(self, gcrSel, sBuf, sRange);
-		  (*ogImp)(aString, gcrSel, oBuf, oRange);
+                    if (gotFetchImps == NO) {
+                        gotFetchImps = YES;
+                        sgImp = (void (*)())[self methodForSelector:gcrSel];
+                        ogImp = (void (*)())[aString methodForSelector:gcrSel];
+                    }
+                    (*sgImp)(self, gcrSel, sBuf, sRange);
+                    (*ogImp)(aString, gcrSel, oBuf, oRange);
 
-		  if (GSeq_compare(&sSeq, &oSeq) == NSOrderedSame)
-		    {
-		      sIndex += sRange.length;
-		      oIndex += oRange.length;
-		    }
-		  else if (mask & NSCaseInsensitiveSearch)
-		    {
-		      GSeq_lowercase(&sSeq);
-		      GSeq_lowercase(&oSeq);
-		      if (GSeq_compare(&sSeq, &oSeq) == NSOrderedSame)
-			{
-			  sIndex += sRange.length;
-			  oIndex += oRange.length;
-			}
-		      else
-			return [self substringWithRange: NSMakeRange(0,sIndex)];
-		    }
-		  else
-		    return [self substringWithRange: NSMakeRange(0,sIndex)];
-		}
-	    }
-	}
-      return [self substringWithRange: NSMakeRange(0, sIndex)];
+                    if (GSeq_compare(&sSeq, &oSeq) == NSOrderedSame) {
+                        sIndex += sRange.length;
+                        oIndex += oRange.length;
+                    } else if (mask & NSCaseInsensitiveSearch) {
+                        GSeq_lowercase(&sSeq);
+                        GSeq_lowercase(&oSeq);
+                        if (GSeq_compare(&sSeq, &oSeq) == NSOrderedSame) {
+                            sIndex += sRange.length;
+                            oIndex += oRange.length;
+                        } else
+                            return [self substringWithRange:NSMakeRange(0, sIndex)];
+                    } else
+                        return [self substringWithRange:NSMakeRange(0, sIndex)];
+                }
+            }
+        }
+        return [self substringWithRange:NSMakeRange(0, sIndex)];
     }
 }
 
@@ -3322,162 +2980,132 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * the information as a range.<br />
  * Calls -getLineStart:end:contentsEnd:forRange: to do the work.
  */
-- (NSRange) lineRangeForRange: (NSRange)aRange
+- (NSRange)lineRangeForRange:(NSRange)aRange
 {
-  NSUInteger startIndex;
-  NSUInteger lineEndIndex;
+    NSUInteger startIndex;
+    NSUInteger lineEndIndex;
 
-  [self getLineStart: &startIndex
-                 end: &lineEndIndex
-         contentsEnd: NULL
-            forRange: aRange];
-  return NSMakeRange(startIndex, lineEndIndex - startIndex);
+    [self getLineStart:&startIndex
+                   end:&lineEndIndex
+           contentsEnd:NULL
+              forRange:aRange];
+    return NSMakeRange(startIndex, lineEndIndex - startIndex);
 }
 
-- (void) _getStart: (NSUInteger*)startIndex
-	       end: (NSUInteger*)lineEndIndex
-       contentsEnd: (NSUInteger*)contentsEndIndex
-	  forRange: (NSRange)aRange
-	   lineSep: (BOOL)flag
+- (void)_getStart:(NSUInteger *)startIndex
+              end:(NSUInteger *)lineEndIndex
+      contentsEnd:(NSUInteger *)contentsEndIndex
+         forRange:(NSRange)aRange
+          lineSep:(BOOL)flag
 {
-  unichar	thischar;
-  unsigned	start, end, len, termlen;
-  unichar	(*caiImp)(NSString*, SEL, NSUInteger);
+    unichar thischar;
+    unsigned start, end, len, termlen;
+    unichar (*caiImp)(NSString *, SEL, NSUInteger);
 
-  len = [self length];
-  GS_RANGE_CHECK(aRange, len);
+    len = [self length];
+    GS_RANGE_CHECK(aRange, len);
 
-  caiImp = (unichar (*)())[self methodForSelector: caiSel];
-  /* Place aRange.location at the beginning of a CR-LF sequence */
-  if (aRange.location > 0 && aRange.location < len
-    && (*caiImp)(self, caiSel, aRange.location - 1) == (unichar)'\r'
-    && (*caiImp)(self, caiSel, aRange.location) == (unichar)'\n')
-    {
-      aRange.location--;
+    caiImp = (unichar(*)())[self methodForSelector:caiSel];
+    /* Place aRange.location at the beginning of a CR-LF sequence */
+    if (aRange.location > 0 && aRange.location < len && (*caiImp)(self, caiSel, aRange.location - 1) == (unichar)'\r' && (*caiImp)(self, caiSel, aRange.location) == (unichar)'\n') {
+        aRange.location--;
     }
-  start = aRange.location;
+    start = aRange.location;
 
-  if (startIndex)
-    {
-      if (start == 0)
-	{
-	  *startIndex = 0;
-	}
-      else
-	{
-	  start--;
-	  while (start > 0)
-	    {
-	      BOOL	done = NO;
+    if (startIndex) {
+        if (start == 0) {
+            *startIndex = 0;
+        } else {
+            start--;
+            while (start > 0) {
+                BOOL done = NO;
 
-	      thischar = (*caiImp)(self, caiSel, start);
-	      switch (thischar)
-		{
-		  case (unichar)0x000A:
-		  case (unichar)0x000D:
-		  case (unichar)0x2029:
-		    done = YES;
-		    break;
-		  case (unichar)0x2028:
-		    if (flag)
-		      {
-			done = YES;
-			break;
-		      }
-		  default:
-		    start--;
-		    break;
-		}
-	      if (done)
-		break;
-	    }
-	  if (start == 0)
-	    {
-	      thischar = (*caiImp)(self, caiSel, start);
-	      switch (thischar)
-		{
-		  case (unichar)0x000A:
-		  case (unichar)0x000D:
-		  case (unichar)0x2029:
-		    start++;
-		    break;
-		  case (unichar)0x2028:
-		    if (flag)
-		      {
-			start++;
-			break;
-		      }
-		  default:
-		    break;
-		}
-	    }
-	  else
-	    {
-	      start++;
-	    }
-	  *startIndex = start;
-	}
-    }
-
-  if (lineEndIndex || contentsEndIndex)
-    {
-      BOOL found = NO;
-      end = aRange.location;
-      if (aRange.length)
-        {
-          end += (aRange.length - 1);
+                thischar = (*caiImp)(self, caiSel, start);
+                switch (thischar) {
+                    case (unichar)0x000A:
+                    case (unichar)0x000D:
+                    case (unichar)0x2029:
+                        done = YES;
+                        break;
+                    case (unichar)0x2028:
+                        if (flag) {
+                            done = YES;
+                            break;
+                        }
+                    default:
+                        start--;
+                        break;
+                }
+                if (done)
+                    break;
+            }
+            if (start == 0) {
+                thischar = (*caiImp)(self, caiSel, start);
+                switch (thischar) {
+                    case (unichar)0x000A:
+                    case (unichar)0x000D:
+                    case (unichar)0x2029:
+                        start++;
+                        break;
+                    case (unichar)0x2028:
+                        if (flag) {
+                            start++;
+                            break;
+                        }
+                    default:
+                        break;
+                }
+            } else {
+                start++;
+            }
+            *startIndex = start;
         }
-      while (end < len)
-	{
-	   thischar = (*caiImp)(self, caiSel, end);
-	   switch (thischar)
-	     {
-	       case (unichar)0x000A:
-	       case (unichar)0x000D:
-	       case (unichar)0x2029:
-		 found = YES;
-		 break;
-	       case (unichar)0x2028:
-		 if (flag)
-		   {
-		     found = YES;
-		     break;
-		   }
-	       default:
-		 break;
-	     }
-	   end++;
-	   if (found)
-	     break;
-	}
-      termlen = 1;
-      if (lineEndIndex)
-	{
-	  if (end < len
-	    && ((*caiImp)(self, caiSel, end-1) == (unichar)0x000D)
-	    && ((*caiImp)(self, caiSel, end) == (unichar)0x000A))
-	    {
-	      *lineEndIndex = ++end;
-	      termlen = 2;
-	    }
-	  else
-	    {
-	      *lineEndIndex = end;
-	    }
-	}
-      if (contentsEndIndex)
-	{
-	  if (found)
-	    {
-	      *contentsEndIndex = end-termlen;
-	    }
-	  else
-	    {
-	      /* xxx OPENSTEP documentation does not say what to do if last
-		 line is not terminated. Assume this */
-	      *contentsEndIndex = end;
-	    }
-	}
+    }
+
+    if (lineEndIndex || contentsEndIndex) {
+        BOOL found = NO;
+        end = aRange.location;
+        if (aRange.length) {
+            end += (aRange.length - 1);
+        }
+        while (end < len) {
+            thischar = (*caiImp)(self, caiSel, end);
+            switch (thischar) {
+                case (unichar)0x000A:
+                case (unichar)0x000D:
+                case (unichar)0x2029:
+                    found = YES;
+                    break;
+                case (unichar)0x2028:
+                    if (flag) {
+                        found = YES;
+                        break;
+                    }
+                default:
+                    break;
+            }
+            end++;
+            if (found)
+                break;
+        }
+        termlen = 1;
+        if (lineEndIndex) {
+            if (end < len && ((*caiImp)(self, caiSel, end - 1) == (unichar)0x000D) && ((*caiImp)(self, caiSel, end) == (unichar)0x000A)) {
+                *lineEndIndex = ++end;
+                termlen = 2;
+            } else {
+                *lineEndIndex = end;
+            }
+        }
+        if (contentsEndIndex) {
+            if (found) {
+                *contentsEndIndex = end - termlen;
+            } else {
+                /* xxx OPENSTEP documentation does not say what to do if last
+                   line is not terminated. Assume this */
+                *contentsEndIndex = end;
+            }
+        }
     }
 }
 
@@ -3503,28 +3131,28 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * arguments to be null pointers (in which case no value is returned in that
  * argument).
  */
-- (void) getLineStart: (NSUInteger *)startIndex
-                  end: (NSUInteger *)lineEndIndex
-          contentsEnd: (NSUInteger *)contentsEndIndex
-	     forRange: (NSRange)aRange
+- (void)getLineStart:(NSUInteger *)startIndex
+                 end:(NSUInteger *)lineEndIndex
+         contentsEnd:(NSUInteger *)contentsEndIndex
+            forRange:(NSRange)aRange
 {
-  [self _getStart: startIndex
-	      end: lineEndIndex
-      contentsEnd: contentsEndIndex
-	 forRange: aRange
-	  lineSep: YES];
+    [self _getStart:startIndex
+                end:lineEndIndex
+        contentsEnd:contentsEndIndex
+           forRange:aRange
+            lineSep:YES];
 }
 
-- (void) getParagraphStart: (NSUInteger *)startIndex 
-                       end: (NSUInteger *)parEndIndex
-               contentsEnd: (NSUInteger *)contentsEndIndex
-                  forRange: (NSRange)range
+- (void)getParagraphStart:(NSUInteger *)startIndex
+                      end:(NSUInteger *)parEndIndex
+              contentsEnd:(NSUInteger *)contentsEndIndex
+                 forRange:(NSRange)range
 {
-  [self _getStart: startIndex
-	      end: parEndIndex
-      contentsEnd: contentsEndIndex
-         forRange: range
-	  lineSep: NO];
+    [self _getStart:startIndex
+                end:parEndIndex
+        contentsEnd:contentsEndIndex
+           forRange:range
+            lineSep:NO];
 }
 
 // Changing Case
@@ -3537,133 +3165,121 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  */
 // xxx There is more than this in word capitalization in Unicode,
 // but this will work in most cases
-- (NSString*) capitalizedString
+- (NSString *)capitalizedString
 {
-  unichar	*s;
-  unsigned	count = 0;
-  BOOL		found = YES;
-  unsigned	len = [self length];
+    unichar *s;
+    unsigned count = 0;
+    BOOL found = YES;
+    unsigned len = [self length];
 
-  if (len == 0)
-    return IMMUTABLE(self);
+    if (len == 0)
+        return IMMUTABLE(self);
 
-  s = NSZoneMalloc([self zone], sizeof(unichar)*len);
-  [self getCharacters: s range: ((NSRange){0, len})];
-  while (count < len)
-    {
-      if (GS_IS_WHITESPACE(s[count]))
-	{
-	  count++;
-	  found = YES;
-	  while (count < len
-	    && GS_IS_WHITESPACE(s[count]))
-	    {
-	      count++;
-	    }
-	}
-      if (count < len)
-	{
-	  if (found)
-	    {
-	      s[count] = uni_toupper(s[count]);
-	      count++;
-	    }
-	  else
-	    {
-	      while (count < len
-		&& !GS_IS_WHITESPACE(s[count]))
-		{
-		  s[count] = uni_tolower(s[count]);
-		  count++;
-		}
-	    }
-	}
-      found = NO;
+    s = NSZoneMalloc([self zone], sizeof(unichar) * len);
+    [self getCharacters:s range:((NSRange){0, len})];
+    while (count < len) {
+        if (GS_IS_WHITESPACE(s[count])) {
+            count++;
+            found = YES;
+            while (count < len && GS_IS_WHITESPACE(s[count])) {
+                count++;
+            }
+        }
+        if (count < len) {
+            if (found) {
+                s[count] = uni_toupper(s[count]);
+                count++;
+            } else {
+                while (count < len && !GS_IS_WHITESPACE(s[count])) {
+                    s[count] = uni_tolower(s[count]);
+                    count++;
+                }
+            }
+        }
+        found = NO;
     }
-  return AUTORELEASE([[NSString allocWithZone: NSDefaultMallocZone()]
-    initWithCharactersNoCopy: s length: len freeWhenDone: YES]);
+    return AUTORELEASE([[NSString allocWithZone:NSDefaultMallocZone()]
+        initWithCharactersNoCopy:s
+                          length:len
+                    freeWhenDone:YES]);
 }
 
 /**
  * Returns a copy of the receiver with all characters converted
  * to lowercase.
  */
-- (NSString*) lowercaseString
+- (NSString *)lowercaseString
 {
-  static NSCharacterSet	*uc = nil;
-  unichar	*s;
-  unsigned	count;
-  NSRange	start;
-  unsigned	len = [self length];
+    static NSCharacterSet *uc = nil;
+    unichar *s;
+    unsigned count;
+    NSRange start;
+    unsigned len = [self length];
 
-  if (len == 0)
-    {
-      return IMMUTABLE(self);
+    if (len == 0) {
+        return IMMUTABLE(self);
     }
-  if (uc == nil)
-    {
-      uc = RETAIN([NSCharacterSet uppercaseLetterCharacterSet]);
+    if (uc == nil) {
+        uc = RETAIN([NSCharacterSet uppercaseLetterCharacterSet]);
     }
-  start = [self rangeOfCharacterFromSet: uc
-				options: NSLiteralSearch
-				  range: ((NSRange){0, len})];
-  if (start.length == 0)
-    {
-      return IMMUTABLE(self);
+    start = [self rangeOfCharacterFromSet:uc
+                                  options:NSLiteralSearch
+                                    range:((NSRange){0, len})];
+    if (start.length == 0) {
+        return IMMUTABLE(self);
     }
-  s = NSZoneMalloc([self zone], sizeof(unichar)*len);
-  [self getCharacters: s range: ((NSRange){0, len})];
-  for (count = start.location; count < len; count++)
-    {
-      s[count] = uni_tolower(s[count]);
+    s = NSZoneMalloc([self zone], sizeof(unichar) * len);
+    [self getCharacters:s range:((NSRange){0, len})];
+    for (count = start.location; count < len; count++) {
+        s[count] = uni_tolower(s[count]);
     }
-  return AUTORELEASE([[NSStringClass allocWithZone: NSDefaultMallocZone()]
-    initWithCharactersNoCopy: s length: len freeWhenDone: YES]);
+    return AUTORELEASE([[NSStringClass allocWithZone:NSDefaultMallocZone()]
+        initWithCharactersNoCopy:s
+                          length:len
+                    freeWhenDone:YES]);
 }
 
 /**
  * Returns a copy of the receiver with all characters converted
  * to uppercase.
  */
-- (NSString*) uppercaseString
+- (NSString *)uppercaseString
 {
-  static NSCharacterSet	*lc = nil;
-  unichar	*s;
-  unsigned	count;
-  NSRange	start;
-  unsigned	len = [self length];
+    static NSCharacterSet *lc = nil;
+    unichar *s;
+    unsigned count;
+    NSRange start;
+    unsigned len = [self length];
 
-  if (len == 0)
-    {
-      return IMMUTABLE(self);
+    if (len == 0) {
+        return IMMUTABLE(self);
     }
-  if (lc == nil)
-    {
-      lc = RETAIN([NSCharacterSet lowercaseLetterCharacterSet]);
+    if (lc == nil) {
+        lc = RETAIN([NSCharacterSet lowercaseLetterCharacterSet]);
     }
-  start = [self rangeOfCharacterFromSet: lc
-				options: NSLiteralSearch
-				  range: ((NSRange){0, len})];
-  if (start.length == 0)
-    {
-      return IMMUTABLE(self);
+    start = [self rangeOfCharacterFromSet:lc
+                                  options:NSLiteralSearch
+                                    range:((NSRange){0, len})];
+    if (start.length == 0) {
+        return IMMUTABLE(self);
     }
-  s = NSZoneMalloc([self zone], sizeof(unichar)*len);
-  [self getCharacters: s range: ((NSRange){0, len})];
-  for (count = start.location; count < len; count++)
-    {
-      s[count] = uni_toupper(s[count]);
+    s = NSZoneMalloc([self zone], sizeof(unichar) * len);
+    [self getCharacters:s range:((NSRange){0, len})];
+    for (count = start.location; count < len; count++) {
+        s[count] = uni_toupper(s[count]);
     }
-  return AUTORELEASE([[NSStringClass allocWithZone: NSDefaultMallocZone()]
-    initWithCharactersNoCopy: s length: len freeWhenDone: YES]);
+    return AUTORELEASE([[NSStringClass allocWithZone:NSDefaultMallocZone()]
+        initWithCharactersNoCopy:s
+                          length:len
+                    freeWhenDone:YES]);
 }
 
 // Storing the String
 
 /** Returns <code>self</code>. */
-- (NSString*) description
+- (NSString *)description
 {
-  return self;
+    return self;
 }
 
 
@@ -3674,20 +3290,19 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * The memory pointed to is not owned by the caller, so the
  * caller must copy its contents to keep it.
  */
-- (const unichar*) unicharString
+- (const unichar *)unicharString
 {
-  NSMutableData	*data;
-  unichar	*uniStr;
+    NSMutableData *data;
+    unichar *uniStr;
 
-  GSOnceMLog(@"deprecated ... use cStringUsingEncoding:");
+    GSOnceMLog(@"deprecated ... use cStringUsingEncoding:");
 
-  data = [NSMutableData dataWithLength: ([self length] + 1) * sizeof(unichar)];
-  uniStr = (unichar*)[data mutableBytes];
-  if (uniStr != 0)
-    {
-      [self getCharacters: uniStr];
+    data = [NSMutableData dataWithLength:([self length] + 1) * sizeof(unichar)];
+    uniStr = (unichar *)[data mutableBytes];
+    if (uniStr != 0) {
+        [self getCharacters:uniStr];
     }
-  return uniStr;
+    return uniStr;
 }
 
 /**
@@ -3697,22 +3312,21 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * <code>NSCharacterConversionException</code> if loss of information would
  * occur during conversion.  (See -canBeConvertedToEncoding: .)
  */
-- (const char*) cString
+- (const char *)cString
 {
-  NSData	*d;
-  NSMutableData	*m;
+    NSData *d;
+    NSMutableData *m;
 
-  d = [self dataUsingEncoding: _DefaultStringEncoding
-	 allowLossyConversion: NO];
-  if (d == nil)
-    {
-      [NSException raise: NSCharacterConversionException
-		  format: @"unable to convert to cString"];
+    d = [self dataUsingEncoding:_DefaultStringEncoding
+           allowLossyConversion:NO];
+    if (d == nil) {
+        [NSException raise:NSCharacterConversionException
+                    format:@"unable to convert to cString"];
     }
-  m = [d mutableCopy];
-  [m appendBytes: "" length: 1];
-  IF_NO_ARC([m autorelease];)
-  return (const char*)[m bytes];
+    m = [d mutableCopy];
+    [m appendBytes:"" length:1];
+    IF_NO_ARC([m autorelease];)
+    return (const char *)[m bytes];
 }
 
 /**
@@ -3725,35 +3339,31 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * Raises an <code>NSCharacterConversionException</code> if loss of
  * information would occur during conversion.
  */
-- (const char*) cStringUsingEncoding: (NSStringEncoding)encoding
+- (const char *)cStringUsingEncoding:(NSStringEncoding)encoding
 {
-  NSMutableData	*m;
+    NSMutableData *m;
 
-  if (NSUnicodeStringEncoding == encoding)
-    {
-      unichar	*u;
-      unsigned	l;
+    if (NSUnicodeStringEncoding == encoding) {
+        unichar *u;
+        unsigned l;
 
-      l = [self length];
-      m = [NSMutableData dataWithLength: (l + 1) * sizeof(unichar)];
-      u = (unichar*)[m mutableBytes];
-      [self getCharacters: u];
-      u[l] = 0;
+        l = [self length];
+        m = [NSMutableData dataWithLength:(l + 1) * sizeof(unichar)];
+        u = (unichar *)[m mutableBytes];
+        [self getCharacters:u];
+        u[l] = 0;
+    } else {
+        NSData *d;
+
+        d = [self dataUsingEncoding:encoding allowLossyConversion:NO];
+        if (d == nil) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"unable to convert to cString"];
+        }
+        m = [[d mutableCopy] autorelease];
+        [m appendBytes:"" length:1];
     }
-  else
-    {
-      NSData	*d;
-
-      d = [self dataUsingEncoding: encoding allowLossyConversion: NO];
-      if (d == nil)
-	{
-	  [NSException raise: NSCharacterConversionException
-		      format: @"unable to convert to cString"];
-	}
-      m = [[d mutableCopy] autorelease];
-      [m appendBytes: "" length: 1];
-    }
-  return (const char*)[m bytes];
+    return (const char *)[m bytes];
 }
 
 /**
@@ -3761,12 +3371,12 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * specified encoding (without adding a nul character terminator).<br />
  * Returns 0 if the conversion is not possible.
  */
-- (NSUInteger) lengthOfBytesUsingEncoding: (NSStringEncoding)encoding
+- (NSUInteger)lengthOfBytesUsingEncoding:(NSStringEncoding)encoding
 {
-  NSData	*d;
+    NSData *d;
 
-  d = [self dataUsingEncoding: encoding allowLossyConversion: NO];
-  return [d length];
+    d = [self dataUsingEncoding:encoding allowLossyConversion:NO];
+    return [d length];
 }
 
 /**
@@ -3774,15 +3384,15 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * specified encoding (without adding a nul character terminator).  This may
  * be larger than the actual number of bytes needed.
  */
-- (NSUInteger) maximumLengthOfBytesUsingEncoding: (NSStringEncoding)encoding
+- (NSUInteger)maximumLengthOfBytesUsingEncoding:(NSStringEncoding)encoding
 {
-  if (encoding == NSUnicodeStringEncoding)
-    return [self length] * 2;
-  if (encoding == NSUTF8StringEncoding)
-    return [self length] * 6;
-  if (encoding == NSUTF7StringEncoding)
-    return [self length] * 8;
-  return [self length];				// Assume single byte/char
+    if (encoding == NSUnicodeStringEncoding)
+        return [self length] * 2;
+    if (encoding == NSUTF8StringEncoding)
+        return [self length] * 6;
+    if (encoding == NSUTF7StringEncoding)
+        return [self length] * 8;
+    return [self length]; // Assume single byte/char
 }
 
 /**
@@ -3790,17 +3400,17 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * result in information loss.  The memory pointed to is not owned by the
  * caller, so the caller must copy its contents to keep it.
  */
-- (const char*) lossyCString
+- (const char *)lossyCString
 {
-  NSData	*d;
-  NSMutableData	*m;
+    NSData *d;
+    NSMutableData *m;
 
-  d = [self dataUsingEncoding: _DefaultStringEncoding
-         allowLossyConversion: YES];
-  m = [d mutableCopy];
-  [m appendBytes: "" length: 1];
-  IF_NO_ARC([m autorelease];)
-  return (const char*)[m bytes];
+    d = [self dataUsingEncoding:_DefaultStringEncoding
+           allowLossyConversion:YES];
+    m = [d mutableCopy];
+    [m appendBytes:"" length:1];
+    IF_NO_ARC([m autorelease];)
+    return (const char *)[m bytes];
 }
 
 /**
@@ -3808,17 +3418,17 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * memory comes from an autoreleased object, so it will eventually go out of
  * scope.
  */
-- (const char *) UTF8String
+- (const char *)UTF8String
 {
-  NSData	*d;
-  NSMutableData	*m;
+    NSData *d;
+    NSMutableData *m;
 
-  d = [self dataUsingEncoding: NSUTF8StringEncoding
-         allowLossyConversion: NO];
-  m = [d mutableCopy];
-  [m appendBytes: "" length: 1];
-  IF_NO_ARC([m autorelease];)
-  return (const char*)[m bytes];
+    d = [self dataUsingEncoding:NSUTF8StringEncoding
+           allowLossyConversion:NO];
+    m = [d mutableCopy];
+    [m appendBytes:"" length:1];
+    IF_NO_ARC([m autorelease];)
+    return (const char *)[m bytes];
 }
 
 /**
@@ -3827,36 +3437,38 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  *  information loss, the results are unpredictable.  Check
  *  -canBeConvertedToEncoding: first.
  */
-- (NSUInteger) cStringLength
+- (NSUInteger)cStringLength
 {
-  NSData	*d;
+    NSData *d;
 
-  d = [self dataUsingEncoding: _DefaultStringEncoding
-         allowLossyConversion: NO];
-  return [d length];
+    d = [self dataUsingEncoding:_DefaultStringEncoding
+           allowLossyConversion:NO];
+    return [d length];
 }
 
 /**
  * Deprecated ... do not use.<br />.
  * Use -getCString:maxLength:encoding: instead.
  */
-- (void) getCString: (char*)buffer
+- (void)getCString:(char *)buffer
 {
-  [self getCString: buffer maxLength: NSMaximumStringLength
-	     range: ((NSRange){0, [self length]})
-    remainingRange: NULL];
+    [self getCString:buffer
+           maxLength:NSMaximumStringLength
+               range:((NSRange){0, [self length]})
+               remainingRange:NULL];
 }
 
 /**
  * Deprecated ... do not use.<br />.
  * Use -getCString:maxLength:encoding: instead.
  */
-- (void) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
+- (void)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
 {
-  [self getCString: buffer maxLength: maxLength
-	     range: ((NSRange){0, [self length]})
-    remainingRange: NULL];
+    [self getCString:buffer
+           maxLength:maxLength
+               range:((NSRange){0, [self length]})
+               remainingRange:NULL];
 }
 
 /**
@@ -3875,47 +3487,42 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * eg. If the receiver is @"hello" then the provided buffer must be
  * at least six bytes long and the value of maxLength must be at least
  * six if NSASCIIStringEncoding is requested, but they must be at least
- * twelve if NSUnicodeStringEncoding is requested. 
+ * twelve if NSUnicodeStringEncoding is requested.
  */
-- (BOOL) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	   encoding: (NSStringEncoding)encoding
+- (BOOL)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+          encoding:(NSStringEncoding)encoding
 {
-  if (0 == maxLength || 0 == buffer) return NO;
-  if (encoding == NSUnicodeStringEncoding)
-    {
-      unsigned	length = [self length];
+    if (0 == maxLength || 0 == buffer)
+        return NO;
+    if (encoding == NSUnicodeStringEncoding) {
+        unsigned length = [self length];
 
-      if (maxLength > length * sizeof(unichar))
-	{
-	  unichar	*ptr = (unichar*)(void*)buffer;
+        if (maxLength > length * sizeof(unichar)) {
+            unichar *ptr = (unichar *)(void *)buffer;
 
-	  maxLength = (maxLength - 1) / sizeof(unichar);
-	  [self getCharacters: ptr
-			range: NSMakeRange(0, maxLength)];
-	  ptr[maxLength] = 0;
-	  return YES;
-	}
-      return NO;
-    }
-  else
-    {
-      NSData	*d = [self dataUsingEncoding: encoding];
-      unsigned	length = [d length];
-      BOOL	result = (length < maxLength) ? YES : NO;
+            maxLength = (maxLength - 1) / sizeof(unichar);
+            [self getCharacters:ptr
+                          range:NSMakeRange(0, maxLength)];
+            ptr[maxLength] = 0;
+            return YES;
+        }
+        return NO;
+    } else {
+        NSData *d = [self dataUsingEncoding:encoding];
+        unsigned length = [d length];
+        BOOL result = (length < maxLength) ? YES : NO;
 
-      if (d == nil)
-        {
-	  [NSException raise: NSCharacterConversionException
-		      format: @"Can't convert to C string."];
-	}
-      if (length >= maxLength)
-        {
-          length = maxLength-1;
-	}
-      memcpy(buffer, [d bytes], length);
-      buffer[length] = '\0';
-      return result;
+        if (d == nil) {
+            [NSException raise:NSCharacterConversionException
+                        format:@"Can't convert to C string."];
+        }
+        if (length >= maxLength) {
+            length = maxLength - 1;
+        }
+        memcpy(buffer, [d bytes], length);
+        buffer[length] = '\0';
+        return result;
     }
 }
 
@@ -3923,69 +3530,64 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * Deprecated ... do not use.<br />.
  * Use -getCString:maxLength:encoding: instead.
  */
-- (void) getCString: (char*)buffer
-	  maxLength: (NSUInteger)maxLength
-	      range: (NSRange)aRange
-     remainingRange: (NSRange*)leftoverRange
+- (void)getCString:(char *)buffer
+         maxLength:(NSUInteger)maxLength
+             range:(NSRange)aRange
+    remainingRange:(NSRange *)leftoverRange
 {
-  NSString	*s;
+    NSString *s;
 
-  /* As this is a deprecated method, keep things simple (but inefficient)
-   * by copying the receiver to a new instance of a base library built-in
-   * class, and use the implementation provided by that class.
-   * We need an autorelease to avoid a memory leak if there is an exception.
-   */
-  s = AUTORELEASE([(NSString*)defaultPlaceholderString initWithString: self]);
-  [s getCString: buffer
-      maxLength: maxLength
-	  range: aRange
- remainingRange: leftoverRange];
+    /* As this is a deprecated method, keep things simple (but inefficient)
+     * by copying the receiver to a new instance of a base library built-in
+     * class, and use the implementation provided by that class.
+     * We need an autorelease to avoid a memory leak if there is an exception.
+     */
+    s = AUTORELEASE([(NSString *)defaultPlaceholderString initWithString:self]);
+    [s getCString:buffer
+             maxLength:maxLength
+                 range:aRange
+        remainingRange:leftoverRange];
 }
 
 
 // Getting Numeric Values
 
-- (BOOL) boolValue
+- (BOOL)boolValue
 {
-  unsigned	length = [self length];
+    unsigned length = [self length];
 
-  if (length > 0)
-    {
-      unsigned	index;
-      SEL	sel = @selector(characterAtIndex:);
-      unichar	(*imp)() = (unichar (*)())[self methodForSelector: sel];
+    if (length > 0) {
+        unsigned index;
+        SEL sel = @selector(characterAtIndex:);
+        unichar (*imp)() = (unichar(*)())[self methodForSelector:sel];
 
-      for (index = 0; index < length; index++)
-	{
-	  unichar	c = (*imp)(self, sel, index);
+        for (index = 0; index < length; index++) {
+            unichar c = (*imp)(self, sel, index);
 
-	  if (c > 'y')
-	    {
-	      break;
-	    }
-          if (strchr("123456789yYtT", c) != 0)
-	    {
-	      return YES;
-	    }
-	  if (!isspace(c) && c != '0' && c != '-' && c != '+')
-	    {
-	      break;
-	    }
-	}
+            if (c > 'y') {
+                break;
+            }
+            if (strchr("123456789yYtT", c) != 0) {
+                return YES;
+            }
+            if (!isspace(c) && c != '0' && c != '-' && c != '+') {
+                break;
+            }
+        }
     }
-  return NO;
+    return NO;
 }
 
 /**
  * Returns the string's content as a decimal.<br />
  * Undocumented feature of Aplle Foundation.
  */
-- (NSDecimal) decimalValue
+- (NSDecimal)decimalValue
 {
-  NSDecimal     result;
+    NSDecimal result;
 
-  NSDecimalFromString(&result, self, nil);
-  return result;
+    NSDecimalFromString(&result, self, nil);
+    return result;
 }
 
 /**
@@ -3993,11 +3595,11 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * Conversion is not localised (i.e. uses '.' as the decimal separator).<br />
  * Returns 0.0 on underflow or if the string does not contain a number.
  */
-- (double) doubleValue
+- (double)doubleValue
 {
-  double	d = 0.0;
-  [NSScanner _scanDouble: &d from: self];
-  return d;
+    double d = 0.0;
+    [NSScanner _scanDouble:&d from:self];
+    return d;
 }
 
 /**
@@ -4005,11 +3607,11 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * Conversion is not localised (i.e. uses '.' as the decimal separator).<br />
  * Returns 0.0 on underflow or if the string does not contain a number.
  */
-- (float) floatValue
+- (float)floatValue
 {
-  double	d = 0.0;
-  [NSScanner _scanDouble: &d from: self];
-  return (float)d;
+    double d = 0.0;
+    [NSScanner _scanDouble:&d from:self];
+    return (float)d;
 }
 
 /**
@@ -4017,67 +3619,55 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  * Current implementation uses a C runtime library function, which does not
  * detect conversion errors -- use with care!</p>
  */
-- (int) intValue
+- (int)intValue
 {
-  const char *ptr = [self UTF8String];
+    const char *ptr = [self UTF8String];
 
-  while (isspace(*ptr))
-    {
-      ptr++;
+    while (isspace(*ptr)) {
+        ptr++;
     }
-  if ('-' == *ptr)
-    {
-      return (int)atoi(ptr);
-    }
-  else
-    {
-      uint64_t v;
+    if ('-' == *ptr) {
+        return (int)atoi(ptr);
+    } else {
+        uint64_t v;
 
-      v = strtoul(ptr, 0, 10);
-      return (int)v;
-    } 
+        v = strtoul(ptr, 0, 10);
+        return (int)v;
+    }
 }
 
-- (NSInteger) integerValue
+- (NSInteger)integerValue
 {
-  const char *ptr = [self UTF8String];
+    const char *ptr = [self UTF8String];
 
-  while (isspace(*ptr))
-    {
-      ptr++;
+    while (isspace(*ptr)) {
+        ptr++;
     }
-  if ('-' == *ptr)
-    {
-      return (NSInteger)atoll(ptr);
-    }
-  else
-    {
-      uint64_t  v;
+    if ('-' == *ptr) {
+        return (NSInteger)atoll(ptr);
+    } else {
+        uint64_t v;
 
-      v = (uint64_t)strtoull(ptr, 0, 10);
-      return (NSInteger)v;
-    } 
+        v = (uint64_t)strtoull(ptr, 0, 10);
+        return (NSInteger)v;
+    }
 }
 
-- (long long) longLongValue
+- (long long)longLongValue
 {
-  const char *ptr = [self UTF8String];
+    const char *ptr = [self UTF8String];
 
-  while (isspace(*ptr))
-    {
-      ptr++;
+    while (isspace(*ptr)) {
+        ptr++;
     }
-  if ('-' == *ptr)
-    {
-      return atoll(ptr);
-    }
-  else
-    {
-      unsigned long long l;
+    if ('-' == *ptr) {
+        return atoll(ptr);
+    } else {
+        unsigned long long l;
 
-      l = strtoull(ptr, 0, 10);
-      return (long long)l;
-    } 
+        l = strtoull(ptr, 0, 10);
+        return (long long)l;
+    }
 }
 
 // Working With Encodings
@@ -4099,858 +3689,742 @@ GSICUCollatorOpen(NSStringCompareOptions mask, NSLocale *locale)
  *   <code>NSISOLatin1StringEncoding</code> is assumed.
  * </p>
  */
-+ (NSStringEncoding) defaultCStringEncoding
++ (NSStringEncoding)defaultCStringEncoding
 {
-  return _DefaultStringEncoding;
+    return _DefaultStringEncoding;
 }
 
 /**
  * Returns an array of all available string encodings,
  * terminated by a null value.
  */
-+ (NSStringEncoding*) availableStringEncodings
++ (NSStringEncoding *)availableStringEncodings
 {
-  return GSPrivateAvailableEncodings();
+    return GSPrivateAvailableEncodings();
 }
 
 /**
  * Returns the localized name of the encoding specified.
  */
-+ (NSString*) localizedNameOfStringEncoding: (NSStringEncoding)encoding
++ (NSString *)localizedNameOfStringEncoding:(NSStringEncoding)encoding
 {
-  id ourbundle;
-  id ourname;
+    id ourbundle;
+    id ourname;
 
-/*
-      Should be path to localizable.strings file.
-      Until we have it, just make sure that bundle
-      is initialized.
-*/
-  ourbundle = [NSBundle bundleForLibrary: @"gnustep-base"];
+    /*
+          Should be path to localizable.strings file.
+          Until we have it, just make sure that bundle
+          is initialized.
+    */
+    ourbundle = [NSBundle bundleForLibrary:@"gnustep-base"];
 
-  ourname = GSPrivateEncodingName(encoding);
-  return [ourbundle localizedStringForKey: ourname
-				    value: ourname
-				    table: nil];
+    ourname = GSPrivateEncodingName(encoding);
+    return [ourbundle localizedStringForKey:ourname
+                                      value:ourname
+                                      table:nil];
 }
 
 /**
  *  Returns whether this string can be converted to the given string encoding
  *  without information loss.
  */
-- (BOOL) canBeConvertedToEncoding: (NSStringEncoding)encoding
+- (BOOL)canBeConvertedToEncoding:(NSStringEncoding)encoding
 {
-  id d = [self dataUsingEncoding: encoding allowLossyConversion: NO];
+    id d = [self dataUsingEncoding:encoding allowLossyConversion:NO];
 
-  return d != nil ? YES : NO;
+    return d != nil ? YES : NO;
 }
 
 /**
  *  Converts string to a byte array in the given encoding, returning nil if
  *  this would result in information loss.
  */
-- (NSData*) dataUsingEncoding: (NSStringEncoding)encoding
+- (NSData *)dataUsingEncoding:(NSStringEncoding)encoding
 {
-  return [self dataUsingEncoding: encoding allowLossyConversion: NO];
+    return [self dataUsingEncoding:encoding allowLossyConversion:NO];
 }
 
 /**
  *  Converts string to a byte array in the given encoding.  If flag is NO,
  *  nil would be returned if this would result in information loss.
  */
-- (NSData*) dataUsingEncoding: (NSStringEncoding)encoding
-	 allowLossyConversion: (BOOL)flag
+- (NSData *)dataUsingEncoding:(NSStringEncoding)encoding
+         allowLossyConversion:(BOOL)flag
 {
-  unsigned	len = [self length];
-  NSData	*d;
+    unsigned len = [self length];
+    NSData *d;
 
-  if (NSUnicodeStringEncoding == encoding)
-    {
-      unichar	*u;
-      unsigned	l;
+    if (NSUnicodeStringEncoding == encoding) {
+        unichar *u;
+        unsigned l;
 
-      /* Fast path for Unicode (UTF16) without a specific byte order,
-       * where we must prepend a byte order mark.
-       * The case for UTF32 is handled in the slower branch.
-       */
-      u = (unichar*)NSZoneMalloc(NSDefaultMallocZone(),
-	(len + 1) * sizeof(unichar));
-      *u = byteOrderMark;
-      [self getCharacters: u + 1];
-      l = GSUnicode(u, len, 0, 0);
-      d = [NSDataClass dataWithBytesNoCopy: u
-				    length: (l + 1) * sizeof(unichar)];
+        /* Fast path for Unicode (UTF16) without a specific byte order,
+         * where we must prepend a byte order mark.
+         * The case for UTF32 is handled in the slower branch.
+         */
+        u = (unichar *)NSZoneMalloc(NSDefaultMallocZone(),
+                                    (len + 1) * sizeof(unichar));
+        *u = byteOrderMark;
+        [self getCharacters:u + 1];
+        l = GSUnicode(u, len, 0, 0);
+        d = [NSDataClass dataWithBytesNoCopy:u
+                                      length:(l + 1) * sizeof(unichar)];
+    } else {
+        unichar buf[8192];
+        unichar *u = buf;
+        unsigned int options;
+        unsigned char *b = 0;
+        unsigned int l = 0;
+
+        /* Build a fake object on the stack and copy unicode characters
+         * into its buffer from the receiver.
+         * We can then use our concrete subclass implementation to do the
+         * work of converting to the desired encoding.
+         */
+        if (NSUTF32StringEncoding == encoding) {
+            /* For UTF32 without byte order specified, we must include a
+             * BOM at the start of the data.
+             */
+            len++;
+            if (len >= 4096) {
+                u = NSZoneMalloc(NSDefaultMallocZone(), len * sizeof(unichar));
+            }
+            *u = byteOrderMark;
+            [self getCharacters:u + 1];
+        } else {
+            if (len >= 4096) {
+                u = NSZoneMalloc(NSDefaultMallocZone(), len * sizeof(unichar));
+            }
+            [self getCharacters:u];
+        }
+
+        if (flag == NO) {
+            options = GSUniStrict;
+        } else {
+            options = 0;
+        }
+        if (GSFromUnicode(&b, &l, u, len, encoding, NSDefaultMallocZone(),
+                          options) == YES) {
+            d = [NSDataClass dataWithBytesNoCopy:b length:l];
+        } else {
+            d = nil;
+        }
+        if (u != buf) {
+            NSZoneFree(NSDefaultMallocZone(), u);
+        }
     }
-  else
-    {
-      unichar		buf[8192];
-      unichar		*u = buf;
-      unsigned int	options;
-      unsigned char	*b = 0;
-      unsigned int	l = 0;
-
-      /* Build a fake object on the stack and copy unicode characters
-       * into its buffer from the receiver.
-       * We can then use our concrete subclass implementation to do the
-       * work of converting to the desired encoding.
-       */
-      if (NSUTF32StringEncoding == encoding)
-	{
-	  /* For UTF32 without byte order specified, we must include a
-	   * BOM at the start of the data.
-	   */
-	  len++;
-	  if (len >= 4096)
-	    {
-	      u = NSZoneMalloc(NSDefaultMallocZone(), len * sizeof(unichar));
-	    }
-	  *u = byteOrderMark;
-	  [self getCharacters: u+1];
-	}
-      else
-	{
-	  if (len >= 4096)
-	    {
-	      u = NSZoneMalloc(NSDefaultMallocZone(), len * sizeof(unichar));
-	    }
-	  [self getCharacters: u];
-	}
-
-      if (flag == NO)
-        {
-	  options = GSUniStrict;
-	}
-      else
-        {
-	  options = 0;
-	}
-      if (GSFromUnicode(&b, &l, u, len, encoding, NSDefaultMallocZone(),
-	options) == YES)
-	{
-	  d = [NSDataClass dataWithBytesNoCopy: b length: l];
-	}
-      else
-        {
-	  d = nil;
-	}
-      if (u != buf)
-	{
-	  NSZoneFree(NSDefaultMallocZone(), u);
-	}
-    }
-  return d;
+    return d;
 }
 
 /**
  * Returns the encoding with which this string can be converted without
  * information loss that would result in most efficient character access.
  */
-- (NSStringEncoding) fastestEncoding
+- (NSStringEncoding)fastestEncoding
 {
-  return NSUnicodeStringEncoding;
+    return NSUnicodeStringEncoding;
 }
 
 /**
  * Returns the smallest encoding with which this string can be converted
  * without information loss.
  */
-- (NSStringEncoding) smallestEncoding
+- (NSStringEncoding)smallestEncoding
 {
-  return NSUnicodeStringEncoding;
+    return NSUnicodeStringEncoding;
 }
 
-- (NSUInteger) completePathIntoString: (NSString**)outputName
-                        caseSensitive: (BOOL)flag
-                     matchesIntoArray: (NSArray**)outputArray
-                          filterTypes: (NSArray*)filterTypes
+- (NSUInteger)completePathIntoString:(NSString **)outputName
+                       caseSensitive:(BOOL)flag
+                    matchesIntoArray:(NSArray **)outputArray
+                         filterTypes:(NSArray *)filterTypes
 {
-  NSString		*basePath = [self stringByDeletingLastPathComponent];
-  NSString		*lastComp = [self lastPathComponent];
-  NSString		*tmpPath;
-  NSDirectoryEnumerator *e;
-  NSMutableArray	*op = nil;
-  unsigned		matchCount = 0;
+    NSString *basePath = [self stringByDeletingLastPathComponent];
+    NSString *lastComp = [self lastPathComponent];
+    NSString *tmpPath;
+    NSDirectoryEnumerator *e;
+    NSMutableArray *op = nil;
+    unsigned matchCount = 0;
 
-  if (outputArray != 0)
-    {
-      op = (NSMutableArray*)[NSMutableArray array];
+    if (outputArray != 0) {
+        op = (NSMutableArray *)[NSMutableArray array];
     }
 
-  if (outputName != NULL)
-    {
-      *outputName = nil;
+    if (outputName != NULL) {
+        *outputName = nil;
     }
 
-  if ([basePath length] == 0)
-    {
-      basePath = @".";
+    if ([basePath length] == 0) {
+        basePath = @".";
     }
 
-  e = [[NSFileManager defaultManager] enumeratorAtPath: basePath];
-  while (tmpPath = [e nextObject], tmpPath)
-    {
-      /* Prefix matching */
-      if (flag == YES)
-	{ /* Case sensitive */
-	  if ([tmpPath hasPrefix: lastComp] == NO)
-	    {
-	      continue;
-	    }
-	}
-      else if ([[tmpPath uppercaseString]
-	hasPrefix: [lastComp uppercaseString]] == NO)
-	{
-	  continue;
-	}
+    e = [[NSFileManager defaultManager] enumeratorAtPath:basePath];
+    while (tmpPath = [e nextObject], tmpPath) {
+        /* Prefix matching */
+        if (flag == YES) { /* Case sensitive */
+            if ([tmpPath hasPrefix:lastComp] == NO) {
+                continue;
+            }
+        } else if ([[tmpPath uppercaseString]
+                       hasPrefix:[lastComp uppercaseString]] == NO) {
+            continue;
+        }
 
-      /* Extensions filtering */
-      if (filterTypes
-	&& ([filterTypes containsObject: [tmpPath pathExtension]] == NO))
-	{
-	  continue;
-	}
+        /* Extensions filtering */
+        if (filterTypes && ([filterTypes containsObject:[tmpPath pathExtension]] == NO)) {
+            continue;
+        }
 
-      /* Found a completion */
-      matchCount++;
-      if (outputArray != NULL)
-	{
-	  [op addObject: tmpPath];
-	}
+        /* Found a completion */
+        matchCount++;
+        if (outputArray != NULL) {
+            [op addObject:tmpPath];
+        }
 
-      if ((outputName != NULL) &&
-	((*outputName == nil) || (([*outputName length] < [tmpPath length]))))
-	{
-	  *outputName = tmpPath;
-	}
+        if ((outputName != NULL) &&
+            ((*outputName == nil) || (([*outputName length] < [tmpPath length])))) {
+            *outputName = tmpPath;
+        }
     }
-  if (outputArray != NULL)
-    {
-      *outputArray = AUTORELEASE([op copy]);
+    if (outputArray != NULL) {
+        *outputArray = AUTORELEASE([op copy]);
     }
-  return matchCount;
+    return matchCount;
 }
 
 static NSFileManager *fm = nil;
 
-#if	defined(_WIN32)
-- (const GSNativeChar*) fileSystemRepresentation
+#if defined(_WIN32)
+- (const GSNativeChar *)fileSystemRepresentation
 {
-  if (fm == nil)
-    {
-      fm = RETAIN([NSFileManager defaultManager]);
+    if (fm == nil) {
+        fm = RETAIN([NSFileManager defaultManager]);
     }
-  return [fm fileSystemRepresentationWithPath: self];
+    return [fm fileSystemRepresentationWithPath:self];
 }
 
-- (BOOL) getFileSystemRepresentation: (GSNativeChar*)buffer
-			   maxLength: (NSUInteger)size
+- (BOOL)getFileSystemRepresentation:(GSNativeChar *)buffer
+                          maxLength:(NSUInteger)size
 {
-  const unichar	*ptr;
-  unsigned	i;
+    const unichar *ptr;
+    unsigned i;
 
-  if (size == 0)
-    {
-      return NO;
+    if (size == 0) {
+        return NO;
     }
-  if (buffer == 0)
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"%@ given null pointer",
-	NSStringFromSelector(_cmd)];
+    if (buffer == 0) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"%@ given null pointer",
+                           NSStringFromSelector(_cmd)];
     }
-  ptr = [self fileSystemRepresentation];
-  for (i = 0; i < size; i++)
-    {
-      buffer[i] = ptr[i];
-      if (ptr[i] == 0)
-	{
-	  break;
-	}
-    }
-  if (i == size && ptr[i] != 0)
-    {
-      return NO;	// Not at end.
-    }
-  return YES;
-}
-#else
-- (const GSNativeChar*) fileSystemRepresentation
-{
-  if (fm == nil)
-    {
-      fm = RETAIN([NSFileManager defaultManager]);
-    }
-  return [fm fileSystemRepresentationWithPath: self];
-}
-
-- (BOOL) getFileSystemRepresentation: (GSNativeChar*)buffer
-			   maxLength: (NSUInteger)size
-{
-  const char* ptr;
-
-  if (size == 0)
-    {
-      return NO;
-    }
-  if (buffer == 0)
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"%@ given null pointer",
-	NSStringFromSelector(_cmd)];
-    }
-  ptr = [self fileSystemRepresentation];
-  if (strlen(ptr) > size)
-    {
-      return NO;
-    }
-  strncpy(buffer, ptr, size);
-  return YES;
-}
-#endif
-
-- (NSString*) lastPathComponent
-{
-  unsigned int	l = [self length];
-  NSRange	range;
-  unsigned int	i;
-
-  if (l == 0)
-    {
-      return @"";		// self is empty
-    }
-
-  // Skip back over any trailing path separators, but not in to root.
-  i = rootOf(self, l);
-  while (l > i && pathSepMember([self characterAtIndex: l-1]) == YES)
-    {
-      l--;
-    }
-
-  // If only the root is left, return it.
-  if (i == l)
-    {
-      /*
-       * NB. tilde escapes should not have trailing separator in the
-       * path component as they are not trreated as true roots.
-       */
-      if ([self characterAtIndex: 0] == '~'
-	&& pathSepMember([self characterAtIndex: i-1]) == YES)
-	{
-	  return [self substringToIndex: i-1];
-	}
-      return [self substringToIndex: i];
-    }
-
-  // Got more than root ... find last component.
-  range = [self rangeOfCharacterFromSet: pathSeps()
-				options: NSBackwardsSearch
-				  range: ((NSRange){i, l-i})];
-  if (range.length > 0)
-    {
-      // Found separator ... adjust to point to component.
-      i = NSMaxRange(range);
-    }
-  return [self substringWithRange: ((NSRange){i, l-i})];
-}
-
-- (NSRange) paragraphRangeForRange: (NSRange)range
-{
-  NSUInteger startIndex;
-  NSUInteger endIndex;
-
-  [self getParagraphStart: &startIndex
-        end: &endIndex
-        contentsEnd: NULL
-        forRange: range];
-  return NSMakeRange(startIndex, endIndex - startIndex);
-}
-
-- (NSString*) pathExtension
-{
-  NSRange	range;
-  unsigned int	l = [self length];
-  unsigned int	root;
-
-  if (l == 0)
-    {
-      return @"";
-    }
-  root = rootOf(self, l);
-
-  /*
-   * Step past trailing path separators.
-   */
-  while (l > root && pathSepMember([self characterAtIndex: l-1]) == YES)
-    {
-      l--;
-    }
-  range = NSMakeRange(root, l-root);
-
-  /*
-   * Look for a dot in the path ... if there isn't one, or if it is
-   * immediately after the root or a path separator, there is no extension.
-   */
-  range = [self rangeOfString: @"."
-                      options: NSBackwardsSearch
-                        range: range
-                       locale: nil];
-  if (range.length > 0 && range.location > root
-    && pathSepMember([self characterAtIndex: range.location-1]) == NO)
-    {
-      NSRange	sepRange;
-
-      /*
-       * Found a dot, so we determine the range of the (possible)
-       * path extension, then check to see if we have a path
-       * separator within it ... if we have a path separator then
-       * the dot is inside the last path component and there is
-       * therefore no extension.
-       */
-      range.location++;
-      range.length = l - range.location;
-      sepRange = [self rangeOfCharacterFromSet: pathSeps()
-				       options: NSBackwardsSearch
-				         range: range];
-      if (sepRange.length == 0)
-	{
-	  return [self substringFromRange: range];
-	}
-    }
-
-  return @"";
-}
-
-- (NSString *) precomposedStringWithCompatibilityMapping
-{
-#if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
-  return [self _normalizedICUStringOfType: "nfkc" mode: UNORM2_COMPOSE];
-#else
-  return [self notImplemented: _cmd];
-#endif
-}
- 
-- (NSString *) precomposedStringWithCanonicalMapping
-{
-#if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
-   return [self _normalizedICUStringOfType: "nfc" mode: UNORM2_COMPOSE];
-#else
-  return [self notImplemented: _cmd];
-#endif
-}
- 
-- (NSString*) stringByAppendingPathComponent: (NSString*)aString
-{
-  unsigned	originalLength = [self length];
-  unsigned	length = originalLength;
-  unsigned	aLength = [aString length];
-  unsigned	root;
-  unichar	buf[length+aLength+1];
-
-  root = rootOf(aString, aLength);
-
-  if (length == 0)
-    {
-      [aString getCharacters: buf range: ((NSRange){0, aLength})];
-      length = aLength;
-      root = rootOf(aString, aLength);
-    }
-  else
-    {
-      /* If the 'component' has a leading path separator (or drive spec
-       * in windows) then we need to find its length so we can strip it.
-       */
-      if (root > 0)
-	{
-	  unichar c = [aString characterAtIndex: 0];
-
-	  if (c == '~')
-	    {
-	      root = 0;
-	    }
-	  else if (root > 1 && pathSepMember(c))
-	    {
-	      int	i;
-
-	      for (i = 1; i < root; i++)
-		{
-		  c = [aString characterAtIndex: i];
-		  if (!pathSepMember(c))
-		    {
-		      break;
-		    }
-		}
-	      root = i;
-	    }
-	}
-
-      [self getCharacters: buf range: ((NSRange){0, length})];
-
-      /* We strip back trailing path separators, and replace them with
-       * a single one ... except in the case where we have a windows
-       * drive specification, and the string being appended does not
-       * have a path separator as a root. In that case we just want to
-       * append to the drive specification directly, leaving a relative
-       * path like c:foo
-       */
-      if (length != 2 || buf[1] != ':' || GSPathHandlingUnix() == YES
-	|| buf[0] < 'A' || buf[0] > 'z' || (buf[0] > 'Z' && buf[0] < 'a')
-	|| (root > 0 && pathSepMember([aString characterAtIndex: root-1])))
-	{
-	  while (length > 0 && pathSepMember(buf[length-1]) == YES)
-	    {
-	      length--;
-	    }
-	  buf[length++] = pathSepChar();
-	}
-
-      if ((aLength - root) > 0)
-	{
-	  // appending .. discard root from aString
-	  [aString getCharacters: &buf[length]
-			   range: ((NSRange){root, aLength-root})];
-	  length += aLength-root;
-	}
-      // Find length of root part of new path.
-      root = rootOf(self, originalLength);
-    }
-
-  if (length > 0)
-    {
-      /* Trim trailing path separators as long as they are not part of
-       * the root. 
-       */
-      aLength = length - 1;
-      while (aLength > root && pathSepMember(buf[aLength]) == YES)
-	{
-	  aLength--;
-	  length--;
-	}
-
-      /* Trim multi separator sequences outside root (root may contain an
-       * initial // pair if it is a windows UNC path).
-       */
-      if (length > 0)
-	{
-	  while (aLength > root)
-	    {
-	      if (pathSepMember(buf[aLength]) == YES)
-		{
-		  buf[aLength] = pathSepChar();
-		  if (pathSepMember(buf[aLength-1]) == YES)
-		    {
-		      unsigned	pos;
-
-		      buf[aLength-1] = pathSepChar();
-		      for (pos = aLength+1; pos < length; pos++)
-			{
-			  buf[pos-1] = buf[pos];
-			}
-		      length--;
-		    }
-		}
-	      aLength--;
-	    }
-	}
-    }
-  return [NSStringClass stringWithCharacters: buf length: length];
-}
-
-- (NSString*) stringByAppendingPathExtension: (NSString*)aString
-{
-  unsigned	l = [self length];
-  unsigned 	originalLength = l;
-  unsigned	root;
-
-  if (l == 0)
-    {
-      NSLog(@"[%@-%@] cannot append extension '%@' to empty string",
-	NSStringFromClass([self class]), NSStringFromSelector(_cmd), aString);
-      return @"";		// Must have a file name to append extension.
-    }
-  root = rootOf(self, l);
-  /*
-   * Step past trailing path separators.
-   */
-  while (l > root && pathSepMember([self characterAtIndex: l-1]) == YES)
-    {
-      l--;
-    }
-  if (root == l)
-    {
-      NSLog(@"[%@-%@] cannot append extension '%@' to path '%@'",
-	NSStringFromClass([self class]), NSStringFromSelector(_cmd),
-	aString, self);
-      return IMMUTABLE(self);	// Must have a file name to append extension.
-    }
-
-  /* MacOS-X prohibits an extension beginning with a path separator,
-   * but this code extends that a little to prohibit any root except
-   * one beginning with '~' from being used as an extension. 
-   */ 
-  root = rootOf(aString, [aString length]);
-  if (root > 0 && [aString characterAtIndex: 0] != '~')
-    {
-      NSLog(@"[%@-%@] cannot append extension '%@' to path '%@'",
-	NSStringFromClass([self class]), NSStringFromSelector(_cmd),
-	aString, self);
-      return IMMUTABLE(self);	// Must have a file name to append extension.
-    }
-
-  if (originalLength != l)
-    {
-      NSRange	range = NSMakeRange(0, l);
-
-      return [[self substringFromRange: range]
-	stringByAppendingFormat: @".%@", aString];
-    }
-  return [self stringByAppendingFormat: @".%@", aString];
-}
-
-- (NSString*) stringByDeletingLastPathComponent
-{
-  unsigned int	length;
-  unsigned int	root;
-  unsigned int	end;
-  unsigned int	i;
-
-  end = length = [self length];
-  if (length == 0)
-    {
-      return @"";
-    }
-  i = root = rootOf(self, length);
-
-  /*
-   * Any root without a trailing path separator can be deleted
-   * as it's either a relative path or a tilde expression.
-   */
-  if (i == length && pathSepMember([self characterAtIndex: i-1]) == NO)
-    {
-      return @"";	// Delete relative root
-    }
-
-  /*
-   * Step past trailing path separators.
-   */
-  while (end > i && pathSepMember([self characterAtIndex: end-1]) == YES)
-    {
-      end--;
-    }
-
-  /*
-   * If all we have left is the root, return that root, except for the
-   * special case of a tilde expression ... which may be deleted even
-   * when it is followed by a separator.
-   */
-  if (end == i)
-    {
-      if ([self characterAtIndex: 0] == '~')
-	{
-	  return @"";				// Tilde roots may be deleted.
-	}
-      return [self substringToIndex: i];	// Return root component.
-    }
-  else
-    {
-      NSString	*result;
-      unichar	*to;
-      unsigned	o;
-      unsigned	lastComponent = root;
-      GS_BEGINITEMBUF(from, (end * 2 * sizeof(unichar)), unichar)
-
-      to = from + end;
-      [self getCharacters: from range: NSMakeRange(0, end)];
-      for (o = 0; o < root; o++)
-	{
-	  to[o] = from[o];
-	}
-      for (i = root; i < end; i++)
-	{
-	  if (pathSepMember(from[i]))
-	    {
-	      if (o > lastComponent)
-		{
-		  to[o++] = from[i];
-		  lastComponent = o;
-		}
-	    }
-	  else
-	    {
-	      to[o++] = from[i];
-	    }
-	}
-      if (lastComponent > root)
-	{
-	  o = lastComponent - 1;
-	}
-      else
-	{
-	  o = root;
-	}
-      result = [NSString stringWithCharacters: to length: o];
-      GS_ENDITEMBUF();
-      return result;
-    }
-}
-
-- (NSString*) stringByDeletingPathExtension
-{
-  NSRange	range;
-  NSRange	r0;
-  NSRange	r1;
-  NSString	*substring;
-  unsigned	l = [self length];
-  unsigned	root;
-
-  if ((root = rootOf(self, l)) == l)
-    {
-      return IMMUTABLE(self);
-    }
-
-  /*
-   * Skip past any trailing path separators... but not into root.
-   */
-  while (l > root && pathSepMember([self characterAtIndex: l-1]) == YES)
-    {
-      l--;
-    }
-  range = NSMakeRange(root, l-root);
-  /*
-   * Locate path extension.
-   */
-  r0 = [self rangeOfString: @"."
-		   options: NSBackwardsSearch
-		     range: range
-                    locale: nil];
-  /*
-   * Locate a path separator.
-   */
-  r1 = [self rangeOfCharacterFromSet: pathSeps()
-			     options: NSBackwardsSearch
-			       range: range];
-  /*
-   * Assuming the extension separator was found in the last path
-   * component, set the length of the substring we want.
-   */
-  if (r0.length > 0 && r0.location > root
-    && (r1.length == 0 || r1.location < r0.location))
-    {
-      l = r0.location;
-    }
-  substring = [self substringToIndex: l];
-  return substring;
-}
-
-- (NSString*) stringByExpandingTildeInPath
-{
-  NSString	*homedir;
-  NSRange	firstSlashRange;
-  unsigned	length;
-
-  if ((length = [self length]) == 0)
-    {
-      return IMMUTABLE(self);
-    }
-  if ([self characterAtIndex: 0] != 0x007E)
-    {
-      return IMMUTABLE(self);
-    }
-
-  /* FIXME ... should remove in future
-   * Anything beginning '~@' is assumed to be a windows path specification
-   * which can't be expanded.
-   */
-  if (length > 1 && [self characterAtIndex: 1] == 0x0040)
-    {
-      return IMMUTABLE(self);
-    }
-
-  firstSlashRange = [self rangeOfCharacterFromSet: pathSeps()
-                                          options: NSLiteralSearch
-                                            range: ((NSRange){0, length})];
-  if (firstSlashRange.length == 0)
-    {
-      firstSlashRange.location = length;
-    }
-
-  /* FIXME ... should remove in future
-   * Anything beginning '~' followed by a single letter is assumed
-   * to be a windows drive specification.
-   */
-  if (firstSlashRange.location == 2 && isalpha([self characterAtIndex: 1]))
-    {
-      return IMMUTABLE(self);
-    }
-
-  if (firstSlashRange.location != 1)
-    {
-      /* It is of the form `~username/blah/...' or '~username' */
-      int	userNameLen;
-      NSString	*uname;
-
-      if (firstSlashRange.length != 0)
-	{
-	  userNameLen = firstSlashRange.location - 1;
-	}
-      else
-	{
-	  /* It is actually of the form `~username' */
-	  userNameLen = [self length] - 1;
-	  firstSlashRange.location = [self length];
-	}
-      uname = [self substringWithRange: ((NSRange){1, userNameLen})];
-      homedir = NSHomeDirectoryForUser(uname);
-    }
-  else
-    {
-      /* It is of the form `~/blah/...' or is '~' */
-      homedir = NSHomeDirectory();
-    }
-
-  if (homedir != nil)
-    {
-      if (firstSlashRange.location < length)
-	{
-	  return [homedir stringByAppendingPathComponent:
-	    [self substringFromIndex: firstSlashRange.location]];
-	}
-      else
-	{
-	  return IMMUTABLE(homedir);
-	}
-    }
-  else
-    {
-      return IMMUTABLE(self);
-    }
-}
-
-- (NSString*) stringByAbbreviatingWithTildeInPath
-{
-  NSString	*homedir;
-
-  if (YES == [self hasPrefix: @"~"])
-    {
-      return IMMUTABLE(self);
-    }
-  homedir = NSHomeDirectory();
-  if (NO == [self hasPrefix: homedir])
-    {
-      /* OSX compatibility ... we clean up the path to try to get a
-       * home directory we can abbreviate.
-       */
-      self = [self stringByStandardizingPath];
-      if (NO == [self hasPrefix: homedir])
-        {
-          return IMMUTABLE(self);
+    ptr = [self fileSystemRepresentation];
+    for (i = 0; i < size; i++) {
+        buffer[i] = ptr[i];
+        if (ptr[i] == 0) {
+            break;
         }
     }
-  if ([self length] == [homedir length])
-    {
-      return @"~";
+    if (i == size && ptr[i] != 0) {
+        return NO; // Not at end.
     }
-  return [@"~" stringByAppendingPathComponent:
-    [self substringFromIndex: [homedir length]]];
+    return YES;
+}
+#else
+- (const GSNativeChar *)fileSystemRepresentation
+{
+    if (fm == nil) {
+        fm = RETAIN([NSFileManager defaultManager]);
+    }
+    return [fm fileSystemRepresentationWithPath:self];
+}
+
+- (BOOL)getFileSystemRepresentation:(GSNativeChar *)buffer
+                          maxLength:(NSUInteger)size
+{
+    const char *ptr;
+
+    if (size == 0) {
+        return NO;
+    }
+    if (buffer == 0) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"%@ given null pointer",
+                           NSStringFromSelector(_cmd)];
+    }
+    ptr = [self fileSystemRepresentation];
+    if (strlen(ptr) > size) {
+        return NO;
+    }
+    strncpy(buffer, ptr, size);
+    return YES;
+}
+#endif
+
+- (NSString *)lastPathComponent
+{
+    unsigned int l = [self length];
+    NSRange range;
+    unsigned int i;
+
+    if (l == 0) {
+        return @""; // self is empty
+    }
+
+    // Skip back over any trailing path separators, but not in to root.
+    i = rootOf(self, l);
+    while (l > i && pathSepMember([self characterAtIndex:l - 1]) == YES) {
+        l--;
+    }
+
+    // If only the root is left, return it.
+    if (i == l) {
+        /*
+         * NB. tilde escapes should not have trailing separator in the
+         * path component as they are not trreated as true roots.
+         */
+        if ([self characterAtIndex:0] == '~' && pathSepMember([self characterAtIndex:i - 1]) == YES) {
+            return [self substringToIndex:i - 1];
+        }
+        return [self substringToIndex:i];
+    }
+
+    // Got more than root ... find last component.
+    range = [self rangeOfCharacterFromSet:pathSeps()
+                                  options:NSBackwardsSearch
+                                    range:((NSRange){i, l - i})];
+    if (range.length > 0) {
+        // Found separator ... adjust to point to component.
+        i = NSMaxRange(range);
+    }
+    return [self substringWithRange:((NSRange){i, l - i})];
+}
+
+- (NSRange)paragraphRangeForRange:(NSRange)range
+{
+    NSUInteger startIndex;
+    NSUInteger endIndex;
+
+    [self getParagraphStart:&startIndex
+                        end:&endIndex
+                contentsEnd:NULL
+                   forRange:range];
+    return NSMakeRange(startIndex, endIndex - startIndex);
+}
+
+- (NSString *)pathExtension
+{
+    NSRange range;
+    unsigned int l = [self length];
+    unsigned int root;
+
+    if (l == 0) {
+        return @"";
+    }
+    root = rootOf(self, l);
+
+    /*
+     * Step past trailing path separators.
+     */
+    while (l > root && pathSepMember([self characterAtIndex:l - 1]) == YES) {
+        l--;
+    }
+    range = NSMakeRange(root, l - root);
+
+    /*
+     * Look for a dot in the path ... if there isn't one, or if it is
+     * immediately after the root or a path separator, there is no extension.
+     */
+    range = [self rangeOfString:@"."
+                        options:NSBackwardsSearch
+                          range:range
+                         locale:nil];
+    if (range.length > 0 && range.location > root && pathSepMember([self characterAtIndex:range.location - 1]) == NO) {
+        NSRange sepRange;
+
+        /*
+         * Found a dot, so we determine the range of the (possible)
+         * path extension, then check to see if we have a path
+         * separator within it ... if we have a path separator then
+         * the dot is inside the last path component and there is
+         * therefore no extension.
+         */
+        range.location++;
+        range.length = l - range.location;
+        sepRange = [self rangeOfCharacterFromSet:pathSeps()
+                                         options:NSBackwardsSearch
+                                           range:range];
+        if (sepRange.length == 0) {
+            return [self substringFromRange:range];
+        }
+    }
+
+    return @"";
+}
+
+- (NSString *)precomposedStringWithCompatibilityMapping
+{
+#if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
+    return [self _normalizedICUStringOfType:"nfkc" mode:UNORM2_COMPOSE];
+#else
+    return [self notImplemented:_cmd];
+#endif
+}
+
+- (NSString *)precomposedStringWithCanonicalMapping
+{
+#if (GS_USE_ICU == 1) && (defined(HAVE_UNICODE_UNORM2_H) || defined(HAVE_ICU_H))
+    return [self _normalizedICUStringOfType:"nfc" mode:UNORM2_COMPOSE];
+#else
+    return [self notImplemented:_cmd];
+#endif
+}
+
+- (NSString *)stringByAppendingPathComponent:(NSString *)aString
+{
+    unsigned originalLength = [self length];
+    unsigned length = originalLength;
+    unsigned aLength = [aString length];
+    unsigned root;
+    unichar buf[length + aLength + 1];
+
+    root = rootOf(aString, aLength);
+
+    if (length == 0) {
+        [aString getCharacters:buf range:((NSRange){0, aLength})];
+        length = aLength;
+        root = rootOf(aString, aLength);
+    } else {
+        /* If the 'component' has a leading path separator (or drive spec
+         * in windows) then we need to find its length so we can strip it.
+         */
+        if (root > 0) {
+            unichar c = [aString characterAtIndex:0];
+
+            if (c == '~') {
+                root = 0;
+            } else if (root > 1 && pathSepMember(c)) {
+                int i;
+
+                for (i = 1; i < root; i++) {
+                    c = [aString characterAtIndex:i];
+                    if (!pathSepMember(c)) {
+                        break;
+                    }
+                }
+                root = i;
+            }
+        }
+
+        [self getCharacters:buf range:((NSRange){0, length})];
+
+        /* We strip back trailing path separators, and replace them with
+         * a single one ... except in the case where we have a windows
+         * drive specification, and the string being appended does not
+         * have a path separator as a root. In that case we just want to
+         * append to the drive specification directly, leaving a relative
+         * path like c:foo
+         */
+        if (length != 2 || buf[1] != ':' || GSPathHandlingUnix() == YES || buf[0] < 'A' || buf[0] > 'z' || (buf[0] > 'Z' && buf[0] < 'a') || (root > 0 && pathSepMember([aString characterAtIndex:root - 1]))) {
+            while (length > 0 && pathSepMember(buf[length - 1]) == YES) {
+                length--;
+            }
+            buf[length++] = pathSepChar();
+        }
+
+        if ((aLength - root) > 0) {
+            // appending .. discard root from aString
+            [aString getCharacters:&buf[length]
+                             range:((NSRange){root, aLength - root})];
+            length += aLength - root;
+        }
+        // Find length of root part of new path.
+        root = rootOf(self, originalLength);
+    }
+
+    if (length > 0) {
+        /* Trim trailing path separators as long as they are not part of
+         * the root.
+         */
+        aLength = length - 1;
+        while (aLength > root && pathSepMember(buf[aLength]) == YES) {
+            aLength--;
+            length--;
+        }
+
+        /* Trim multi separator sequences outside root (root may contain an
+         * initial // pair if it is a windows UNC path).
+         */
+        if (length > 0) {
+            while (aLength > root) {
+                if (pathSepMember(buf[aLength]) == YES) {
+                    buf[aLength] = pathSepChar();
+                    if (pathSepMember(buf[aLength - 1]) == YES) {
+                        unsigned pos;
+
+                        buf[aLength - 1] = pathSepChar();
+                        for (pos = aLength + 1; pos < length; pos++) {
+                            buf[pos - 1] = buf[pos];
+                        }
+                        length--;
+                    }
+                }
+                aLength--;
+            }
+        }
+    }
+    return [NSStringClass stringWithCharacters:buf length:length];
+}
+
+- (NSString *)stringByAppendingPathExtension:(NSString *)aString
+{
+    unsigned l = [self length];
+    unsigned originalLength = l;
+    unsigned root;
+
+    if (l == 0) {
+        NSLog(@"[%@-%@] cannot append extension '%@' to empty string",
+              NSStringFromClass([self class]), NSStringFromSelector(_cmd), aString);
+        return @""; // Must have a file name to append extension.
+    }
+    root = rootOf(self, l);
+    /*
+     * Step past trailing path separators.
+     */
+    while (l > root && pathSepMember([self characterAtIndex:l - 1]) == YES) {
+        l--;
+    }
+    if (root == l) {
+        NSLog(@"[%@-%@] cannot append extension '%@' to path '%@'",
+              NSStringFromClass([self class]), NSStringFromSelector(_cmd),
+              aString, self);
+        return IMMUTABLE(self); // Must have a file name to append extension.
+    }
+
+    /* MacOS-X prohibits an extension beginning with a path separator,
+     * but this code extends that a little to prohibit any root except
+     * one beginning with '~' from being used as an extension.
+     */
+    root = rootOf(aString, [aString length]);
+    if (root > 0 && [aString characterAtIndex:0] != '~') {
+        NSLog(@"[%@-%@] cannot append extension '%@' to path '%@'",
+              NSStringFromClass([self class]), NSStringFromSelector(_cmd),
+              aString, self);
+        return IMMUTABLE(self); // Must have a file name to append extension.
+    }
+
+    if (originalLength != l) {
+        NSRange range = NSMakeRange(0, l);
+
+        return [[self substringFromRange:range]
+            stringByAppendingFormat:@".%@", aString];
+    }
+    return [self stringByAppendingFormat:@".%@", aString];
+}
+
+- (NSString *)stringByDeletingLastPathComponent
+{
+    unsigned int length;
+    unsigned int root;
+    unsigned int end;
+    unsigned int i;
+
+    end = length = [self length];
+    if (length == 0) {
+        return @"";
+    }
+    i = root = rootOf(self, length);
+
+    /*
+     * Any root without a trailing path separator can be deleted
+     * as it's either a relative path or a tilde expression.
+     */
+    if (i == length && pathSepMember([self characterAtIndex:i - 1]) == NO) {
+        return @""; // Delete relative root
+    }
+
+    /*
+     * Step past trailing path separators.
+     */
+    while (end > i && pathSepMember([self characterAtIndex:end - 1]) == YES) {
+        end--;
+    }
+
+    /*
+     * If all we have left is the root, return that root, except for the
+     * special case of a tilde expression ... which may be deleted even
+     * when it is followed by a separator.
+     */
+    if (end == i) {
+        if ([self characterAtIndex:0] == '~') {
+            return @""; // Tilde roots may be deleted.
+        }
+        return [self substringToIndex:i]; // Return root component.
+    } else {
+        NSString *result;
+        unichar *to;
+        unsigned o;
+        unsigned lastComponent = root;
+        GS_BEGINITEMBUF(from, (end * 2 * sizeof(unichar)), unichar)
+
+        to = from + end;
+        [self getCharacters:from range:NSMakeRange(0, end)];
+        for (o = 0; o < root; o++) {
+            to[o] = from[o];
+        }
+        for (i = root; i < end; i++) {
+            if (pathSepMember(from[i])) {
+                if (o > lastComponent) {
+                    to[o++] = from[i];
+                    lastComponent = o;
+                }
+            } else {
+                to[o++] = from[i];
+            }
+        }
+        if (lastComponent > root) {
+            o = lastComponent - 1;
+        } else {
+            o = root;
+        }
+        result = [NSString stringWithCharacters:to length:o];
+        GS_ENDITEMBUF();
+        return result;
+    }
+}
+
+- (NSString *)stringByDeletingPathExtension
+{
+    NSRange range;
+    NSRange r0;
+    NSRange r1;
+    NSString *substring;
+    unsigned l = [self length];
+    unsigned root;
+
+    if ((root = rootOf(self, l)) == l) {
+        return IMMUTABLE(self);
+    }
+
+    /*
+     * Skip past any trailing path separators... but not into root.
+     */
+    while (l > root && pathSepMember([self characterAtIndex:l - 1]) == YES) {
+        l--;
+    }
+    range = NSMakeRange(root, l - root);
+    /*
+     * Locate path extension.
+     */
+    r0 = [self rangeOfString:@"."
+                     options:NSBackwardsSearch
+                       range:range
+                      locale:nil];
+    /*
+     * Locate a path separator.
+     */
+    r1 = [self rangeOfCharacterFromSet:pathSeps()
+                               options:NSBackwardsSearch
+                                 range:range];
+    /*
+     * Assuming the extension separator was found in the last path
+     * component, set the length of the substring we want.
+     */
+    if (r0.length > 0 && r0.location > root && (r1.length == 0 || r1.location < r0.location)) {
+        l = r0.location;
+    }
+    substring = [self substringToIndex:l];
+    return substring;
+}
+
+- (NSString *)stringByExpandingTildeInPath
+{
+    NSString *homedir;
+    NSRange firstSlashRange;
+    unsigned length;
+
+    if ((length = [self length]) == 0) {
+        return IMMUTABLE(self);
+    }
+    if ([self characterAtIndex:0] != 0x007E) {
+        return IMMUTABLE(self);
+    }
+
+    /* FIXME ... should remove in future
+     * Anything beginning '~@' is assumed to be a windows path specification
+     * which can't be expanded.
+     */
+    if (length > 1 && [self characterAtIndex:1] == 0x0040) {
+        return IMMUTABLE(self);
+    }
+
+    firstSlashRange = [self rangeOfCharacterFromSet:pathSeps()
+                                            options:NSLiteralSearch
+                                              range:((NSRange){0, length})];
+    if (firstSlashRange.length == 0) {
+        firstSlashRange.location = length;
+    }
+
+    /* FIXME ... should remove in future
+     * Anything beginning '~' followed by a single letter is assumed
+     * to be a windows drive specification.
+     */
+    if (firstSlashRange.location == 2 && isalpha([self characterAtIndex:1])) {
+        return IMMUTABLE(self);
+    }
+
+    if (firstSlashRange.location != 1) {
+        /* It is of the form `~username/blah/...' or '~username' */
+        int userNameLen;
+        NSString *uname;
+
+        if (firstSlashRange.length != 0) {
+            userNameLen = firstSlashRange.location - 1;
+        } else {
+            /* It is actually of the form `~username' */
+            userNameLen = [self length] - 1;
+            firstSlashRange.location = [self length];
+        }
+        uname = [self substringWithRange:((NSRange){1, userNameLen})];
+        homedir = NSHomeDirectoryForUser(uname);
+    } else {
+        /* It is of the form `~/blah/...' or is '~' */
+        homedir = NSHomeDirectory();
+    }
+
+    if (homedir != nil) {
+        if (firstSlashRange.location < length) {
+            return [homedir stringByAppendingPathComponent:
+                                [self substringFromIndex:firstSlashRange.location]];
+        } else {
+            return IMMUTABLE(homedir);
+        }
+    } else {
+        return IMMUTABLE(self);
+    }
+}
+
+- (NSString *)stringByAbbreviatingWithTildeInPath
+{
+    NSString *homedir;
+
+    if (YES == [self hasPrefix:@"~"]) {
+        return IMMUTABLE(self);
+    }
+    homedir = NSHomeDirectory();
+    if (NO == [self hasPrefix:homedir]) {
+        /* OSX compatibility ... we clean up the path to try to get a
+         * home directory we can abbreviate.
+         */
+        self = [self stringByStandardizingPath];
+        if (NO == [self hasPrefix:homedir]) {
+            return IMMUTABLE(self);
+        }
+    }
+    if ([self length] == [homedir length]) {
+        return @"~";
+    }
+    return [@"~" stringByAppendingPathComponent:
+                     [self substringFromIndex:[homedir length]]];
 }
 
 /**
@@ -4960,80 +4434,66 @@ static NSFileManager *fm = nil;
  * as required).  The first character from padString to be appended
  * is specified by padIndex.<br />
  */
-- (NSString*) stringByPaddingToLength: (NSUInteger)newLength
-			   withString: (NSString*)padString
-		      startingAtIndex: (NSUInteger)padIndex
+- (NSString *)stringByPaddingToLength:(NSUInteger)newLength
+                           withString:(NSString *)padString
+                      startingAtIndex:(NSUInteger)padIndex
 {
-  unsigned	length = [self length];
-  unsigned	padLength;
+    unsigned length = [self length];
+    unsigned padLength;
 
-  if (padString == nil || [padString isKindOfClass: [NSString class]] == NO)
-    {
-      [NSException raise: NSInvalidArgumentException
-	format: @"%@ - Illegal pad string", NSStringFromSelector(_cmd)];
+    if (padString == nil || [padString isKindOfClass:[NSString class]] == NO) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"%@ - Illegal pad string", NSStringFromSelector(_cmd)];
     }
-  padLength = [padString length];
-  if (padIndex >= padLength)
-    {
-      [NSException raise: NSRangeException
-	format: @"%@ - pad index larger too big", NSStringFromSelector(_cmd)];
+    padLength = [padString length];
+    if (padIndex >= padLength) {
+        [NSException raise:NSRangeException
+                    format:@"%@ - pad index larger too big", NSStringFromSelector(_cmd)];
     }
-  if (newLength == length)
-    {
-      return IMMUTABLE(self);
-    }
-  else if (newLength < length)
-    {
-      return [self substringToIndex: newLength];
-    }
-  else
-    {
-      length = newLength - length;	// What we want to add.
-      if (length <= (padLength - padIndex))
-	{
-	  NSRange	r;
+    if (newLength == length) {
+        return IMMUTABLE(self);
+    } else if (newLength < length) {
+        return [self substringToIndex:newLength];
+    } else {
+        length = newLength - length; // What we want to add.
+        if (length <= (padLength - padIndex)) {
+            NSRange r;
 
-	  r = NSMakeRange(padIndex, length);
-	  return [self stringByAppendingString:
-	    [padString substringWithRange: r]];
-	}
-      else
-	{
-	  NSMutableString	*m = [self mutableCopy];
+            r = NSMakeRange(padIndex, length);
+            return [self stringByAppendingString:
+                             [padString substringWithRange:r]];
+        } else {
+            NSMutableString *m = [self mutableCopy];
 
-	  if (padIndex > 0)
-	    {
-	      NSRange	r;
+            if (padIndex > 0) {
+                NSRange r;
 
-	      r = NSMakeRange(padIndex, padLength - padIndex);
-	      [m appendString: [padString substringWithRange: r]];
-	      length -= r.length;
-	    }
-	  /*
-	   * In case we have to append a small string lots of times,
-	   * we cache the method impllementation to do it.
-	   */
-	  if (length >= padLength)
-	    {
-	      void	(*appImp)(NSMutableString*, SEL, NSString*);
-	      SEL	appSel;
+                r = NSMakeRange(padIndex, padLength - padIndex);
+                [m appendString:[padString substringWithRange:r]];
+                length -= r.length;
+            }
+            /*
+             * In case we have to append a small string lots of times,
+             * we cache the method impllementation to do it.
+             */
+            if (length >= padLength) {
+                void (*appImp)(NSMutableString *, SEL, NSString *);
+                SEL appSel;
 
-	      appSel = @selector(appendString:);
-	      appImp = (void (*)(NSMutableString*, SEL, NSString*))
-		[m methodForSelector: appSel];
-	      while (length >= padLength)
-		{
-		  (*appImp)(m, appSel, padString);
-		  length -= padLength;
-		}
-	    }
-	  if (length > 0)
-	    {
-	      [m appendString:
-		[padString substringWithRange: NSMakeRange(0, length)]];
-	    }
-	  return AUTORELEASE(m);
-	}
+                appSel = @selector(appendString:);
+                appImp = (void (*)(NSMutableString *, SEL, NSString *))
+                    [m methodForSelector:appSel];
+                while (length >= padLength) {
+                    (*appImp)(m, appSel, padString);
+                    length -= padLength;
+                }
+            }
+            if (length > 0) {
+                [m appendString:
+                        [padString substringWithRange:NSMakeRange(0, length)]];
+            }
+            return AUTORELEASE(m);
+        }
     }
 }
 
@@ -5043,485 +4503,387 @@ static NSFileManager *fm = nil;
  * the specified encoding.<br />
  * Returns nil if the result is not a string in the specified encoding.
  */
-- (NSString*) stringByReplacingPercentEscapesUsingEncoding: (NSStringEncoding)e
+- (NSString *)stringByReplacingPercentEscapesUsingEncoding:(NSStringEncoding)e
 {
-  NSMutableData	*d;
-  NSString	*s = nil;
+    NSMutableData *d;
+    NSString *s = nil;
 
-  d = [[self dataUsingEncoding: NSASCIIStringEncoding] mutableCopy];
-  if (d != nil)
-    {
-      unsigned char	*p = (unsigned char*)[d mutableBytes];
-      unsigned		l = [d length];
-      unsigned		i = 0;
-      unsigned		j = 0;
+    d = [[self dataUsingEncoding:NSASCIIStringEncoding] mutableCopy];
+    if (d != nil) {
+        unsigned char *p = (unsigned char *)[d mutableBytes];
+        unsigned l = [d length];
+        unsigned i = 0;
+        unsigned j = 0;
 
-      while (i < l)
-	{
-	  unsigned char	t;
+        while (i < l) {
+            unsigned char t;
 
-	  if ((t = p[i++]) == '%')
-	    {
-	      unsigned char	c;
+            if ((t = p[i++]) == '%') {
+                unsigned char c;
 
-	      if (i >= l)
-		{
-		  DESTROY(d);
-		  break;
-		}
-	      t = p[i++];
+                if (i >= l) {
+                    DESTROY(d);
+                    break;
+                }
+                t = p[i++];
 
-	      if (isxdigit(t))
-		{
-		  if (t <= '9')
-		    {
-		      c = t - '0';
-		    }
-		  else if (t <= 'F')
-		    {
-		      c = t - 'A' + 10;
-		    }
-		  else
-		    {
-		      c = t - 'a' + 10;
-		    }
-		}
-	      else
-		{
-		  DESTROY(d);
-		  break;
-		}
-	      c <<= 4;
+                if (isxdigit(t)) {
+                    if (t <= '9') {
+                        c = t - '0';
+                    } else if (t <= 'F') {
+                        c = t - 'A' + 10;
+                    } else {
+                        c = t - 'a' + 10;
+                    }
+                } else {
+                    DESTROY(d);
+                    break;
+                }
+                c <<= 4;
 
-	      if (i >= l)
-		{
-		  DESTROY(d);
-		  break;
-		}
-	      t = p[i++];
-	      if (isxdigit(t))
-		{
-		  if (t <= '9')
-		    {
-		      c |= t - '0';
-		    }
-		  else if (t <= 'F')
-		    {
-		      c |= t - 'A' + 10;
-		    }
-		  else
-		    {
-		      c |= t - 'a' + 10;
-		    }
-		}
-	      else
-		{
-		  DESTROY(d);
-		  break;
-		}
-	      p[j++] = c;
-	    }
-	  else
-	    {
-	      p[j++] = t;
-	    }
-	}
-      [d setLength: j];
-      s = AUTORELEASE([[NSString alloc] initWithData: d encoding: e]);
-      RELEASE(d);
+                if (i >= l) {
+                    DESTROY(d);
+                    break;
+                }
+                t = p[i++];
+                if (isxdigit(t)) {
+                    if (t <= '9') {
+                        c |= t - '0';
+                    } else if (t <= 'F') {
+                        c |= t - 'A' + 10;
+                    } else {
+                        c |= t - 'a' + 10;
+                    }
+                } else {
+                    DESTROY(d);
+                    break;
+                }
+                p[j++] = c;
+            } else {
+                p[j++] = t;
+            }
+        }
+        [d setLength:j];
+        s = AUTORELEASE([[NSString alloc] initWithData:d encoding:e]);
+        RELEASE(d);
     }
-  return s;
+    return s;
 }
 
-- (NSString*) stringByResolvingSymlinksInPath
+- (NSString *)stringByResolvingSymlinksInPath
 {
-  NSString	*s = self;
+    NSString *s = self;
 
-  if (0 == [s length])
-    {
-      return @"";
+    if (0 == [s length]) {
+        return @"";
     }
-  if ('~' == [s characterAtIndex: 0])
-    {
-      s = [s stringByExpandingTildeInPath];
+    if ('~' == [s characterAtIndex:0]) {
+        s = [s stringByExpandingTildeInPath];
     }
 #if defined(_WIN32)
-  return IMMUTABLE(s);
-#else
-
-{
-  #if defined(__GLIBC__) || defined(__FreeBSD__)
-  #define GS_MAXSYMLINKS sysconf(_SC_SYMLOOP_MAX)
-  #else
-  #define GS_MAXSYMLINKS MAXSYMLINKS
-  #endif
- 
-  #ifndef PATH_MAX
-  #define PATH_MAX 1024
-  /* Don't use realpath unless we know we have the correct path size limit */
-  #ifdef        HAVE_REALPATH
-  #undef        HAVE_REALPATH
-  #endif
-  #endif
-  char		newBuf[PATH_MAX];
-#ifdef HAVE_REALPATH
-
-  if (realpath([s fileSystemRepresentation], newBuf) == 0)
     return IMMUTABLE(s);
 #else
-  char		extra[PATH_MAX];
-  char		*dest;
-  const char	*name = [s fileSystemRepresentation];
-  const char	*start;
-  const	char	*end;
-  unsigned	num_links = 0;
 
-  if (name[0] != '/')
     {
-      if (!getcwd(newBuf, PATH_MAX))
-	{
-	  return IMMUTABLE(s);	/* Couldn't get directory.	*/
-	}
-      dest = strchr(newBuf, '\0');
-    }
-  else
-    {
-      newBuf[0] = '/';
-      dest = &newBuf[1];
-    }
+#if defined(__GLIBC__) || defined(__FreeBSD__)
+#define GS_MAXSYMLINKS sysconf(_SC_SYMLOOP_MAX)
+#else
+#define GS_MAXSYMLINKS MAXSYMLINKS
+#endif
 
-  for (start = end = name; *start; start = end)
-    {
-      struct stat	st;
-      int		n;
-      int		len;
+#ifndef PATH_MAX
+#define PATH_MAX 1024
+/* Don't use realpath unless we know we have the correct path size limit */
+#ifdef HAVE_REALPATH
+#undef HAVE_REALPATH
+#endif
+#endif
+        char newBuf[PATH_MAX];
+#ifdef HAVE_REALPATH
 
-      /* Elide repeated path separators	*/
-      while (*start == '/')
-	{
-	  start++;
-	}
-      /* Locate end of path component	*/
-      end = start;
-      while (*end && *end != '/')
-	{
-	  end++;
-	}
-      len = end - start;
-      if (len == 0)
-	{
-	  break;	/* End of path.	*/
-	}
-      else if (len == 1 && *start == '.')
-	{
-          /* Elide '/./' sequence by ignoring it.	*/
-	}
-      else if (len == 2 && strncmp(start, "..", len) == 0)
-	{
-	  /*
-	   * Backup - if we are not at the root, remove the last component.
-	   */
-	  if (dest > &newBuf[1])
-	    {
-	      do
-		{
-		  dest--;
-		}
-	      while (dest[-1] != '/');
-	    }
-	}
-      else
-        {
-          if (dest[-1] != '/')
-	    {
-	      *dest++ = '/';
-	    }
-          if (&dest[len] >= &newBuf[PATH_MAX])
-	    {
-	      return IMMUTABLE(s);	/* Resolved name too long.	*/
-	    }
-          memmove(dest, start, len);
-          dest += len;
-          *dest = '\0';
+        if (realpath([s fileSystemRepresentation], newBuf) == 0)
+            return IMMUTABLE(s);
+#else
+        char extra[PATH_MAX];
+        char *dest;
+        const char *name = [s fileSystemRepresentation];
+        const char *start;
+        const char *end;
+        unsigned num_links = 0;
 
-          if (lstat(newBuf, &st) < 0)
-	    {
-	      return IMMUTABLE(s);	/* Unable to stat file.		*/
-	    }
-          if (S_ISLNK(st.st_mode))
-            {
-              char	buf[PATH_MAX];
-	      int	l;
-
-              if (++num_links > GS_MAXSYMLINKS)
-		{
-		  return IMMUTABLE(s);	/* Too many links.	*/
-		}
-              n = readlink(newBuf, buf, PATH_MAX);
-              if (n < 0)
-		{
-		  return IMMUTABLE(s);	/* Couldn't resolve.	*/
-		}
-              buf[n] = '\0';
-
-	      l = strlen(end);
-              if ((n + l) >= PATH_MAX)
-		{
-		  return IMMUTABLE(s);	/* Path too long.	*/
-		}
-	      /*
-	       * Concatenate the resolved name with the string still to
-	       * be processed, and start using the result as input.
-	       */
-              memcpy(buf + n, end, l);
-	      n += l;
-	      buf[n] = '\0';
-              memcpy(extra, buf, n);
-	      extra[n] = '\0';
-              name = end = extra;
-
-              if (buf[0] == '/')
-		{
-		  /*
-		   * For an absolute link, we start at root again.
-		   */
-		  dest = newBuf + 1;
-		}
-              else
-		{
-		  /*
-		   * Backup - remove the last component.
-		   */
-		  if (dest > newBuf + 1)
-		    {
-		      do
-			{
-			  dest--;
-			}
-		      while (dest[-1] != '/');
-		    }
-		}
+        if (name[0] != '/') {
+            if (!getcwd(newBuf, PATH_MAX)) {
+                return IMMUTABLE(s); /* Couldn't get directory.	*/
             }
-          else
-	    {
-	      num_links = 0;
-	    }
+            dest = strchr(newBuf, '\0');
+        } else {
+            newBuf[0] = '/';
+            dest = &newBuf[1];
+        }
+
+        for (start = end = name; *start; start = end) {
+            struct stat st;
+            int n;
+            int len;
+
+            /* Elide repeated path separators	*/
+            while (*start == '/') {
+                start++;
+            }
+            /* Locate end of path component	*/
+            end = start;
+            while (*end && *end != '/') {
+                end++;
+            }
+            len = end - start;
+            if (len == 0) {
+                break; /* End of path.	*/
+            } else if (len == 1 && *start == '.') {
+                /* Elide '/./' sequence by ignoring it.	*/
+            } else if (len == 2 && strncmp(start, "..", len) == 0) {
+                /*
+                 * Backup - if we are not at the root, remove the last component.
+                 */
+                if (dest > &newBuf[1]) {
+                    do {
+                        dest--;
+                    } while (dest[-1] != '/');
+                }
+            } else {
+                if (dest[-1] != '/') {
+                    *dest++ = '/';
+                }
+                if (&dest[len] >= &newBuf[PATH_MAX]) {
+                    return IMMUTABLE(s); /* Resolved name too long.	*/
+                }
+                memmove(dest, start, len);
+                dest += len;
+                *dest = '\0';
+
+                if (lstat(newBuf, &st) < 0) {
+                    return IMMUTABLE(s); /* Unable to stat file.		*/
+                }
+                if (S_ISLNK(st.st_mode)) {
+                    char buf[PATH_MAX];
+                    int l;
+
+                    if (++num_links > GS_MAXSYMLINKS) {
+                        return IMMUTABLE(s); /* Too many links.	*/
+                    }
+                    n = readlink(newBuf, buf, PATH_MAX);
+                    if (n < 0) {
+                        return IMMUTABLE(s); /* Couldn't resolve.	*/
+                    }
+                    buf[n] = '\0';
+
+                    l = strlen(end);
+                    if ((n + l) >= PATH_MAX) {
+                        return IMMUTABLE(s); /* Path too long.	*/
+                    }
+                    /*
+                     * Concatenate the resolved name with the string still to
+                     * be processed, and start using the result as input.
+                     */
+                    memcpy(buf + n, end, l);
+                    n += l;
+                    buf[n] = '\0';
+                    memcpy(extra, buf, n);
+                    extra[n] = '\0';
+                    name = end = extra;
+
+                    if (buf[0] == '/') {
+                        /*
+                         * For an absolute link, we start at root again.
+                         */
+                        dest = newBuf + 1;
+                    } else {
+                        /*
+                         * Backup - remove the last component.
+                         */
+                        if (dest > newBuf + 1) {
+                            do {
+                                dest--;
+                            } while (dest[-1] != '/');
+                        }
+                    }
+                } else {
+                    num_links = 0;
+                }
+            }
+        }
+        if (dest > newBuf + 1 && dest[-1] == '/') {
+            --dest;
+        }
+        *dest = '\0';
+#endif
+        if (strncmp(newBuf, "/private/", 9) == 0) {
+            struct stat st;
+
+            if (lstat(&newBuf[8], &st) == 0) {
+                int l = strlen(newBuf) - 7;
+
+                memmove(newBuf, &newBuf[8], l);
+            }
+        }
+        return [[NSFileManager defaultManager]
+            stringWithFileSystemRepresentation:newBuf
+                                        length:strlen(newBuf)];
+    }
+#endif
+}
+
+- (NSString *)stringByStandardizingPath
+{
+    NSMutableString *s;
+    NSRange r;
+    unichar (*caiImp)(NSString *, SEL, NSUInteger);
+    unsigned int l = [self length];
+    unichar c;
+    unsigned root;
+
+    if (l == 0) {
+        return @"";
+    }
+    c = [self characterAtIndex:0];
+    if (c == '~') {
+        s = AUTORELEASE([[self stringByExpandingTildeInPath] mutableCopy]);
+    } else {
+        s = AUTORELEASE([self mutableCopy]);
+    }
+
+    /* We must always use the standard path separator unless specifically set
+     * to use the mswindows one.  That ensures that standardised paths and
+     * anything built by adding path components to them use a consistent
+     * separator character anad can be compared readily using standard string
+     * comparisons.
+     */
+    if (GSPathHandlingWindows() == YES) {
+        [s replaceString:@"/" withString:@"\\"];
+    } else {
+        [s replaceString:@"\\" withString:@"/"];
+    }
+
+    l = [s length];
+    root = rootOf(s, l);
+
+    caiImp = (unichar(*)())[s methodForSelector:caiSel];
+
+    /* Remove any separators ('/') immediately after the trailing
+     * separator in the root (if any).
+     */
+    if (root > 0 && YES == pathSepMember((*caiImp)(s, caiSel, root - 1))) {
+        unsigned i;
+
+        for (i = root; i < l; i++) {
+            if (NO == pathSepMember((*caiImp)(s, caiSel, i))) {
+                break;
+            }
+        }
+        if (i > root) {
+            r = (NSRange){root, i - root};
+            [s deleteCharactersInRange:r];
+            l -= r.length;
         }
     }
-  if (dest > newBuf + 1 && dest[-1] == '/')
-    {
-      --dest;
-    }
-  *dest = '\0';
-#endif
-  if (strncmp(newBuf, "/private/", 9) == 0)
-    {
-      struct stat	st;
 
-      if (lstat(&newBuf[8], &st) == 0)
-	{
-	  int	l = strlen(newBuf) - 7;
-
-	  memmove(newBuf, &newBuf[8], l);
-	}
-    }
-  return [[NSFileManager defaultManager]
-   stringWithFileSystemRepresentation: newBuf length: strlen(newBuf)];
-}
-#endif
-}
-
-- (NSString*) stringByStandardizingPath
-{
-  NSMutableString	*s;
-  NSRange		r;
-  unichar		(*caiImp)(NSString*, SEL, NSUInteger);
-  unsigned int		l = [self length];
-  unichar		c;
-  unsigned		root;
-
-  if (l == 0)
-    {
-      return @"";
-    }
-  c = [self characterAtIndex: 0];
-  if (c == '~')
-    {
-      s = AUTORELEASE([[self stringByExpandingTildeInPath] mutableCopy]);
-    }
-  else
-    {
-      s = AUTORELEASE([self mutableCopy]);
+    /* Condense multiple separator ('/') sequences.
+     */
+    r = (NSRange){root, l - root};
+    while ((r = [s rangeOfCharacterFromSet:pathSeps()
+                                   options:0
+                                     range:r])
+               .length == 1) {
+        while (NSMaxRange(r) < l && pathSepMember((*caiImp)(s, caiSel, NSMaxRange(r))) == YES) {
+            r.length++;
+        }
+        r.location++;
+        r.length--;
+        if (r.length > 0) {
+            [s deleteCharactersInRange:r];
+            l -= r.length;
+        }
+        r.length = l - r.location;
     }
 
-  /* We must always use the standard path separator unless specifically set
-   * to use the mswindows one.  That ensures that standardised paths and
-   * anything built by adding path components to them use a consistent
-   * separator character anad can be compared readily using standard string
-   * comparisons.
-   */
-  if (GSPathHandlingWindows() == YES)
-    {
-      [s replaceString: @"/" withString: @"\\"];
-    }
-  else
-    {
-      [s replaceString: @"\\" withString: @"/"];
+    /* Remove trailing ('.') as long as it's preceeded by a path separator.
+     * As a special case for OSX compatibility, we only remove the trailing
+     * dot if it's not immediately after the root.
+     */
+    if (l > root + 1 && (*caiImp)(s, caiSel, l - 1) == '.' && pathSepMember((*caiImp)(s, caiSel, l - 2)) == YES) {
+        l--;
+        [s deleteCharactersInRange:NSMakeRange(l, 1)];
     }
 
-  l = [s length];
-  root = rootOf(s, l);
-
-  caiImp = (unichar (*)())[s methodForSelector: caiSel];
-
-  /* Remove any separators ('/') immediately after the trailing
-   * separator in the root (if any).
-   */
-  if (root > 0 && YES == pathSepMember((*caiImp)(s, caiSel, root-1)))
-    {
-      unsigned	i;
-
-      for (i = root; i < l; i++)
-	{
-	  if (NO == pathSepMember((*caiImp)(s, caiSel, i)))
-	    {
-	      break;
-	    }
-	}
-      if (i > root)
-	{
-	  r = (NSRange){root, i-root};
-	  [s deleteCharactersInRange: r];
-	  l -= r.length;
-	}
+    // Condense ('/./') sequences.
+    r = (NSRange){root, l - root};
+    while ((r = [s rangeOfString:@"." options:0 range:r locale:nil]).length == 1) {
+        if (r.location > 0 && r.location < l - 1 && pathSepMember((*caiImp)(s, caiSel, r.location - 1)) == YES && pathSepMember((*caiImp)(s, caiSel, r.location + 1)) == YES) {
+            r.length++;
+            [s deleteCharactersInRange:r];
+            l -= r.length;
+        } else {
+            r.location++;
+        }
+        r.length = l - r.location;
     }
 
-  /* Condense multiple separator ('/') sequences.
-   */
-  r = (NSRange){root, l-root};
-  while ((r = [s rangeOfCharacterFromSet: pathSeps()
-				 options: 0
-				   range: r]).length == 1)
-    {
-      while (NSMaxRange(r) < l
-	&& pathSepMember((*caiImp)(s, caiSel, NSMaxRange(r))) == YES)
-	{
-	  r.length++;
-	}
-      r.location++;
-      r.length--;
-      if (r.length > 0)
-	{
-	  [s deleteCharactersInRange: r];
-	  l -= r.length;
-	}
-      r.length = l - r.location;
+    // Strip trailing '/' if present.
+    if (l > root && pathSepMember([s characterAtIndex:l - 1]) == YES) {
+        r.length = 1;
+        r.location = l - r.length;
+        [s deleteCharactersInRange:r];
+        l -= r.length;
     }
 
-  /* Remove trailing ('.') as long as it's preceeded by a path separator.
-   * As a special case for OSX compatibility, we only remove the trailing
-   * dot if it's not immediately after the root.
-   */
-  if (l > root + 1 && (*caiImp)(s, caiSel, l-1) == '.'
-    && pathSepMember((*caiImp)(s, caiSel, l-2)) == YES)
-    {
-      l--;
-      [s deleteCharactersInRange: NSMakeRange(l, 1)];
+    if ([s isAbsolutePath] == NO) {
+        return s;
     }
 
-  // Condense ('/./') sequences.
-  r = (NSRange){root, l-root};
-  while ((r = [s rangeOfString: @"." options: 0 range: r locale: nil]).length
-    == 1)
-    {
-      if (r.location > 0 && r.location < l - 1
-	&& pathSepMember((*caiImp)(s, caiSel, r.location-1)) == YES
-	&& pathSepMember((*caiImp)(s, caiSel, r.location+1)) == YES)
-	{
-	  r.length++;
-	  [s deleteCharactersInRange: r];
-	  l -= r.length;
-	}
-      else
-	{
-	  r.location++;
-	}
-      r.length = l - r.location;
+    // Remove leading `/private' if present.
+    if ([s hasPrefix:@"/private"]) {
+        [s deleteCharactersInRange:((NSRange){0, 8})];
+        l -= 8;
     }
 
-  // Strip trailing '/' if present.
-  if (l > root && pathSepMember([s characterAtIndex: l - 1]) == YES)
-    {
-      r.length = 1;
-      r.location = l - r.length;
-      [s deleteCharactersInRange: r];
-      l -= r.length;
+    /*
+     *	For absolute paths, we must
+     *	remove '/../' sequences and their matching parent directories.
+     */
+    r = (NSRange){root, l - root};
+    while ((r = [s rangeOfString:@".." options:0 range:r locale:nil]).length == 2) {
+        if (r.location > 0 && pathSepMember((*caiImp)(s, caiSel, r.location - 1)) == YES && (NSMaxRange(r) == l || pathSepMember((*caiImp)(s, caiSel, NSMaxRange(r))) == YES)) {
+            BOOL atEnd = (NSMaxRange(r) == l) ? YES : NO;
+
+            if (r.location > root) {
+                NSRange r2;
+
+                r.location--;
+                r.length++;
+                r2 = NSMakeRange(root, r.location - root);
+                r = [s rangeOfCharacterFromSet:pathSeps()
+                                       options:NSBackwardsSearch
+                                         range:r2];
+                if (r.length == 0) {
+                    r = r2; // Location just after root
+                    r.length++;
+                } else {
+                    r.length = NSMaxRange(r2) - r.location;
+                    r.location++; // Location Just after last separator
+                }
+                r.length += 2; // Add the `..'
+            }
+            if (NO == atEnd) {
+                r.length++; // Add the '/' after the '..'
+            }
+            [s deleteCharactersInRange:r];
+            l -= r.length;
+        } else {
+            r.location++;
+        }
+        r.length = l - r.location;
     }
 
-  if ([s isAbsolutePath] == NO)
-    {
-      return s;
-    }
-
-  // Remove leading `/private' if present.
-  if ([s hasPrefix: @"/private"])
-    {
-      [s deleteCharactersInRange: ((NSRange){0,8})];
-      l -= 8;
-    }
-
-  /*
-   *	For absolute paths, we must 
-   *	remove '/../' sequences and their matching parent directories.
-   */
-  r = (NSRange){root, l-root};
-  while ((r = [s rangeOfString: @".." options: 0 range: r locale: nil]).length
-    == 2)
-    {
-      if (r.location > 0
-	&& pathSepMember((*caiImp)(s, caiSel, r.location-1)) == YES
-        && (NSMaxRange(r) == l
-	  || pathSepMember((*caiImp)(s, caiSel, NSMaxRange(r))) == YES))
-	{
-	  BOOL	atEnd = (NSMaxRange(r) == l) ? YES : NO;
-
-	  if (r.location > root)
-	    {
-	      NSRange r2;
-
-	      r.location--;
-	      r.length++;
-	      r2 = NSMakeRange(root, r.location-root);
-	      r = [s rangeOfCharacterFromSet: pathSeps()
-				     options: NSBackwardsSearch
-				       range: r2];
-	      if (r.length == 0)
-		{
-		  r = r2;	// Location just after root
-		  r.length++;
-		}
-	      else
-		{
-		  r.length = NSMaxRange(r2) - r.location;
-	          r.location++;		// Location Just after last separator
-		}
-	      r.length += 2;		// Add the `..' 
-	    }
-	  if (NO == atEnd)
-	    {
-	      r.length++;		// Add the '/' after the '..'
-	    }
-	  [s deleteCharactersInRange: r];
-	  l -= r.length;
-	}
-      else
-	{
-	  r.location++;
-	}
-      r.length = l - r.location;
-    }
-
-  return IMMUTABLE(s);
+    return IMMUTABLE(s);
 }
 
 /**
@@ -5531,253 +4893,224 @@ static NSFileManager *fm = nil;
  * string is returned.<br />
  * The aSet argument must not be nil.<br />
  */
-- (NSString*) stringByTrimmingCharactersInSet: (NSCharacterSet*)aSet
+- (NSString *)stringByTrimmingCharactersInSet:(NSCharacterSet *)aSet
 {
-  unsigned	length = [self length];
-  unsigned	end = length;
-  unsigned	start = 0;
+    unsigned length = [self length];
+    unsigned end = length;
+    unsigned start = 0;
 
-  if (aSet == nil)
-    {
-      [NSException raise: NSInvalidArgumentException
-	format: @"%@ - nil character set argument", NSStringFromSelector(_cmd)];
+    if (aSet == nil) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"%@ - nil character set argument", NSStringFromSelector(_cmd)];
     }
-  if (length > 0)
-    {
-      unichar	(*caiImp)(NSString*, SEL, NSUInteger);
-      BOOL	(*mImp)(id, SEL, unichar);
-      unichar	letter;
+    if (length > 0) {
+        unichar (*caiImp)(NSString *, SEL, NSUInteger);
+        BOOL (*mImp)
+        (id, SEL, unichar);
+        unichar letter;
 
-      caiImp = (unichar (*)())[self methodForSelector: caiSel];
-      mImp = (BOOL(*)(id,SEL,unichar)) [aSet methodForSelector: cMemberSel];
+        caiImp = (unichar(*)())[self methodForSelector:caiSel];
+        mImp = (BOOL(*)(id, SEL, unichar))[aSet methodForSelector:cMemberSel];
 
-      while (end > 0)
-	{
-	  letter = (*caiImp)(self, caiSel, end-1);
-	  if ((*mImp)(aSet, cMemberSel, letter) == NO)
-	    {
-	      break;
-	    }
-	  end--;
-	}
-      while (start < end)
-	{
-	  letter = (*caiImp)(self, caiSel, start);
-	  if ((*mImp)(aSet, cMemberSel, letter) == NO)
-	    {
-	      break;
-	    }
-	  start++;
-	}
+        while (end > 0) {
+            letter = (*caiImp)(self, caiSel, end - 1);
+            if ((*mImp)(aSet, cMemberSel, letter) == NO) {
+                break;
+            }
+            end--;
+        }
+        while (start < end) {
+            letter = (*caiImp)(self, caiSel, start);
+            if ((*mImp)(aSet, cMemberSel, letter) == NO) {
+                break;
+            }
+            start++;
+        }
     }
-  if (start == 0 && end == length)
-    {
-      return IMMUTABLE(self);
+    if (start == 0 && end == length) {
+        return IMMUTABLE(self);
     }
-  if (start == end)
-    {
-      return @"";
+    if (start == end) {
+        return @"";
     }
-  return [self substringFromRange: NSMakeRange(start, end - start)];
+    return [self substringFromRange:NSMakeRange(start, end - start)];
 }
 
 // private methods for Unicode level 3 implementation
-- (int) _baseLength
+- (int)_baseLength
 {
-  int		blen = 0;
-  unsigned	len = [self length];
+    int blen = 0;
+    unsigned len = [self length];
 
-  if (len > 0)
-    {
-      unsigned int	count = 0;
-      unichar	(*caiImp)(NSString*, SEL, NSUInteger);
+    if (len > 0) {
+        unsigned int count = 0;
+        unichar (*caiImp)(NSString *, SEL, NSUInteger);
 
-      caiImp = (unichar (*)())[self methodForSelector: caiSel];
-      while (count < len)
-	{
-	  if (!uni_isnonsp((*caiImp)(self, caiSel, count++)))
-	    {
-	      blen++;
-	    }
-	}
+        caiImp = (unichar(*)())[self methodForSelector:caiSel];
+        while (count < len) {
+            if (!uni_isnonsp((*caiImp)(self, caiSel, count++))) {
+                blen++;
+            }
+        }
     }
-  return blen;
+    return blen;
 }
 
-+ (NSString*) pathWithComponents: (NSArray*)components
++ (NSString *)pathWithComponents:(NSArray *)components
 {
-  NSString	*s;
-  unsigned	c;
-  unsigned	i;
+    NSString *s;
+    unsigned c;
+    unsigned i;
 
-  c = [components count];
-  if (c == 0)
-    {
-      return @"";
+    c = [components count];
+    if (c == 0) {
+        return @"";
     }
-  s = [components objectAtIndex: 0];
-  if ([s length] == 0)
-    {
-      s = pathSepString();
+    s = [components objectAtIndex:0];
+    if ([s length] == 0) {
+        s = pathSepString();
     }
-  for (i = 1; i < c; i++)
-    {
-      s = [s stringByAppendingPathComponent: [components objectAtIndex: i]];
+    for (i = 1; i < c; i++) {
+        s = [s stringByAppendingPathComponent:[components objectAtIndex:i]];
     }
-  return s;
+    return s;
 }
 
-- (BOOL) isAbsolutePath
+- (BOOL)isAbsolutePath
 {
-  unichar	c;
-  unsigned	l = [self length];
-  unsigned	root;
+    unichar c;
+    unsigned l = [self length];
+    unsigned root;
 
-  if (l == 0)
-    {
-      return NO;		// Empty string ... relative
+    if (l == 0) {
+        return NO; // Empty string ... relative
     }
-  c = [self characterAtIndex: 0];
-  if (c == (unichar)'~')
-    {
-      return YES;		// Begins with tilde ... absolute
+    c = [self characterAtIndex:0];
+    if (c == (unichar)'~') {
+        return YES; // Begins with tilde ... absolute
     }
 
-  /*
-   * Any string beginning with '/' is absolute ... except in windows mode
-   * or on windows and not in unix mode.
-   */
-  if (c == pathSepChar())
-    {
+    /*
+     * Any string beginning with '/' is absolute ... except in windows mode
+     * or on windows and not in unix mode.
+     */
+    if (c == pathSepChar()) {
 #if defined(_WIN32)
-      if (GSPathHandlingUnix() == YES)
-	{
-	  return YES;
-	}
+        if (GSPathHandlingUnix() == YES) {
+            return YES;
+        }
 #else
-      if (GSPathHandlingWindows() == NO)
-	{
-	  return YES;
-	}
+        if (GSPathHandlingWindows() == NO) {
+            return YES;
+        }
 #endif
-     }
-
-  /*
-   * Any root over two characters long must be a drive specification with a
-   * slash (absolute) or a UNC path (always absolute).
-   */
-  root = rootOf(self, l);
-  if (root > 2)
-    {
-      return YES;		// UNC or C:/ ... absolute
     }
 
-  /*
-   * What we have left are roots of the form 'C:' or '\' or a path
-   * with no root, or a '/' (in windows mode only sence we already
-   * handled a single slash in unix mode) ...
-   * all these cases are relative paths.
-   */
-  return NO;
+    /*
+     * Any root over two characters long must be a drive specification with a
+     * slash (absolute) or a UNC path (always absolute).
+     */
+    root = rootOf(self, l);
+    if (root > 2) {
+        return YES; // UNC or C:/ ... absolute
+    }
+
+    /*
+     * What we have left are roots of the form 'C:' or '\' or a path
+     * with no root, or a '/' (in windows mode only sence we already
+     * handled a single slash in unix mode) ...
+     * all these cases are relative paths.
+     */
+    return NO;
 }
 
-- (NSArray*) pathComponents
+- (NSArray *)pathComponents
 {
-  NSMutableArray	*a;
-  NSArray		*r;
-  NSString		*s = self;
-  unsigned int		l = [s length];
-  unsigned int		root;
-  unsigned int		i;
-  NSRange		range;
+    NSMutableArray *a;
+    NSArray *r;
+    NSString *s = self;
+    unsigned int l = [s length];
+    unsigned int root;
+    unsigned int i;
+    NSRange range;
 
-  if (l == 0)
-    {
-      return [NSArray array];
+    if (l == 0) {
+        return [NSArray array];
     }
-  root = rootOf(s, l);
-  a = [[NSMutableArray alloc] initWithCapacity: 8];
-  if (root > 0)
-    {
-      [a addObject: [s substringToIndex: root]];
+    root = rootOf(s, l);
+    a = [[NSMutableArray alloc] initWithCapacity:8];
+    if (root > 0) {
+        [a addObject:[s substringToIndex:root]];
     }
-  i = root;
+    i = root;
 
-  while (i < l)
-    {
-      range = [s rangeOfCharacterFromSet: pathSeps()
-				 options: NSLiteralSearch
-				   range: ((NSRange){i, l - i})];
-      if (range.length > 0)
-	{
-	  if (range.location > i)
-	    {
-	      [a addObject: [s substringWithRange:
-		NSMakeRange(i, range.location - i)]];
-	    }
-	  i = NSMaxRange(range);
-	}
-      else
-	{
-	  [a addObject: [s substringFromIndex: i]];
-	  i = l;
-	}
+    while (i < l) {
+        range = [s rangeOfCharacterFromSet:pathSeps()
+                                   options:NSLiteralSearch
+                                     range:((NSRange){i, l - i})];
+        if (range.length > 0) {
+            if (range.location > i) {
+                [a addObject:[s substringWithRange:
+                                     NSMakeRange(i, range.location - i)]];
+            }
+            i = NSMaxRange(range);
+        } else {
+            [a addObject:[s substringFromIndex:i]];
+            i = l;
+        }
     }
 
-  /*
-   * If the path ended with a path separator which was not already
-   * added as part of the root, add it as final component.
-   */
-  if (l > root && pathSepMember([s characterAtIndex: l-1]))
-    {
-      [a addObject: pathSepString()];
+    /*
+     * If the path ended with a path separator which was not already
+     * added as part of the root, add it as final component.
+     */
+    if (l > root && pathSepMember([s characterAtIndex:l - 1])) {
+        [a addObject:pathSepString()];
     }
 
-  r = [a copy];
-  RELEASE(a);
-  return AUTORELEASE(r);
+    r = [a copy];
+    RELEASE(a);
+    return AUTORELEASE(r);
 }
 
-- (NSArray*) stringsByAppendingPaths: (NSArray*)paths
+- (NSArray *)stringsByAppendingPaths:(NSArray *)paths
 {
-  NSMutableArray	*a;
-  NSArray		*r;
-  unsigned		i, count = [paths count];
+    NSMutableArray *a;
+    NSArray *r;
+    unsigned i, count = [paths count];
 
-  a = [[NSMutableArray allocWithZone: NSDefaultMallocZone()]
-	initWithCapacity: count];
-  for (i = 0; i < count; i++)
-    {
-      NSString	*s = [paths objectAtIndex: i];
+    a = [[NSMutableArray allocWithZone:NSDefaultMallocZone()]
+        initWithCapacity:count];
+    for (i = 0; i < count; i++) {
+        NSString *s = [paths objectAtIndex:i];
 
-      s = [self stringByAppendingPathComponent: s];
-      [a addObject: s];
+        s = [self stringByAppendingPathComponent:s];
+        [a addObject:s];
     }
-  r = [a copy];
-  RELEASE(a);
-  return AUTORELEASE(r);
+    r = [a copy];
+    RELEASE(a);
+    return AUTORELEASE(r);
 }
 
 /**
  * Returns an autoreleased string with given format using the default locale.
  */
-+ (NSString*) localizedStringWithFormat: (NSString*) format, ...
++ (NSString *)localizedStringWithFormat:(NSString *)format, ...
 {
-  va_list ap;
-  id ret;
+    va_list ap;
+    id ret;
 
-  va_start(ap, format);
-  if (format == nil)
-    {
-      ret = nil;
+    va_start(ap, format);
+    if (format == nil) {
+        ret = nil;
+    } else {
+        ret = AUTORELEASE([[self allocWithZone:NSDefaultMallocZone()]
+            initWithFormat:format
+                    locale:GSPrivateDefaultLocale()
+                 arguments:ap]);
     }
-  else
-    {
-      ret = AUTORELEASE([[self allocWithZone: NSDefaultMallocZone()]
-        initWithFormat: format locale: GSPrivateDefaultLocale() arguments: ap]);
-    }
-  va_end(ap);
-  return ret;
+    va_end(ap);
+    return ret;
 }
 
 /**
@@ -5785,22 +5118,23 @@ static NSFileManager *fm = nil;
  * -compare:options:range: with the <code>NSCaseInsensitiveSearch</code>
  * option, in the default locale.
  */
-- (NSComparisonResult) caseInsensitiveCompare: (NSString*)aString
+- (NSComparisonResult)caseInsensitiveCompare:(NSString *)aString
 {
-  if (aString == self) return NSOrderedSame;
-  return [self compare: aString
-	       options: NSCaseInsensitiveSearch
-		 range: ((NSRange){0, [self length]})];
+    if (aString == self)
+        return NSOrderedSame;
+    return [self compare:aString
+                 options:NSCaseInsensitiveSearch
+                   range:((NSRange){0, [self length]})];
 }
 
 /**
  * <p>Compares this instance with string. If locale is an NSLocale
- * instance and ICU is available, performs a comparison using the 
- * ICU collator for that locale. If locale is an instance of a class 
+ * instance and ICU is available, performs a comparison using the
+ * ICU collator for that locale. If locale is an instance of a class
  * other than NSLocale, perform a comparison using +[NSLocale currentLocale].
  * If locale is nil, or ICU is not available, use a POSIX-style
  * collation (for example, latin capital letters A-Z are ordered before
- * all of the lowercase letter, a-z.) 
+ * all of the lowercase letter, a-z.)
  * </p>
  * <p>mask may be <code>NSLiteralSearch</code>, which requests a literal
  * byte-by-byte
@@ -5820,80 +5154,80 @@ static NSFileManager *fm = nil;
  * before or after string in lexical order, or is equal to it.
  * </p>
  */
-- (NSComparisonResult) compare: (NSString *)string
-		       options: (NSUInteger)mask
-			 range: (NSRange)compareRange
-			locale: (id)locale
+- (NSComparisonResult)compare:(NSString *)string
+                      options:(NSUInteger)mask
+                        range:(NSRange)compareRange
+                       locale:(id)locale
 {
-  GS_RANGE_CHECK(compareRange, [self length]);
-  if (nil == string)
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"compare with nil"];
+    GS_RANGE_CHECK(compareRange, [self length]);
+    if (nil == string) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"compare with nil"];
     }
 
 #if GS_USE_ICU == 1
     {
-      UCollator *coll = GSICUCollatorOpen(mask, locale);
+        UCollator *coll = GSICUCollatorOpen(mask, locale);
 
-      if (coll != NULL)
-	{
-	  NSUInteger countSelf = compareRange.length;
-	  NSUInteger countOther = [string length];       
-	  unichar *charsSelf;
-	  unichar *charsOther;
-	  UCollationResult result;
-	  
-	  charsSelf = NSZoneMalloc(NSDefaultMallocZone(),
-	    countSelf * sizeof(unichar));
-	  charsOther = NSZoneMalloc(NSDefaultMallocZone(),
-	    countOther * sizeof(unichar));
-	  // Copy to buffer
+        if (coll != NULL) {
+            NSUInteger countSelf = compareRange.length;
+            NSUInteger countOther = [string length];
+            unichar *charsSelf;
+            unichar *charsOther;
+            UCollationResult result;
 
-	  [self getCharacters: charsSelf range: compareRange];
-	  [string getCharacters: charsOther range: NSMakeRange(0, countOther)];
-	  
-	  result = ucol_strcoll(coll,
-	    charsSelf, countSelf, charsOther, countOther);
+            charsSelf = NSZoneMalloc(NSDefaultMallocZone(),
+                                     countSelf * sizeof(unichar));
+            charsOther = NSZoneMalloc(NSDefaultMallocZone(),
+                                      countOther * sizeof(unichar));
+            // Copy to buffer
 
-	  NSZoneFree(NSDefaultMallocZone(), charsSelf);
-	  NSZoneFree(NSDefaultMallocZone(), charsOther);	  
-	  ucol_close(coll); 
-	  
-	  switch (result)
-	    {
-	      case UCOL_EQUAL: return NSOrderedSame;
-	      case UCOL_GREATER: return NSOrderedDescending;
-	      case UCOL_LESS: return NSOrderedAscending;
-	    }
-	}
+            [self getCharacters:charsSelf range:compareRange];
+            [string getCharacters:charsOther range:NSMakeRange(0, countOther)];
+
+            result = ucol_strcoll(coll,
+                                  charsSelf, countSelf, charsOther, countOther);
+
+            NSZoneFree(NSDefaultMallocZone(), charsSelf);
+            NSZoneFree(NSDefaultMallocZone(), charsOther);
+            ucol_close(coll);
+
+            switch (result) {
+                case UCOL_EQUAL:
+                    return NSOrderedSame;
+                case UCOL_GREATER:
+                    return NSOrderedDescending;
+                case UCOL_LESS:
+                    return NSOrderedAscending;
+            }
+        }
     }
 #endif
 
-  return strCompNsNs(self, string, mask, compareRange);
+    return strCompNsNs(self, string, mask, compareRange);
 }
 
 /**
  * Compares this instance with string, using +[NSLocale currentLocale].
  */
-- (NSComparisonResult) localizedCompare: (NSString *)string
+- (NSComparisonResult)localizedCompare:(NSString *)string
 {
-  return [self compare: string
-               options: 0
-                 range: NSMakeRange(0, [self length])
-                locale: [NSLocale currentLocale]];
+    return [self compare:string
+                 options:0
+                   range:NSMakeRange(0, [self length])
+                  locale:[NSLocale currentLocale]];
 }
 
 /**
  * Compares this instance with string, using +[NSLocale currentLocale],
  * ignoring case.
  */
-- (NSComparisonResult) localizedCaseInsensitiveCompare: (NSString *)string
+- (NSComparisonResult)localizedCaseInsensitiveCompare:(NSString *)string
 {
-  return [self compare: string
-               options: NSCaseInsensitiveSearch
-                 range: NSMakeRange(0, [self length])
-                locale: [NSLocale currentLocale]];
+    return [self compare:string
+                 options:NSCaseInsensitiveSearch
+                   range:NSMakeRange(0, [self length])
+                  locale:[NSLocale currentLocale]];
 }
 
 /**
@@ -5903,16 +5237,15 @@ static NSFileManager *fm = nil;
  * written to a temp file, which is then closed and renamed to filename.  Thus,
  * an incomplete file at filename should never result.
  */
-- (BOOL) writeToFile: (NSString*)filename
-	  atomically: (BOOL)useAuxiliaryFile
+- (BOOL)writeToFile:(NSString *)filename
+         atomically:(BOOL)useAuxiliaryFile
 {
-  id	d = [self dataUsingEncoding: _DefaultStringEncoding];
+    id d = [self dataUsingEncoding:_DefaultStringEncoding];
 
-  if (d == nil)
-    {
-      d = [self dataUsingEncoding: NSUnicodeStringEncoding];
+    if (d == nil) {
+        d = [self dataUsingEncoding:NSUnicodeStringEncoding];
     }
-  return [d writeToFile: filename atomically: useAuxiliaryFile];
+    return [d writeToFile:filename atomically:useAuxiliaryFile];
 }
 
 /**
@@ -5924,26 +5257,24 @@ static NSFileManager *fm = nil;
  * If there is a problem and error is not NULL, the cause of the problem is
  * returned in *error.
  */
-- (BOOL) writeToFile: (NSString*)path
-	  atomically: (BOOL)atomically
-	    encoding: (NSStringEncoding)enc
-	       error: (NSError**)error
+- (BOOL)writeToFile:(NSString *)path
+         atomically:(BOOL)atomically
+           encoding:(NSStringEncoding)enc
+              error:(NSError **)error
 {
-  id	d = [self dataUsingEncoding: enc];
+    id d = [self dataUsingEncoding:enc];
 
-  if (d == nil)
-    {
-      if (error != 0)
-        {
-          *error = [NSError errorWithDomain: NSCocoaErrorDomain
-	    code: NSFileWriteInapplicableStringEncodingError
-	    userInfo: nil];
+    if (d == nil) {
+        if (error != 0) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                         code:NSFileWriteInapplicableStringEncodingError
+                                     userInfo:nil];
         }
-      return NO;
+        return NO;
     }
-  return [d writeToFile: path
-	        options: atomically ? NSDataWritingAtomic : 0
-		  error: error];
+    return [d writeToFile:path
+                  options:atomically ? NSDataWritingAtomic : 0
+                    error:error];
 }
 
 /**
@@ -5955,30 +5286,27 @@ static NSFileManager *fm = nil;
  * If there is a problem and error is not NULL, the cause of the problem is
  * returned in *error.
  */
-- (BOOL) writeToURL: (NSURL*)url
-	 atomically: (BOOL)atomically
-	    encoding: (NSStringEncoding)enc
-	       error: (NSError**)error
+- (BOOL)writeToURL:(NSURL *)url
+        atomically:(BOOL)atomically
+          encoding:(NSStringEncoding)enc
+             error:(NSError **)error
 {
-  id	d = [self dataUsingEncoding: enc];
+    id d = [self dataUsingEncoding:enc];
 
-  if (d == nil)
-    {
-      d = [self dataUsingEncoding: NSUnicodeStringEncoding];
+    if (d == nil) {
+        d = [self dataUsingEncoding:NSUnicodeStringEncoding];
     }
-  if (d == nil)
-    {
-      if (error != 0)
-        {
-          *error = [NSError errorWithDomain: NSCocoaErrorDomain
-	    code: NSFileWriteInapplicableStringEncodingError
-	    userInfo: nil];
+    if (d == nil) {
+        if (error != 0) {
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain
+                                         code:NSFileWriteInapplicableStringEncodingError
+                                     userInfo:nil];
         }
-      return NO;
+        return NO;
     }
-  return [d writeToURL: url
-	       options: atomically ? NSDataWritingAtomic : 0
-		 error: error];
+    return [d writeToURL:url
+                 options:atomically ? NSDataWritingAtomic : 0
+                   error:error];
 }
 
 /**
@@ -5988,167 +5316,145 @@ static NSFileManager *fm = nil;
  * The '<code>atomically</code>' option is only heeded if the URL is a
  * <code>file://</code> URL; see -writeToFile:atomically: .
  */
-- (BOOL) writeToURL: (NSURL*)url atomically: (BOOL)atomically
+- (BOOL)writeToURL:(NSURL *)url atomically:(BOOL)atomically
 {
-  id	d = [self dataUsingEncoding: _DefaultStringEncoding];
+    id d = [self dataUsingEncoding:_DefaultStringEncoding];
 
-  if (d == nil)
-    {
-      d = [self dataUsingEncoding: NSUnicodeStringEncoding];
+    if (d == nil) {
+        d = [self dataUsingEncoding:NSUnicodeStringEncoding];
     }
-  return [d writeToURL: url atomically: atomically];
+    return [d writeToURL:url atomically:atomically];
 }
 
 /* NSCopying Protocol */
 
-- (id) copyWithZone: (NSZone*)zone
+- (id)copyWithZone:(NSZone *)zone
 {
-  /*
-   * Default implementation should not simply retain ... the string may
-   * have been initialised with freeWhenDone==NO and not own its
-   * characters ... so the code which created it may destroy the memory
-   * when it has finished with the original string ... leaving the
-   * copy with pointers to invalid data.  So, we always copy in full.
-   */
-  return [[NSStringClass allocWithZone: zone] initWithString: self];
+    /*
+     * Default implementation should not simply retain ... the string may
+     * have been initialised with freeWhenDone==NO and not own its
+     * characters ... so the code which created it may destroy the memory
+     * when it has finished with the original string ... leaving the
+     * copy with pointers to invalid data.  So, we always copy in full.
+     */
+    return [[NSStringClass allocWithZone:zone] initWithString:self];
 }
 
-- (id) mutableCopyWithZone: (NSZone*)zone
+- (id)mutableCopyWithZone:(NSZone *)zone
 {
-  return [[GSMutableStringClass allocWithZone: zone] initWithString: self];
+    return [[GSMutableStringClass allocWithZone:zone] initWithString:self];
 }
 
 /* NSCoding Protocol */
 
-- (void) encodeWithCoder: (NSCoder*)aCoder
+- (void)encodeWithCoder:(NSCoder *)aCoder
 {
-  if ([aCoder allowsKeyedCoding])
-    {
-      [(NSKeyedArchiver*)aCoder _encodePropertyList: self forKey: @"NS.string"];
-    }
-  else
-    {
-      unsigned	count = [self length];
+    if ([aCoder allowsKeyedCoding]) {
+        [(NSKeyedArchiver *)aCoder _encodePropertyList:self forKey:@"NS.string"];
+    } else {
+        unsigned count = [self length];
 
-      [aCoder encodeValueOfObjCType: @encode(unsigned) at: &count];
-      if (count > 0)
-	{
-	  NSStringEncoding	enc = NSUnicodeStringEncoding;
-	  unichar		*chars;
+        [aCoder encodeValueOfObjCType:@encode(unsigned) at:&count];
+        if (count > 0) {
+            NSStringEncoding enc = NSUnicodeStringEncoding;
+            unichar *chars;
 
-	  /* For backwards-compatibility, we always encode/decode
-	     'NSStringEncoding' (which really is an 'unsigned int') as
-	     an 'int'.  Due to a bug, GCC up to 4.5 always encode all
-	     enums as 'i' (int) regardless of the actual integer type
-	     required to store them; we need to be able to read/write
-	     archives compatible with GCC <= 4.5 so we explictly use
-	     'int' to read/write these variables.  */
-	  [aCoder encodeValueOfObjCType: @encode(int) at: &enc];
+            /* For backwards-compatibility, we always encode/decode
+               'NSStringEncoding' (which really is an 'unsigned int') as
+               an 'int'.  Due to a bug, GCC up to 4.5 always encode all
+               enums as 'i' (int) regardless of the actual integer type
+               required to store them; we need to be able to read/write
+               archives compatible with GCC <= 4.5 so we explictly use
+               'int' to read/write these variables.  */
+            [aCoder encodeValueOfObjCType:@encode(int) at:&enc];
 
-	  chars = NSZoneMalloc(NSDefaultMallocZone(), count*sizeof(unichar));
-	  [self getCharacters: chars range: ((NSRange){0, count})];
-	  [aCoder encodeArrayOfObjCType: @encode(unichar)
-				  count: count
-				     at: chars];
-	  NSZoneFree(NSDefaultMallocZone(), chars);
-	}
+            chars = NSZoneMalloc(NSDefaultMallocZone(), count * sizeof(unichar));
+            [self getCharacters:chars range:((NSRange){0, count})];
+            [aCoder encodeArrayOfObjCType:@encode(unichar)
+                                    count:count
+                                       at:chars];
+            NSZoneFree(NSDefaultMallocZone(), chars);
+        }
     }
 }
 
-- (id) initWithCoder: (NSCoder*)aCoder
+- (id)initWithCoder:(NSCoder *)aCoder
 {
-  if ([aCoder allowsKeyedCoding])
-    {
-      if ([aCoder containsValueForKey: @"NS.string"])
-        {
-          NSString *string = nil;
-      
-          string = (NSString*)[(NSKeyedUnarchiver*)aCoder
-                                  _decodePropertyListForKey: @"NS.string"];
-          self = [self initWithString: string];
-        }
-      else if ([aCoder containsValueForKey: @"NS.bytes"])
-        {
-          id bytes = [(NSKeyedUnarchiver*)aCoder
-                         decodeObjectForKey: @"NS.bytes"];
+    if ([aCoder allowsKeyedCoding]) {
+        if ([aCoder containsValueForKey:@"NS.string"]) {
+            NSString *string = nil;
 
-          if ([bytes isKindOfClass: NSStringClass])
-            {
-              self = [self initWithString: (NSString*)bytes];
+            string = (NSString *)[(NSKeyedUnarchiver *)aCoder
+                _decodePropertyListForKey:@"NS.string"];
+            self = [self initWithString:string];
+        } else if ([aCoder containsValueForKey:@"NS.bytes"]) {
+            id bytes = [(NSKeyedUnarchiver *)aCoder
+                decodeObjectForKey:@"NS.bytes"];
+
+            if ([bytes isKindOfClass:NSStringClass]) {
+                self = [self initWithString:(NSString *)bytes];
+            } else {
+                self = [self initWithData:(NSData *)bytes
+                                 encoding:NSUTF8StringEncoding];
             }
-          else
-            {
-              self = [self initWithData: (NSData*)bytes 
-                               encoding: NSUTF8StringEncoding];
+        } else {
+            // empty string
+            self = [self initWithString:@""];
+        }
+    } else {
+        unsigned count;
+
+        [aCoder decodeValueOfObjCType:@encode(unsigned) at:&count];
+
+        if (count > 0) {
+            NSStringEncoding enc;
+            NSZone *zone;
+
+            [aCoder decodeValueOfObjCType:@encode(int) at:&enc];
+            zone = [self zone];
+
+            if (enc == NSUnicodeStringEncoding) {
+                unichar *chars;
+
+                chars = NSZoneMalloc(zone, count * sizeof(unichar));
+                [aCoder decodeArrayOfObjCType:@encode(unichar)
+                                        count:count
+                                           at:chars];
+                self = [self initWithCharactersNoCopy:chars
+                                               length:count
+                                         freeWhenDone:YES];
+            } else {
+                unsigned char *chars;
+
+                chars = NSZoneMalloc(zone, count + 1);
+                [aCoder decodeArrayOfObjCType:@encode(unsigned char)
+                                        count:count
+                                           at:chars];
+                self = [self initWithBytesNoCopy:chars
+                                          length:count
+                                        encoding:enc
+                                    freeWhenDone:YES];
             }
-        }
-      else
-        {
-          // empty string
-          self = [self initWithString: @""];
+        } else {
+            self = [self initWithBytesNoCopy:(char *)""
+                                      length:0
+                                    encoding:NSASCIIStringEncoding
+                                freeWhenDone:NO];
         }
     }
-  else
-    {
-      unsigned	count;
-	
-      [aCoder decodeValueOfObjCType: @encode(unsigned) at: &count];
-
-      if (count > 0)
-        {
-	  NSStringEncoding	enc;
-	  NSZone		*zone;
-	
-	  [aCoder decodeValueOfObjCType: @encode(int) at: &enc];
-	  zone = [self zone];
-	
-	  if (enc == NSUnicodeStringEncoding)
-	    {
-	      unichar	*chars;
-	
-	      chars = NSZoneMalloc(zone, count*sizeof(unichar));
-	      [aCoder decodeArrayOfObjCType: @encode(unichar)
-		                      count: count
-		                         at: chars];
-	      self = [self initWithCharactersNoCopy: chars
-					     length: count
-				       freeWhenDone: YES];
-	    }
-	  else
-	    {
-	      unsigned char	*chars;
-	
-	      chars = NSZoneMalloc(zone, count+1);
-	      [aCoder decodeArrayOfObjCType: @encode(unsigned char)
-		                      count: count
-				         at: chars];
-	      self = [self initWithBytesNoCopy: chars
-					length: count
-				      encoding: enc
-				  freeWhenDone: YES];
-	    }
-	}
-      else
-        {
-	  self = [self initWithBytesNoCopy: (char *)""
-				    length: 0
-			          encoding: NSASCIIStringEncoding
-			      freeWhenDone: NO];
-	}
-    }
-  return self;
-}
-
-- (Class) classForCoder
-{
-  return NSStringClass;
-}
-
-- (id) replacementObjectForPortCoder: (NSPortCoder*)aCoder
-{
-  if ([aCoder isByref] == NO)
     return self;
-  return [super replacementObjectForPortCoder: aCoder];
+}
+
+- (Class)classForCoder
+{
+    return NSStringClass;
+}
+
+- (id)replacementObjectForPortCoder:(NSPortCoder *)aCoder
+{
+    if ([aCoder isByref] == NO)
+        return self;
+    return [super replacementObjectForPortCoder:aCoder];
 }
 
 /**
@@ -6200,49 +5506,46 @@ static NSFileManager *fm = nil;
  * -propertyListFromStringsFileFormat method).
  * </p>
  */
-- (id) propertyList
+- (id)propertyList
 {
-  NSData		*data;
-  id			result = nil;
-  NSPropertyListFormat	format;
-  NSString		*error = nil;
+    NSData *data;
+    id result = nil;
+    NSPropertyListFormat format;
+    NSString *error = nil;
 
-  if ([self length] == 0)
-    {
-      return nil;
+    if ([self length] == 0) {
+        return nil;
     }
-  data = [self dataUsingEncoding: NSUTF8StringEncoding];
-  NSAssert(data, @"Couldn't get utf8 data from string.");
+    data = [self dataUsingEncoding:NSUTF8StringEncoding];
+    NSAssert(data, @"Couldn't get utf8 data from string.");
 
-  result = [NSPropertyListSerialization
-    propertyListFromData: data
-    mutabilityOption: NSPropertyListMutableContainers
-    format: &format
-    errorDescription: &error];
+    result = [NSPropertyListSerialization
+        propertyListFromData:data
+            mutabilityOption:NSPropertyListMutableContainers
+                      format:&format
+            errorDescription:&error];
 
-  if (result == nil)
-    {
-      extern id	GSPropertyListFromStringsFormat(NSString *string);
+    if (result == nil) {
+        extern id GSPropertyListFromStringsFormat(NSString * string);
 
-      NS_DURING
+        NS_DURING
         {
-          result = GSPropertyListFromStringsFormat(self);
+            result = GSPropertyListFromStringsFormat(self);
         }
-      NS_HANDLER
+        NS_HANDLER
         {
-          error = [NSString stringWithFormat:
-            @"as property list {%@}, and as strings file {%@}",
-            error, [localException reason]];
-          result = nil;
+            error = [NSString stringWithFormat:
+                                  @"as property list {%@}, and as strings file {%@}",
+                                  error, [localException reason]];
+            result = nil;
         }
-      NS_ENDHANDLER
-      if (result == nil)
-        {
-          [NSException raise: NSGenericException
-                      format: @"Parse failed - %@", error];
+        NS_ENDHANDLER
+        if (result == nil) {
+            [NSException raise:NSGenericException
+                        format:@"Parse failed - %@", error];
         }
     }
-  return result;
+    return result;
 }
 
 /**
@@ -6264,216 +5567,193 @@ static NSFileManager *fm = nil;
  *   "Another key" = "a longer string value for th third key";
  * </example>
  */
-- (NSDictionary*) propertyListFromStringsFileFormat
+- (NSDictionary *)propertyListFromStringsFileFormat
 {
-  extern id	GSPropertyListFromStringsFormat(NSString *string);
+    extern id GSPropertyListFromStringsFormat(NSString * string);
 
-  return GSPropertyListFromStringsFormat(self);
+    return GSPropertyListFromStringsFormat(self);
 }
 
 /**
-  * Returns YES if the receiver contains string, otherwise, NO.
-  */
-- (BOOL) containsString: (NSString *)string
+ * Returns YES if the receiver contains string, otherwise, NO.
+ */
+- (BOOL)containsString:(NSString *)string
 {
-  return [self rangeOfString: string].location != NSNotFound;
+    return [self rangeOfString:string].location != NSNotFound;
 }
 
-- (void) enumerateSubstringsInRange: (NSRange)range 
-                            options: (NSStringEnumerationOptions)opts 
-                         usingBlock: (GSNSStringEnumerationBlock)block
+- (void)enumerateSubstringsInRange:(NSRange)range
+                           options:(NSStringEnumerationOptions)opts
+                        usingBlock:(GSNSStringEnumerationBlock)block
 {
-  // Get low byte.
-  uint8_t substringType = opts & 0xFF;
+    // Get low byte.
+    uint8_t substringType = opts & 0xFF;
 
-  BOOL isReverse = opts & NSStringEnumerationReverse;
-  BOOL substringNotRequired = opts & NSStringEnumerationSubstringNotRequired;
-  BOOL localized = opts & NSStringEnumerationLocalized;
-  
-  NSUInteger currentLocation;
-  BOOL stop = NO;
+    BOOL isReverse = opts & NSStringEnumerationReverse;
+    BOOL substringNotRequired = opts & NSStringEnumerationSubstringNotRequired;
+    BOOL localized = opts & NSStringEnumerationLocalized;
 
-  if (isReverse)
-    {
-      currentLocation = range.location + range.length;
-    } 
-  else 
-    {
-      currentLocation = range.location;
+    NSUInteger currentLocation;
+    BOOL stop = NO;
+
+    if (isReverse) {
+        currentLocation = range.location + range.length;
+    } else {
+        currentLocation = range.location;
     }
 
-  if (substringType == NSStringEnumerationByLines
-    || substringType == NSStringEnumerationByParagraphs)
-    {
-      BOOL isLineSep = substringType == NSStringEnumerationByLines;
-      
-      while (YES)
-        {
-          /* Contains the index of the first character of the line
-	   * containing the beginning of aRange.
-	   */
-          NSUInteger	start;
+    if (substringType == NSStringEnumerationByLines || substringType == NSStringEnumerationByParagraphs) {
+        BOOL isLineSep = substringType == NSStringEnumerationByLines;
 
-          /* Contains the index of the first character past the
-	   * terminator of the line containing the end of aRange.
-	   */
-          NSUInteger	end;
+        while (YES) {
+            /* Contains the index of the first character of the line
+             * containing the beginning of aRange.
+             */
+            NSUInteger start;
 
-          /* Contains the index of the first character of the terminator
-	   * of the line containing the end of aRange. 
-	   */
-          NSUInteger	contentsEnd;
-          NSRange	currentLocationRange = NSMakeRange(currentLocation, 0);
-          NSUInteger 	substringStart;
-          NSRange	substringRange;
+            /* Contains the index of the first character past the
+             * terminator of the line containing the end of aRange.
+             */
+            NSUInteger end;
 
-          [self _getStart: &start 
-                      end: &end 
-              contentsEnd: &contentsEnd 
-                forRange: currentLocationRange 
-                  lineSep: isLineSep];
+            /* Contains the index of the first character of the terminator
+             * of the line containing the end of aRange.
+             */
+            NSUInteger contentsEnd;
+            NSRange currentLocationRange = NSMakeRange(currentLocation, 0);
+            NSUInteger substringStart;
+            NSRange substringRange;
 
-          /* If the enumerated range starts after the line/paragraph,
-	   * we start at the beginning of the enumerated range
-	   */
-          substringStart = start > range.location ? start : range.location;
-          substringRange
-	    = NSMakeRange(substringStart, contentsEnd - substringStart);
-          CALL_BLOCK(block, 
-            substringNotRequired
-	      ? nil
-	      : [self substringWithRange: substringRange],
-            substringRange,
-            NSMakeRange(start, end - start),
-            &stop);
-          if (stop) break;
-          if (end == range.location + range.length) break;
-          currentLocation = end;
+            [self _getStart:&start
+                        end:&end
+                contentsEnd:&contentsEnd
+                   forRange:currentLocationRange
+                    lineSep:isLineSep];
+
+            /* If the enumerated range starts after the line/paragraph,
+             * we start at the beginning of the enumerated range
+             */
+            substringStart = start > range.location ? start : range.location;
+            substringRange = NSMakeRange(substringStart, contentsEnd - substringStart);
+            CALL_BLOCK(block,
+                       substringNotRequired ? nil : [self substringWithRange:substringRange],
+                       substringRange,
+                       NSMakeRange(start, end - start),
+                       &stop);
+            if (stop)
+                break;
+            if (end == range.location + range.length)
+                break;
+            currentLocation = end;
         }
-    } 
-  else if (substringType == NSStringEnumerationByComposedCharacterSequences)
-    {
-      /* We could also use rangeOfComposedCharacterSequenceAtIndex:,
-       * but then we would need different logic.
-       */
-      while (YES)
-        {
-          NSRange	enclosingRange;
+    } else if (substringType == NSStringEnumerationByComposedCharacterSequences) {
+        /* We could also use rangeOfComposedCharacterSequenceAtIndex:,
+         * but then we would need different logic.
+         */
+        while (YES) {
+            NSRange enclosingRange;
 
-          /* Since all characters are in a composed character sequence,
-	   * enclosingRange == substringRange
-	   */
-          enclosingRange
-	    = [self rangeOfComposedCharacterSequenceAtIndex: currentLocation];
-          CALL_BLOCK(block, 
-            substringNotRequired
-	      ? nil
-	      : [self substringWithRange: enclosingRange],
-            enclosingRange,
-            enclosingRange,
-            &stop);
-          if (stop) break;
-          currentLocation = enclosingRange.location + enclosingRange.length;
+            /* Since all characters are in a composed character sequence,
+             * enclosingRange == substringRange
+             */
+            enclosingRange = [self rangeOfComposedCharacterSequenceAtIndex:currentLocation];
+            CALL_BLOCK(block,
+                       substringNotRequired ? nil : [self substringWithRange:enclosingRange],
+                       enclosingRange,
+                       enclosingRange,
+                       &stop);
+            if (stop)
+                break;
+            currentLocation = enclosingRange.location + enclosingRange.length;
         }
-    } 
-  else if (substringType == NSStringEnumerationByWords
-    || substringType == NSStringEnumerationBySentences)
-    {
-      #if GS_USE_ICU
-      // These macros may be useful elsewhere.
-      #define GS_U_HANDLE_ERROR(errorCode, description) do { \
-        if (U_FAILURE(errorCode)) { \
-          NSWarnMLog(@"Error " description ": %s", u_errorName(errorCode)); \
-          return; \
-        } else if (errorCode < U_ZERO_ERROR) { \
-          NSWarnMLog(@"Warning " description ": %s", u_errorName(errorCode)); \
-        } \
-        errorCode = U_ZERO_ERROR; \
-      } while (NO)
+    } else if (substringType == NSStringEnumerationByWords || substringType == NSStringEnumerationBySentences) {
+#if GS_USE_ICU
+// These macros may be useful elsewhere.
+#define GS_U_HANDLE_ERROR(errorCode, description)                               \
+    do {                                                                        \
+        if (U_FAILURE(errorCode)) {                                             \
+            NSWarnMLog(@"Error " description ": %s", u_errorName(errorCode));   \
+            return;                                                             \
+        } else if (errorCode < U_ZERO_ERROR) {                                  \
+            NSWarnMLog(@"Warning " description ": %s", u_errorName(errorCode)); \
+        }                                                                       \
+        errorCode = U_ZERO_ERROR;                                               \
+    } while (NO)
 
-      BOOL		byWords = substringType == NSStringEnumerationByWords;
-      NSUInteger	length = range.length;
-      UChar 		characters[length];
-      UErrorCode 	errorCode = U_ZERO_ERROR;
-      const char	*locale;
-      UBreakIterator	*breakIterator;
+        BOOL byWords = substringType == NSStringEnumerationByWords;
+        NSUInteger length = range.length;
+        UChar characters[length];
+        UErrorCode errorCode = U_ZERO_ERROR;
+        const char *locale;
+        UBreakIterator *breakIterator;
 
-      [self getCharacters: characters range: range];
-      /* @ss=standard will use lists of common abbreviations,
-       * such as Mr., Mrs., etc.
-       */
-      locale = localized
-        ? [[[[NSLocale currentLocale] localeIdentifier] 
-	      stringByAppendingString: @"@ss=standard"] UTF8String]
-        : "en_US_POSIX";
-      breakIterator = ubrk_open(
-	byWords ? UBRK_WORD : UBRK_SENTENCE,	// type
-	locale, 				// locale
-	characters, 				// text
-	length, 				// textLength
-	&errorCode);
-      GS_U_HANDLE_ERROR(errorCode, @"opening ICU break iterator");
-      ubrk_first(breakIterator);
-      while (YES)
-        {
-          // Make sure it's a valid substring.
-          BOOL		isValidSubstring = YES;
-          int32_t	nextPosition;
-          NSUInteger 	nextLocation;
-          NSRange 	enclosingRange;
-          
-          if (byWords) 
-            {
-              int32_t ruleStatus = ubrk_getRuleStatus(breakIterator);
-              /* From ICU User Guide:
-               *   A status value UBRK_WORD_NONE indicates that the boundary
-               *   does not start a word or number.
-               * However, valid words seem to be UBRK_WORD_NONE, and invalid
-	       * words seem to be UBRK_WORD_NONE_LIMIT.
-	       */
-              isValidSubstring = ruleStatus != UBRK_WORD_NONE_LIMIT;
-// NSLog(@"Status for position %d (%d): %d", (int)currentLocation, (int)ubrk_current(breakIterator), (int) ruleStatus);
-            }
-          
-          nextPosition = ubrk_next(breakIterator);
-          if (nextPosition == UBRK_DONE) break;
+        [self getCharacters:characters range:range];
+        /* @ss=standard will use lists of common abbreviations,
+         * such as Mr., Mrs., etc.
+         */
+        locale = localized ? [[[[NSLocale currentLocale] localeIdentifier]
+                                 stringByAppendingString:@"@ss=standard"] UTF8String] :
+                             "en_US_POSIX";
+        breakIterator = ubrk_open(
+            byWords ? UBRK_WORD : UBRK_SENTENCE, // type
+            locale, // locale
+            characters, // text
+            length, // textLength
+            &errorCode);
+        GS_U_HANDLE_ERROR(errorCode, @"opening ICU break iterator");
+        ubrk_first(breakIterator);
+        while (YES) {
+            // Make sure it's a valid substring.
+            BOOL isValidSubstring = YES;
+            int32_t nextPosition;
+            NSUInteger nextLocation;
+            NSRange enclosingRange;
 
-          nextLocation = range.location + nextPosition;
-          // Same as substringRange
-          enclosingRange
-	    = NSMakeRange(currentLocation, nextLocation - currentLocation);
-          
-          if (isValidSubstring)
-            {
-              CALL_BLOCK(block, 
-                substringNotRequired
-		  ? nil
-		  : [self substringWithRange: enclosingRange],
-                enclosingRange,
-                enclosingRange,
-                &stop);
-              if (stop) break;
+            if (byWords) {
+                int32_t ruleStatus = ubrk_getRuleStatus(breakIterator);
+                /* From ICU User Guide:
+                 *   A status value UBRK_WORD_NONE indicates that the boundary
+                 *   does not start a word or number.
+                 * However, valid words seem to be UBRK_WORD_NONE, and invalid
+                 * words seem to be UBRK_WORD_NONE_LIMIT.
+                 */
+                isValidSubstring = ruleStatus != UBRK_WORD_NONE_LIMIT;
+                // NSLog(@"Status for position %d (%d): %d", (int)currentLocation, (int)ubrk_current(breakIterator), (int) ruleStatus);
             }
 
-          currentLocation = nextLocation;
+            nextPosition = ubrk_next(breakIterator);
+            if (nextPosition == UBRK_DONE)
+                break;
+
+            nextLocation = range.location + nextPosition;
+            // Same as substringRange
+            enclosingRange = NSMakeRange(currentLocation, nextLocation - currentLocation);
+
+            if (isValidSubstring) {
+                CALL_BLOCK(block,
+                           substringNotRequired ? nil : [self substringWithRange:enclosingRange],
+                           enclosingRange,
+                           enclosingRange,
+                           &stop);
+                if (stop)
+                    break;
+            }
+
+            currentLocation = nextLocation;
         }
-      #else
-      NSWarnLog(@"NSStringEnumerationByWords and NSStringEnumerationBySentences"
-	@" are not supported when GNUstep-base is compiled without ICU.");
-      return;
-      #endif
-    }
-  else if (substringType == NSStringEnumerationByCaretPositions)
-    {
-      // FIXME - Not documented by Apple.
-      NSWarnLog(@"NSStringEnumerationByCaretPositions is not supported");
-      return;
-    }
-  else if (substringType == NSStringEnumerationByDeletionClusters)
-    {
-      // FIXME - Not documented by Apple.
-      NSWarnLog(@"NSStringEnumerationByDeletionClusters is not supported");
-      return;
+#else
+        NSWarnLog(@"NSStringEnumerationByWords and NSStringEnumerationBySentences"
+                  @" are not supported when GNUstep-base is compiled without ICU.");
+        return;
+#endif
+    } else if (substringType == NSStringEnumerationByCaretPositions) {
+        // FIXME - Not documented by Apple.
+        NSWarnLog(@"NSStringEnumerationByCaretPositions is not supported");
+        return;
+    } else if (substringType == NSStringEnumerationByDeletionClusters) {
+        // FIXME - Not documented by Apple.
+        NSWarnLog(@"NSStringEnumerationByDeletionClusters is not supported");
+        return;
     }
 }
 
@@ -6484,15 +5764,12 @@ static NSFileManager *fm = nil;
  */
 @implementation NSMutableString
 
-+ (id) allocWithZone: (NSZone*)z
++ (id)allocWithZone:(NSZone *)z
 {
-  if (self == NSMutableStringClass)
-    {
-      return NSAllocateObject(GSMutableStringClass, 0, z);
-    }
-  else
-    {
-      return NSAllocateObject(self, 0, z);
+    if (self == NSMutableStringClass) {
+        return NSAllocateObject(GSMutableStringClass, 0, z);
+    } else {
+        return NSAllocateObject(self, 0, z);
     }
 }
 
@@ -6501,30 +5778,31 @@ static NSFileManager *fm = nil;
 /**
  * Constructs an empty string.
  */
-+ (id) string
++ (id)string
 {
-  return AUTORELEASE([[GSMutableStringClass allocWithZone:
-    NSDefaultMallocZone()] initWithCapacity: 0]);
+    return AUTORELEASE([[GSMutableStringClass allocWithZone:
+                                                  NSDefaultMallocZone()] initWithCapacity:0]);
 }
 
 /**
  * Constructs an empty string with initial buffer size of capacity.
  */
-+ (NSMutableString*) stringWithCapacity: (NSUInteger)capacity
++ (NSMutableString *)stringWithCapacity:(NSUInteger)capacity
 {
-  return AUTORELEASE([[GSMutableStringClass allocWithZone:
-    NSDefaultMallocZone()] initWithCapacity: capacity]);
+    return AUTORELEASE([[GSMutableStringClass allocWithZone:
+                                                  NSDefaultMallocZone()] initWithCapacity:capacity]);
 }
 
 /**
  * Create a string of unicode characters.
  */
 // Inefficient implementation.
-+ (id) stringWithCharacters: (const unichar*)characters
-		     length: (NSUInteger)length
++ (id)stringWithCharacters:(const unichar *)characters
+                    length:(NSUInteger)length
 {
-  return AUTORELEASE([[GSMutableStringClass allocWithZone:
-    NSDefaultMallocZone()] initWithCharacters: characters length: length]);
+    return AUTORELEASE([[GSMutableStringClass allocWithZone:
+                                                  NSDefaultMallocZone()] initWithCharacters:characters
+                                                                                     length:length]);
 }
 
 /**
@@ -6532,10 +5810,10 @@ static NSFileManager *fm = nil;
  * containing direct unicode if it begins with the unicode byte order mark,
  * else converts to unicode using default C string encoding.
  */
-+ (id) stringWithContentsOfFile: (NSString *)path
++ (id)stringWithContentsOfFile:(NSString *)path
 {
-  return AUTORELEASE([[GSMutableStringClass allocWithZone:
-    NSDefaultMallocZone()] initWithContentsOfFile: path]);
+    return AUTORELEASE([[GSMutableStringClass allocWithZone:
+                                                  NSDefaultMallocZone()] initWithContentsOfFile:path]);
 }
 
 /**
@@ -6543,10 +5821,10 @@ static NSFileManager *fm = nil;
  * null-terminated and encoded in the default C string encoding.  (Characters
  * will be converted to unicode representation internally.)
  */
-+ (id) stringWithCString: (const char*)byteString
++ (id)stringWithCString:(const char *)byteString
 {
-  return AUTORELEASE([[GSMutableStringClass allocWithZone:
-    NSDefaultMallocZone()] initWithCString: byteString]);
+    return AUTORELEASE([[GSMutableStringClass allocWithZone:
+                                                  NSDefaultMallocZone()] initWithCString:byteString]);
 }
 
 /**
@@ -6554,11 +5832,12 @@ static NSFileManager *fm = nil;
  * null bytes and should be encoded in the default C string encoding.
  * (Characters will be converted to unicode representation internally.)
  */
-+ (id) stringWithCString: (const char*)byteString
-		  length: (NSUInteger)length
++ (id)stringWithCString:(const char *)byteString
+                 length:(NSUInteger)length
 {
-  return AUTORELEASE([[GSMutableStringClass allocWithZone:
-    NSDefaultMallocZone()] initWithCString: byteString length: length]);
+    return AUTORELEASE([[GSMutableStringClass allocWithZone:
+                                                  NSDefaultMallocZone()] initWithCString:byteString
+                                                                                  length:length]);
 }
 
 /**
@@ -6566,15 +5845,15 @@ static NSFileManager *fm = nil;
  * be a constant format string, like '<code>@"float val = %f"</code>', remaining
  * arguments should be the variables to print the values of, comma-separated.
  */
-+ (id) stringWithFormat: (NSString*)format, ...
++ (id)stringWithFormat:(NSString *)format, ...
 {
-  id    s;
+    id s;
 
-  va_list ap;
-  va_start(ap, format);
-  s = [super stringWithFormat: format arguments: ap];
-  va_end(ap);
-  return s;
+    va_list ap;
+    va_start(ap, format);
+    s = [super stringWithFormat:format arguments:ap];
+    va_end(ap);
+    return s;
 }
 
 /** <init/> <override-subclass />
@@ -6583,46 +5862,44 @@ static NSFileManager *fm = nil;
  * and needs to be re-implemented in subclasses in order to have all
  * other initialisers work.
  */
-- (id) initWithCapacity: (NSUInteger)capacity
+- (id)initWithCapacity:(NSUInteger)capacity
 {
-  self = [self init];
-  return self;
+    self = [self init];
+    return self;
 }
 
-- (id) initWithCharactersNoCopy: (unichar*)chars
-			 length: (NSUInteger)length
-		   freeWhenDone: (BOOL)flag
+- (id)initWithCharactersNoCopy:(unichar *)chars
+                        length:(NSUInteger)length
+                  freeWhenDone:(BOOL)flag
 {
-  if ((self = [self initWithCapacity: length]) != nil && length > 0)
-    {
-      NSString	*tmp;
+    if ((self = [self initWithCapacity:length]) != nil && length > 0) {
+        NSString *tmp;
 
-      tmp = [NSString allocWithZone: NSDefaultMallocZone()];
-      tmp = [tmp initWithCharactersNoCopy: chars
-				   length: length
-			     freeWhenDone: flag];
-      [self replaceCharactersInRange: NSMakeRange(0,0) withString: tmp];
-      RELEASE(tmp);
+        tmp = [NSString allocWithZone:NSDefaultMallocZone()];
+        tmp = [tmp initWithCharactersNoCopy:chars
+                                     length:length
+                               freeWhenDone:flag];
+        [self replaceCharactersInRange:NSMakeRange(0, 0) withString:tmp];
+        RELEASE(tmp);
     }
-  return self;
+    return self;
 }
 
-- (id) initWithCStringNoCopy: (char*)chars
-		      length: (NSUInteger)length
-		freeWhenDone: (BOOL)flag
+- (id)initWithCStringNoCopy:(char *)chars
+                     length:(NSUInteger)length
+               freeWhenDone:(BOOL)flag
 {
-  if ((self = [self initWithCapacity: length]) != nil && length > 0)
-    {
-      NSString	*tmp;
+    if ((self = [self initWithCapacity:length]) != nil && length > 0) {
+        NSString *tmp;
 
-      tmp = [NSString allocWithZone: NSDefaultMallocZone()];
-      tmp = [tmp initWithCStringNoCopy: chars
-				length: length
-			  freeWhenDone: flag];
-      [self replaceCharactersInRange: NSMakeRange(0,0) withString: tmp];
-      RELEASE(tmp);
+        tmp = [NSString allocWithZone:NSDefaultMallocZone()];
+        tmp = [tmp initWithCStringNoCopy:chars
+                                  length:length
+                            freeWhenDone:flag];
+        [self replaceCharactersInRange:NSMakeRange(0, 0) withString:tmp];
+        RELEASE(tmp);
     }
-  return self;
+    return self;
 }
 
 // Modify A String
@@ -6630,62 +5907,63 @@ static NSFileManager *fm = nil;
 /**
  *  Modifies this string by appending aString.
  */
-- (void) appendString: (NSString*)aString
+- (void)appendString:(NSString *)aString
 {
-  NSRange aRange;
+    NSRange aRange;
 
-  aRange.location = [self length];
-  aRange.length = 0;
-  [self replaceCharactersInRange: aRange withString: aString];
+    aRange.location = [self length];
+    aRange.length = 0;
+    [self replaceCharactersInRange:aRange withString:aString];
 }
 
 /**
  *  Modifies this string by appending string described by given format.
  */
 // Inefficient implementation.
-- (void) appendFormat: (NSString*)format, ...
+- (void)appendFormat:(NSString *)format, ...
 {
-  va_list	ap;
-  id		tmp;
+    va_list ap;
+    id tmp;
 
-  va_start(ap, format);
-  tmp = [[NSStringClass allocWithZone: NSDefaultMallocZone()]
-    initWithFormat: format arguments: ap];
-  va_end(ap);
-  [self appendString: tmp];
-  RELEASE(tmp);
+    va_start(ap, format);
+    tmp = [[NSStringClass allocWithZone:NSDefaultMallocZone()]
+        initWithFormat:format
+             arguments:ap];
+    va_end(ap);
+    [self appendString:tmp];
+    RELEASE(tmp);
 }
 
-- (Class) classForCoder
+- (Class)classForCoder
 {
-  return NSMutableStringClass;
+    return NSMutableStringClass;
 }
 
 /**
  * Modifies this instance by deleting specified range of characters.
  */
-- (void) deleteCharactersInRange: (NSRange)range
+- (void)deleteCharactersInRange:(NSRange)range
 {
-  [self replaceCharactersInRange: range withString: nil];
+    [self replaceCharactersInRange:range withString:nil];
 }
 
 /**
  * Modifies this instance by inserting aString at loc.
  */
-- (void) insertString: (NSString*)aString atIndex: (NSUInteger)loc
+- (void)insertString:(NSString *)aString atIndex:(NSUInteger)loc
 {
-  NSRange range = {loc, 0};
-  [self replaceCharactersInRange: range withString: aString];
+    NSRange range = {loc, 0};
+    [self replaceCharactersInRange:range withString:aString];
 }
 
 /**
  * Modifies this instance by deleting characters in range and then inserting
  * aString at its beginning.
  */
-- (void) replaceCharactersInRange: (NSRange)range
-		       withString: (NSString*)aString
+- (void)replaceCharactersInRange:(NSRange)range
+                      withString:(NSString *)aString
 {
-  [self subclassResponsibility: _cmd];
+    [self subclassResponsibility:_cmd];
 }
 
 /**
@@ -6699,76 +5977,67 @@ static NSFileManager *fm = nil;
  * Raises NSRangeException if part of searchRange is beyond the end
  * of the receiver.
  */
-- (NSUInteger) replaceOccurrencesOfString: (NSString*)replace
-                               withString: (NSString*)by
-                                  options: (NSUInteger)opts
-                                    range: (NSRange)searchRange
+- (NSUInteger)replaceOccurrencesOfString:(NSString *)replace
+                              withString:(NSString *)by
+                                 options:(NSUInteger)opts
+                                   range:(NSRange)searchRange
 {
-  NSRange	range;
-  unsigned int	count = 0;
-  GSRSFunc	func;
+    NSRange range;
+    unsigned int count = 0;
+    GSRSFunc func;
 
-  if ([replace isKindOfClass: NSStringClass] == NO)
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"%@ bad search string", NSStringFromSelector(_cmd)];
+    if ([replace isKindOfClass:NSStringClass] == NO) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"%@ bad search string", NSStringFromSelector(_cmd)];
     }
-  if ([by isKindOfClass: NSStringClass] == NO)
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"%@ bad replace string", NSStringFromSelector(_cmd)];
+    if ([by isKindOfClass:NSStringClass] == NO) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"%@ bad replace string", NSStringFromSelector(_cmd)];
     }
-  if (NSMaxRange(searchRange) > [self length])
-    {
-      [NSException raise: NSInvalidArgumentException
-		  format: @"%@ bad search range", NSStringFromSelector(_cmd)];
+    if (NSMaxRange(searchRange) > [self length]) {
+        [NSException raise:NSInvalidArgumentException
+                    format:@"%@ bad search range", NSStringFromSelector(_cmd)];
     }
-  func = GSPrivateRangeOfString(self, replace);
-  range = (*func)(self, replace, opts, searchRange);
+    func = GSPrivateRangeOfString(self, replace);
+    range = (*func)(self, replace, opts, searchRange);
 
-  if (range.length > 0)
-    {
-      unsigned	byLen = [by length];
-      SEL	sel;
-      void	(*imp)(id, SEL, NSRange, NSString*);
+    if (range.length > 0) {
+        unsigned byLen = [by length];
+        SEL sel;
+        void (*imp)(id, SEL, NSRange, NSString *);
 
-      sel = @selector(replaceCharactersInRange:withString:);
-      imp = (void(*)(id, SEL, NSRange, NSString*))[self methodForSelector: sel];
-      do
-	{
-	  count++;
-	  (*imp)(self, sel, range, by);
-	  if ((opts & NSBackwardsSearch) == NSBackwardsSearch)
-	    {
-	      searchRange.length = range.location - searchRange.location;
-	    }
-	  else
-	    {
-	      unsigned int	newEnd;
+        sel = @selector(replaceCharactersInRange:withString:);
+        imp = (void (*)(id, SEL, NSRange, NSString *))[self methodForSelector:sel];
+        do {
+            count++;
+            (*imp)(self, sel, range, by);
+            if ((opts & NSBackwardsSearch) == NSBackwardsSearch) {
+                searchRange.length = range.location - searchRange.location;
+            } else {
+                unsigned int newEnd;
 
-	      newEnd = NSMaxRange(searchRange) + byLen - range.length;
-	      searchRange.location = range.location + byLen;
-	      searchRange.length = newEnd - searchRange.location;
-	    }
-	  /* We replaced something and now need to scan again.
-	   * As we modified the receiver, we must refresh the
-	   * method implementation for searching.
-	   */
-	  func = GSPrivateRangeOfString(self, replace);
-	  range = (*func)(self, replace, opts, searchRange);
-	}
-      while (range.length > 0);
+                newEnd = NSMaxRange(searchRange) + byLen - range.length;
+                searchRange.location = range.location + byLen;
+                searchRange.length = newEnd - searchRange.location;
+            }
+            /* We replaced something and now need to scan again.
+             * As we modified the receiver, we must refresh the
+             * method implementation for searching.
+             */
+            func = GSPrivateRangeOfString(self, replace);
+            range = (*func)(self, replace, opts, searchRange);
+        } while (range.length > 0);
     }
-  return count;
+    return count;
 }
 
 /**
  * Modifies this instance by replacing contents with those of aString.
  */
-- (void) setString: (NSString*)aString
+- (void)setString:(NSString *)aString
 {
-  NSRange range = {0, [self length]};
-  [self replaceCharactersInRange: range withString: aString];
+    NSRange range = {0, [self length]};
+    [self replaceCharactersInRange:range withString:aString];
 }
 
 @end
@@ -6781,303 +6050,284 @@ static NSFileManager *fm = nil;
 
 - (id)initWithDictionary:(NSDictionary *)dict defaultValue:(NSString *)value
 {
-  _dict = dict;
-  return [self initWithString:value];
+    _dict = dict;
+    return [self initWithString:value];
 }
 
 /* Returns a format that's appropriate for the pluralization of the arguments in
  * the current language */
 - (NSString *)getPluralizedFormat:(va_list)argList
 {
-  /* Sample dictionary:
-      NSStringLocalizedFormatKey=%#@x_hours@, %#@x_minutes@
-      x_hours=NSDictionary {
-	NSStringFormatSpecTypeKey=NSStringPluralRuleType
-	NSStringFormatValueTypeKey=ld
-	zero=0 hours
-	one=1 hour
-	other=%1$ld hours
-      }
-      x_minutes=NSDictionary {
-	NSStringFormatSpecTypeKey=NSStringPluralRuleType
-	NSStringFormatValueTypeKey=ld
-	zero=0 minutes
-	one=1 minute
-	other=%2$ld minutes
-      }
-   */
+    /* Sample dictionary:
+        NSStringLocalizedFormatKey=%#@x_hours@, %#@x_minutes@
+        x_hours=NSDictionary {
+          NSStringFormatSpecTypeKey=NSStringPluralRuleType
+          NSStringFormatValueTypeKey=ld
+          zero=0 hours
+          one=1 hour
+          other=%1$ld hours
+        }
+        x_minutes=NSDictionary {
+          NSStringFormatSpecTypeKey=NSStringPluralRuleType
+          NSStringFormatValueTypeKey=ld
+          zero=0 minutes
+          one=1 minute
+          other=%2$ld minutes
+        }
+     */
 
-  NSString *formatKey = _dict[@"NSStringLocalizedFormatKey"];
-  if (!formatKey)
-    {
-      return self;
+    NSString *formatKey = _dict[@"NSStringLocalizedFormatKey"];
+    if (!formatKey) {
+        return self;
     }
 
-  NSRegularExpression *regex = nil;
+    NSRegularExpression *regex = nil;
 
-  regex = [NSRegularExpression
-    regularExpressionWithPattern:@"%#@([^@]+)@"
-			 options:NSRegularExpressionCaseInsensitive
-			   error:nil];
+    regex = [NSRegularExpression
+        regularExpressionWithPattern:@"%#@([^@]+)@"
+                             options:NSRegularExpressionCaseInsensitive
+                               error:nil];
 
-  NSArray<NSTextCheckingResult *> *matches =
-    [regex matchesInString:formatKey
-		   options:0
-		     range:NSMakeRange(0, [formatKey length])];
+    NSArray<NSTextCheckingResult *> *matches =
+        [regex matchesInString:formatKey
+                       options:0
+                         range:NSMakeRange(0, [formatKey length])];
 
-  va_list args;
-  va_copy(args, argList);
+    va_list args;
+    va_copy(args, argList);
 
-  NSMutableString *newFormat = [formatKey mutableCopy];
-  NSInteger	   offset = 0;
+    NSMutableString *newFormat = [formatKey mutableCopy];
+    NSInteger offset = 0;
 
-  for (NSTextCheckingResult *match in matches)
-    {
-      NSString *varKey = [formatKey substringWithRange:[match rangeAtIndex:1]];
+    for (NSTextCheckingResult *match in matches) {
+        NSString *varKey = [formatKey substringWithRange:[match rangeAtIndex:1]];
 
-      NSDictionary<NSString *, NSString *> *varDict = _dict[varKey];
+        NSDictionary<NSString *, NSString *> *varDict = _dict[varKey];
 
-      // Get the numeric value of the variable (luckily, only "%ld", "%lu", and
-      // "%1g" is used).
-      unsigned long number = 0;
-      NSString	   *type = varDict[@"NSStringFormatValueTypeKey"];
+        // Get the numeric value of the variable (luckily, only "%ld", "%lu", and
+        // "%1g" is used).
+        unsigned long number = 0;
+        NSString *type = varDict[@"NSStringFormatValueTypeKey"];
 
-      if ([type isEqualToString:@"ld"])
-	{
-	  number = va_arg(args, long);
-	}
-      else if ([type isEqualToString:@"lu"])
-	{
-	  number = va_arg(args, unsigned long);
-	}
-      else if ([type isEqualToString:@"d"])
-	{
-	  number = va_arg(args, int);
-	}
-      else if ([type isEqualToString:@"u"])
-	{
-	  number = va_arg(args, unsigned int);
-	}
-      else if ([type isEqualToString:@"1g"])
-	{
-	  double d = va_arg(args, double);
-	  // Casting to an int would mean 0.3 is "zero" and 1.2 would be "one", so
-	  // check against just 0 or 1 and let any other value be "other". 
-	  number = d == 0 ? 0 : (d == 1 || d == -1) ? 1 : 10;
-	}
-      else
-	{
-	  number = va_arg(args, int);
-	}
+        if ([type isEqualToString:@"ld"]) {
+            number = va_arg(args, long);
+        } else if ([type isEqualToString:@"lu"]) {
+            number = va_arg(args, unsigned long);
+        } else if ([type isEqualToString:@"d"]) {
+            number = va_arg(args, int);
+        } else if ([type isEqualToString:@"u"]) {
+            number = va_arg(args, unsigned int);
+        } else if ([type isEqualToString:@"1g"]) {
+            double d = va_arg(args, double);
+            // Casting to an int would mean 0.3 is "zero" and 1.2 would be "one", so
+            // check against just 0 or 1 and let any other value be "other".
+            number = d == 0 ? 0 : (d == 1 || d == -1) ? 1 :
+                                                        10;
+        } else {
+            number = va_arg(args, int);
+        }
 
-      // Only supports languages which have similar rules to english (zero,
-      // none, or other), as well as japanese (zero or other).
-      NSString *variantKey;
-      if (number == 0)
-	{
-	  variantKey = @"zero";
-	}
-      else if (number == 1)
-	{
-	  variantKey = @"one";
-	}
-      else
-	{
-	  variantKey = @"other";
-	}
+        // Only supports languages which have similar rules to english (zero,
+        // none, or other), as well as japanese (zero or other).
+        NSString *variantKey;
+        if (number == 0) {
+            variantKey = @"zero";
+        } else if (number == 1) {
+            variantKey = @"one";
+        } else {
+            variantKey = @"other";
+        }
 
-      NSString *replacement = varDict[variantKey];
-      if (!replacement)
-	{
-	  // Fallback to the "other" variant.
-	  replacement = varDict[@"other"];
-	}
+        NSString *replacement = varDict[variantKey];
+        if (!replacement) {
+            // Fallback to the "other" variant.
+            replacement = varDict[@"other"];
+        }
 
-      if (replacement)
-	{
-	  [newFormat
-	    replaceCharactersInRange:NSMakeRange(match.range.location + offset,
-						 match.range.length)
-			  withString:replacement];
-	  offset += (NSInteger) ([replacement length] - match.range.length);
-	}
+        if (replacement) {
+            [newFormat
+                replaceCharactersInRange:NSMakeRange(match.range.location + offset,
+                                                     match.range.length)
+                              withString:replacement];
+            offset += (NSInteger)([replacement length] - match.range.length);
+        }
     }
 
-  va_end(args);
+    va_end(args);
 
-  return newFormat;
+    return newFormat;
 }
 
 - (BOOL)canBeConvertedToEncoding:(NSStringEncoding)enc
 {
-  return [_parent canBeConvertedToEncoding:enc];
+    return [_parent canBeConvertedToEncoding:enc];
 }
 
 - (unichar)characterAtIndex:(NSUInteger)index
 {
-  return [_parent characterAtIndex:index];
+    return [_parent characterAtIndex:index];
 }
 
 - (NSComparisonResult)compare:(NSString *)aString
-		      options:(NSUInteger)mask
-			range:(NSRange)aRange
+                      options:(NSUInteger)mask
+                        range:(NSRange)aRange
 {
-  return [_parent compare:aString options:mask range:aRange];
+    return [_parent compare:aString options:mask range:aRange];
 }
 
 - (const char *)cString
 {
-  return [_parent cString];
+    return [_parent cString];
 }
 
 - (const char *)cStringUsingEncoding:(NSStringEncoding)encoding
 {
-  return [_parent cStringUsingEncoding:encoding];
+    return [_parent cStringUsingEncoding:encoding];
 }
 
 - (NSUInteger)cStringLength
 {
-  return [_parent cStringLength];
+    return [_parent cStringLength];
 }
 
 - (NSData *)dataUsingEncoding:(NSStringEncoding)encoding
-	 allowLossyConversion:(BOOL)flag
+         allowLossyConversion:(BOOL)flag
 {
-  return [_parent dataUsingEncoding:encoding allowLossyConversion:flag];
+    return [_parent dataUsingEncoding:encoding allowLossyConversion:flag];
 }
 
 - (void)dealloc
 {
-  RELEASE(_parent);
-  [super dealloc];
+    RELEASE(_parent);
+    [super dealloc];
 }
 
 - (id)copyWithZone:(NSZone *)z
 {
-  return [_parent copyWithZone:z];
+    return [_parent copyWithZone:z];
 }
 
 - (id)mutableCopyWithZone:(NSZone *)z
 {
-  return [_parent mutableCopyWithZone:z];
+    return [_parent mutableCopyWithZone:z];
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-  [_parent encodeWithCoder:aCoder];
+    [_parent encodeWithCoder:aCoder];
 }
 
 - (NSStringEncoding)fastestEncoding
 {
-  return [_parent fastestEncoding];
+    return [_parent fastestEncoding];
 }
 
 - (void)getCharacters:(unichar *)buffer
 {
-  [_parent getCharacters:buffer];
+    [_parent getCharacters:buffer];
 }
 
 - (void)getCharacters:(unichar *)buffer range:(NSRange)aRange
 {
-  [_parent getCharacters:buffer range:aRange];
+    [_parent getCharacters:buffer range:aRange];
 }
 
 - (void)getCString:(char *)buffer
 {
-  [_parent getCString:buffer];
+    [_parent getCString:buffer];
 }
 
 - (void)getCString:(char *)buffer maxLength:(NSUInteger)maxLength
 {
-  [_parent getCString:buffer maxLength:maxLength];
+    [_parent getCString:buffer maxLength:maxLength];
 }
 
 - (BOOL)getCString:(char *)buffer
-	 maxLength:(NSUInteger)maxLength
-	  encoding:(NSStringEncoding)encoding
+         maxLength:(NSUInteger)maxLength
+          encoding:(NSStringEncoding)encoding
 {
-  return [_parent getCString:buffer maxLength:maxLength encoding:encoding];
+    return [_parent getCString:buffer maxLength:maxLength encoding:encoding];
 }
 
 - (void)getCString:(char *)buffer
-	 maxLength:(NSUInteger)maxLength
-	     range:(NSRange)aRange
+         maxLength:(NSUInteger)maxLength
+             range:(NSRange)aRange
     remainingRange:(NSRange *)leftoverRange
 {
-  [_parent getCString:buffer
-	    maxLength:maxLength
-		range:aRange
-       remainingRange:leftoverRange];
+    [_parent getCString:buffer
+              maxLength:maxLength
+                  range:aRange
+         remainingRange:leftoverRange];
 }
 
 - (NSUInteger)hash
 {
-  return [_parent hash];
+    return [_parent hash];
 }
 
 - (id)initWithString:(NSString *)parent
 {
-  _parent = RETAIN(parent);
-  return self;
+    _parent = RETAIN(parent);
+    return self;
 }
 
 - (BOOL)isEqual:(id)anObject
 {
-  return [_parent isEqual:anObject];
+    return [_parent isEqual:anObject];
 }
 
 - (BOOL)isEqualToString:(NSString *)anObject
 {
-  return [_parent isEqualToString:anObject];
+    return [_parent isEqualToString:anObject];
 }
 
 - (BOOL)isProxy
 {
-  return YES;
+    return YES;
 }
 
 - (NSUInteger)length
 {
-  return [_parent length];
+    return [_parent length];
 }
 
 - (NSUInteger)lengthOfBytesUsingEncoding:(NSStringEncoding)encoding
 {
-  return [_parent lengthOfBytesUsingEncoding:encoding];
+    return [_parent lengthOfBytesUsingEncoding:encoding];
 }
 
 - (const char *)lossyCString
 {
-  return [_parent lossyCString];
+    return [_parent lossyCString];
 }
 
 - (NSUInteger)maximumLengthOfBytesUsingEncoding:(NSStringEncoding)encoding
 {
-  return [_parent maximumLengthOfBytesUsingEncoding:encoding];
+    return [_parent maximumLengthOfBytesUsingEncoding:encoding];
 }
 
 - (NSRange)rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)anIndex
 {
-  return [_parent rangeOfComposedCharacterSequenceAtIndex:anIndex];
+    return [_parent rangeOfComposedCharacterSequenceAtIndex:anIndex];
 }
 
 - (NSRange)rangeOfCharacterFromSet:(NSCharacterSet *)aSet
-			   options:(NSUInteger)mask
-			     range:(NSRange)aRange
+                           options:(NSUInteger)mask
+                             range:(NSRange)aRange
 {
-  return [_parent rangeOfCharacterFromSet:aSet options:mask range:aRange];
+    return [_parent rangeOfCharacterFromSet:aSet options:mask range:aRange];
 }
 
 - (NSRange)rangeOfString:(NSString *)aString
-		 options:(NSUInteger)mask
-		   range:(NSRange)aRange
+                 options:(NSUInteger)mask
+                   range:(NSRange)aRange
 {
-  return [_parent rangeOfString:aString options:mask range:aRange];
+    return [_parent rangeOfString:aString options:mask range:aRange];
 }
 
 - (NSStringEncoding)smallestEncoding
 {
-  return [_parent smallestEncoding];
+    return [_parent smallestEncoding];
 }
 
 @end


### PR DESCRIPTION
fixes:
 - getCStringE_c was allowing the buffer to be reallocated, and also returning NO even when the function succeeded
 - the other getCString methods on NSString are all broken, so I hid their implementations. they're deprecated anyways, so they shouldn't be used in the first place
 - the implementation of getCString on the NSString base class had a few bugs where it was measuring the buffer size incorrectly, placing bad null terminators, etc. Rewrote it to fix those issues

misc:
 - Learned not to trust any encodings other than NSASCIIStringEncoding/NSUnicodeStringEncoding. At the very least, NSUTF16LittleEndianStringEncoding (even though it should just be the same thing) is broken because of bad logic in GSFromUnicode
 - learned that lengthOfBytesUsingEncoding is broken for unicode strings
 - completely unrelated, modified -[NSDate description] to always print out the date in UTC for clarity
 - reformatted things for sanity
