### PR TITLE
FAN-7770: Using case-insensitive dictionary for HTTP headers

### DIFF
--- a/Source/GSTransferState.m
+++ b/Source/GSTransferState.m
@@ -152,6 +152,7 @@
   NSMutableDictionary *headerFields = nil;
   NSEnumerator        *e;
   NSString            *line;
+  NSDictionary        *ret;
 
   e = [_lines objectEnumerator];
   while (nil != (line = [e nextObject]))
@@ -196,7 +197,10 @@
         }
     }
   
-  return AUTORELEASE([headerFields copy]);
+  ret = AUTORELEASE([headerFields copy]);
+  DESTROY(headerFields);
+  
+  return ret;
 }
 
 - (instancetype) _byAppendingHeaderLine: (NSString*)line 

--- a/Source/GSTransferState.m
+++ b/Source/GSTransferState.m
@@ -1,4 +1,5 @@
 #import "GSTransferState.h"
+#import "GSPrivate.h"
 #import "GSURLSessionTaskBodySource.h"
 #import "Foundation/NSArray.h"
 #import "Foundation/NSCharacterSet.h"
@@ -175,7 +176,7 @@
             {
               if (nil == headerFields) 
                 {
-                  headerFields = [NSMutableDictionary dictionary];
+                  headerFields = [_GSMutableInsensitiveDictionary new];
                 }
               if (nil != [headerFields objectForKey: key]) 
                 {


### PR DESCRIPTION
HTTP headers of the same name get combined, but case wasn't being ignored for this.

 eg:

```
WWW-Authenticate: Negotiate
Www-Authenticate: NTLM
```

should become `Negotiate, NTLM` but it was just `Negotiate`, due to the differing case of `www`.