### PR TITLE
Fix getCString for 0 length tiny strings

### DIFF
--- a/Source/GSString.m
+++ b/Source/GSString.m
@@ -862,7 +862,7 @@ tsbytes(uintptr_t s, char *buf)
     }
     if (NSUnicodeStringEncoding == encoding) {
         maxLength /= 2;
-        if (maxLength > 1) {
+        if (maxLength > 0) {
             unichar *buf = (unichar *)(void *)buffer;
             BOOL result = (length < maxLength) ? YES : NO;
 


### PR DESCRIPTION
`maxLength` includes the null terminator, so if we are given a 2 byte buffer, we are expected to fill in the null terminator and return YES
