### PR TITLE
NSURLSession loop break

### DIFF
--- a/Source/GSMultiHandle.m
+++ b/Source/GSMultiHandle.m
@@ -232,17 +232,19 @@ static int curl_timer_function(CURLM *multi, long timeout_ms, void *clientp)
 }
 
 - (void) readAndWriteAvailableDataOnSocket: (curl_socket_t)socket
-{  
+{
+  int numfds = 0;
+  
   do
     {
       handleMultiCode(curl_multi_perform(_rawHandle, &_runningHandlesCount));
 
       if (_runningHandlesCount)
         {
-          handleMultiCode(curl_multi_poll(_rawHandle, NULL, 0, 10000, NULL));
+          handleMultiCode(curl_multi_poll(_rawHandle, NULL, 0, 1000, &numfds));
         }
     }
-    while (_runningHandlesCount);
+    while (_runningHandlesCount && numfds);
 
   handleMultiCode(curl_multi_socket_action(_rawHandle, socket, 0, &_runningHandlesCount));
   


### PR DESCRIPTION
Discussed here: https://flexibits.slack.com/archives/C054WRJ7Q1M/p1739545436968919

This loop will continue while there's an open connection - not good for "keep-alive" connections, combined with this being called in NSURLSession's worker queue.

Using `numfds` from `curl_multi_poll` to determine if the loop should continue.

> On completion, if numfds is non-NULL, it gets populated with the total number of file descriptors on which interesting events occurred. This number can include both libcurl internal descriptors as well as descriptors provided in extra_fds.

Also lowered the timeout from 10s to 1s
